### PR TITLE
specify les, scm relative directories

### DIFF
--- a/experiments/les_strats/tc_calibrate.jl
+++ b/experiments/les_strats/tc_calibrate.jl
@@ -81,11 +81,9 @@ function construct_reference_models()::Vector{ReferenceModel}
             # Define variables considered in the loss function
             y_names = vars,
             # Reference data specification
-            les_root = les_root,
-            les_name = sim_name,
-            les_suffix = les_suffix,
+            les_dir = data_directory("/groups/esm/ilopezgo", sim_name, les_suffix),
             # Simulation case specification
-            scm_root = scm_root,
+            scm_dir = data_directory("./tc_inputs", sim_name, "00000"),
             scm_name = sim_name,
             t_start = t_start,
             t_end = t_end,

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
@@ -19,24 +19,21 @@ using JLD2
 
 """ Define reference simulations for loss function"""
 function construct_reference_models()::Vector{ReferenceModel}
-    les_root = "/groups/esm/zhaoyi/pycles_clima"
-    scm_root = "/groups/esm/hervik/calibration/static_input"  # path to folder with `Output.<scm_name>.00000` files
-
     # Calibrate using reference data and options described by the ReferenceModel struct.
     ref_bomex = ReferenceModel(
         # Define variables considered in the loss function
         y_names = ["thetal_mean", "ql_mean", "qt_mean", "total_flux_h", "total_flux_qt"],
-        # Reference data specification
-        les_root = les_root,
-        les_name = "Bomex",
-        les_suffix = "aug09",
-        # Simulation case specification
-        scm_root = scm_root,
+        # Reference path specification
+        les_dir = "/groups/esm/zhaoyi/pycles_clima/Output.Bomex.aug09",
+        # Simulation path specification
+        scm_dir = "/groups/esm/hervik/calibration/static_input/Output.Bomex.00000",
+        # Simulation casename specification
         scm_name = "Bomex",
         # Define observation window (s)
         t_start = 4.0 * 3600,  # 4hrs
         t_end = 24.0 * 3600,  # 24hrs
     )
+
     # Make vector of reference models
     ref_models::Vector{ReferenceModel} = [ref_bomex]
     @assert all(isdir.([les_dir.(ref_models)... scm_dir.(ref_models)...]))

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
@@ -55,17 +55,17 @@ function construct_reference_models()::Vector{ReferenceModel}
     ref_bomex = ReferenceModel(
         # Define variables considered in the loss function
         y_names = ["thetal_mean", "ql_mean", "qt_mean", "total_flux_h", "total_flux_qt"],
-        # Reference data specification
-        les_root = les_root,
-        les_name = "Bomex",
-        les_suffix = "aug09",
-        # Simulation case specification
-        scm_root = scm_root,
+        # Reference path specification
+        les_dir = "/groups/esm/zhaoyi/pycles_clima/Output.Bomex.aug09",
+        # Simulation path specification
+        scm_dir = "/groups/esm/hervik/calibration/static_input/Output.Bomex.00000",
+        # Simulation casename specification
         scm_name = "Bomex",
         # Define observation window (s)
         t_start = 4.0 * 3600,  # 4hrs
         t_end = 24.0 * 3600,  # 24hrs
     )
