### PR TITLE
Add more regularization options to ReferenceStatistics.

### DIFF
--- a/experiments/scm_pycles_pipeline/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/calibrate.jl
@@ -95,7 +95,7 @@ function run_calibrate(return_ekobj = false)
     #########
 
     # Compute data covariance
-    ref_stats = ReferenceStatistics(ref_models, model_type, perform_PCA, normalize)
+    ref_stats = ReferenceStatistics(ref_models, model_type, perform_PCA, normalize, tikhonov_noise = 1e-3)
     d = length(ref_stats.y) # Length of data array
 
     #########

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -12,7 +12,13 @@ using TurbulenceConvection
 tc_dir = dirname(dirname(pathof(TurbulenceConvection)));
 include(joinpath(tc_dir, "integration_tests", "utils", "main.jl"))
 
-
+"""
+    struct ReferenceModel
+    
+A structure containing information about the 'true' reference model
+and the observation map used to compare the parameterized and
+reference models.
+"""
 Base.@kwdef struct ReferenceModel
     "Vector of reference variable names"
     y_names::Vector{String}
@@ -48,6 +54,12 @@ namelist_directory(root::S, casename::S) where {S <: AbstractString} = joinpath(
 num_vars(m::ReferenceModel) = length(m.y_names)
 
 
+"""
+    struct ReferenceStatistics
+    
+A structure containing statistics from the reference model used to
+define a well-posed inverse problem.
+"""
 Base.@kwdef struct ReferenceStatistics{FT <: Real}
     "Reference data, length: nSim * n_vars * n_zLevels(possibly reduced by PCA)"
     y::Vector{FT} # yt
@@ -64,12 +76,44 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
     "Full covariance matrix, dims: (y,y)"
     Γ_full::Array{FT, 2}  # yt_var_big
 
+    """
+        ReferenceStatistics(
+            RM::Vector{ReferenceModel},
+            model_type::Symbol,
+            perform_PCA::Bool,
+            normalize::Bool,
+            FT::DataType = Float64;
+            variance_loss::Float64 = 0.1,
+            tikhonov_noise::Float64 = 0.0,
+            tikhonov_mode::String = "absolute",
+            Γ_scaling::Float64 = 1.0,
+        )
+
+    Constructs the ReferenceStatistics defining the inverse problem.
+
+    Inputs:
+     - RM               :: Vector of `ReferenceModel`s
+     - model_type       :: Type of the reference model, either :les or :scm.
+     - perform_PCA      :: Boolean specifying whether to perform PCA.
+     - normalize        :: Boolean specifying whether to normalize the data.
+     - variance_loss    :: Fraction of variance loss when performing PCA.
+     - tikhonov_noise   :: Tikhonov regularization factor for covariance matrices.
+     - tikhonov_mode    :: If "relative", tikhonov_noise is scaled by the minimum
+        eigenvalue in the covariance matrix considered.
+     - dim_scaling      :: Whether to scale covariance blocks by their size.
+    Outputs:
+     - A ReferenceStatistics struct.
+    """
     function ReferenceStatistics(
         RM::Vector{ReferenceModel},
         model_type::Symbol,
         perform_PCA::Bool,
         normalize::Bool,
-        FT = Float64,
+        FT::DataType = Float64;
+        variance_loss::Float64 = 0.1,
+        tikhonov_noise::Float64 = 0.0,
+        tikhonov_mode::String = "absolute",
+        dim_scaling::Bool = false,
     )
         # Init arrays
         y = FT[]  # yt
@@ -84,7 +128,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
             y_, y_var_, pool_var = get_obs(model_type, m, z_scm = get_height(scm_dir(m)), normalize)
             push!(norm_vec, pool_var)
             if perform_PCA
-                y_pca, y_var_pca, P_pca = obs_PCA(y_, y_var_)
+                y_pca, y_var_pca, P_pca = obs_PCA(y_, y_var_, variance_loss)
                 append!(y, y_pca)
                 push!(Γ_vec, y_var_pca)
                 push!(pca_vec, P_pca)
@@ -97,12 +141,21 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
             append!(y_full, y_)
             push!(Γ_full_vec, y_var_)
         end
+
+        # Construct global observational covariance matrix, original space
+        Γ_full = cat(Γ_full_vec..., dims = (1, 2))
+
         # Construct global observational covariance matrix, TSVD
-        indep_noise = 1e-3I
-        Γ = cat(Γ_vec..., dims = (1, 2)) + indep_noise
+        if tikhonov_mode == "relative"
+            Γ_vec = map(x -> x + tikhonov_noise * minimum(diag(x)) * I, Γ_vec)
+        else
+            Γ_vec = map(x -> x + tikhonov_noise * I, Γ_vec)
+        end
+        # Scale by number of dimensions
+        Γ_vec = dim_scaling ? map(x -> size(x, 1) * x, Γ_vec) : Γ_vec
+        Γ = cat(Γ_vec..., dims = (1, 2))
         @assert isposdef(Γ)
 
-        Γ_full = cat(Γ_full_vec..., dims = (1, 2)) + indep_noise
         return new{FT}(y, Γ, norm_vec, pca_vec, y_full, Γ_full)
     end
 end


### PR DESCRIPTION
This PR adds more regularization options to the `ReferenceStatistics` struct. In particular,

- It adds the option to specify the retained variance fraction in PCA.
- It adds the option to specify the magnitude of Tikhonov regularization.
- It adds the option to scale the covariance by the dimension of each observed vector.