+
     # Make vector of reference models
     ref_models::Vector{ReferenceModel} = [ref_bomex]
     @assert all(isdir.([les_dir.(ref_models)... scm_dir.(ref_models)...]))

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -14,22 +14,14 @@ reference models.
 """
 Base.@kwdef struct ReferenceModel
     "Vector of reference variable names"
+    # Field names for cost function
     y_names::Vector{String}
-
-    "Root directory for reference LES data"
-    les_root::String
-    "Name of LES reference simulation file"
-    les_name::String
-    "Suffix of LES reference simulation file"
-    les_suffix::String
-
-    "Root directory for SCM data (used for interpolation)"
-    scm_root::String
-    "Name of SCM reference simulation file"
+    # Relative path to LES reference simulation file
+    les_dir::String
+    # Relative path to LES reference simulation file
+    scm_dir::String
+    # Name of case
     scm_name::String
-    "Suffix of SCM reference simulation file"
-    scm_suffix::String = "00000"
-
     # TODO: Make t_start and t_end vectors for multiple time intervals per reference model.
     "Start time for computing statistics over"
     t_start::Real
@@ -37,8 +29,8 @@ Base.@kwdef struct ReferenceModel
     t_end::Real
 end
 
-les_dir(m::ReferenceModel) = data_directory(m.les_root, m.les_name, m.les_suffix)
-scm_dir(m::ReferenceModel) = data_directory(m.scm_root, m.scm_name, m.scm_suffix)
+les_dir(m::ReferenceModel) = m.les_dir
+scm_dir(m::ReferenceModel) = m.scm_dir
 data_directory(root::S, name::S, suffix::S) where {S <: AbstractString} = joinpath(root, "Output.$name.$suffix")
 
 namelist_directory(root::String, m::ReferenceModel) = namelist_directory(root, m.scm_name)

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -88,7 +88,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
 
         for m in RM
             # Get (interpolated and pool-normalized) observations, get pool variance vector
-            y_, y_var_, pool_var = get_obs(model_type, m, z_scm = get_height(scm_dir(m)), normalize)
+            y_, y_var_, pool_var = get_obs(model_type, m, z_scm = get_height(m.scm_dir), normalize)
             push!(norm_vec, pool_var)
             if perform_PCA
                 y_pca, y_var_pca, P_pca = obs_PCA(y_, y_var_, variance_loss)

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -104,7 +104,7 @@ function run_SCM_handler(
 ) where {FT <: AbstractFloat}
 
     # fetch default namelist
-    inputdir = scm_dir(m)
+    inputdir = m.scm_dir
     namelist = JSON.parsefile(namelist_directory(inputdir, m))
 
     # update parameter values

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -41,19 +41,19 @@ function get_obs(
     normalize::Bool;
     z_scm::Union{Vector{FT}, Nothing} = nothing,
 ) where {FT <: Real}
-    les_names = get_les_names(m.y_names, les_dir(m))
+    les_names = get_les_names(m.y_names, m.les_dir)
 
     # True observables from SCM or LES depending on `obs_type` flag
     y_names, sim_dir = if obs_type == :scm
-        m.y_names, scm_dir(m)
+        m.y_names, m.scm_dir
     elseif obs_type == :les
-        les_names, les_dir(m)
+        les_names, m.les_dir
     else
         error("Unknown observation type $obs_type")
     end
 
     # For now, we always use LES to construct covariance matrix
-    y_tvar, pool_var = get_time_covariance(m, les_dir(m), les_names, z_scm = z_scm)
+    y_tvar, pool_var = get_time_covariance(m, m.les_dir, les_names, z_scm = z_scm)
 
     norm_vec = if normalize
         pool_var

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -3,26 +3,25 @@ using CalibrateEDMF.ReferenceModels
 
 
 @testset "ReferenceModel" begin
-    les_root = "foo"
-    scm_root = "bar"
-    sim_name = "foo1"
-    les_suffix = "bar1"
+    les_dir_test = "/foo/bar/les"
+    scm_dir_test = "/foo/bar/scm"
+    scm_name_test = "test_case"
     y_names = ["thetal_mean", "ql_mean", "qt_mean"]
     t_start = 0.0
     t_end = 10.0
 
     ref_model = ReferenceModel(
         y_names = y_names,
-        les_root = les_root,
-        les_name = sim_name,
-        les_suffix = les_suffix,
-        scm_root = scm_root,
-        scm_name = sim_name,
+        les_dir = les_dir_test,
+        scm_dir = scm_dir_test,
+        scm_name = scm_name_test,
         t_start = t_start,
         t_end = t_end,
     )
 
-    @test les_dir(ref_model) == joinpath(les_root, "Output.$sim_name.$les_suffix")
-    @test scm_dir(ref_model) == joinpath(scm_root, "Output.$sim_name.00000")
+    @test les_dir(ref_model) == ref_model.les_dir
+    @test scm_dir(ref_model) == ref_model.scm_dir
+    @test les_dir(ref_model) == "/foo/bar/les"
+    @test scm_dir(ref_model) == "/foo/bar/scm"
     @test num_vars(ref_model) == 3
 end


### PR DESCRIPTION
Replaces root & suffix attributes with full simulation directories in `ReferenceModel` object + propagates changes throughout codebase. I'm still working out an `InexactError`, but this is my thinking for how to deal with the paths. 