### PR TITLE
Use TC.jl alias dictionary.

### DIFF
--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -31,7 +31,7 @@ function get_config()
     # Define preconditioning and regularization of inverse problem
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
-    config["reference"] = get_reference_config(ObsCampaigns())
+    config["reference"] = get_reference_config(LesDrivenScm())
     # Define the parameter priors
     config["prior"] = get_prior_config()
     # Define the kalman process
@@ -51,7 +51,7 @@ end
 function get_regularization_config()
     config = Dict()
     config["perform_PCA"] = true # Performs PCA on data
-    config["variance_loss"] = 1.0e-3 # Variance truncation level in PCA
+    config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
     config["normalize"] = true  # whether to normalize data by pooled variance
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 10.0 # Tikhonov regularization
@@ -101,18 +101,22 @@ end
 
 function get_reference_config(::LesDrivenScm)
     config = Dict()
-    config["case_name"] = ["LES_driven_SCM"]
+    config["case_name"] = repeat(["LES_driven_SCM"], 3)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
     config["y_reference_type"] = LES()
     config["Σ_reference_type"] = LES()
-    config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean"]]
-    cfsite_number = 17
+    config["y_names"] = repeat([["thetal_mean", "ql_mean", "qt_mean", "s_mean", "s_mean"]], 3)
     les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip")
-    config["y_dir"] = [get_cfsite_les_dir(cfsite_number; les_kwargs...)]
-    config["scm_suffix"] = [get_gcm_les_uuid(cfsite_number; les_kwargs...)]
-    config["scm_parent_dir"] = ["scm_init"]
-    config["t_start"] = [4.0 * 3600]
-    config["t_end"] = [12.0 * 3600]
+    config["y_dir"] = [
+        get_cfsite_les_dir(17; les_kwargs...),
+        get_cfsite_les_dir(19; les_kwargs...),
+        get_cfsite_les_dir(22; les_kwargs...),
+    ]
+    config["scm_suffix"] =
+        [get_gcm_les_uuid(17; les_kwargs...), get_gcm_les_uuid(19; les_kwargs...), get_gcm_les_uuid(22; les_kwargs...)]
+    config["scm_parent_dir"] = repeat(["scm_init"], 3)
+    config["t_start"] = repeat([9.0 * 3600], 3)
+    config["t_end"] = repeat([12.0 * 3600], 3)
     # config["Σ_t_start"] = [...]
     # config["Σ_t_end"] = [...]
     return config

--- a/experiments/les_strats/tc_calibrate.jl
+++ b/experiments/les_strats/tc_calibrate.jl
@@ -166,8 +166,8 @@ function run_calibrate(config; return_ekobj = false)
     end
     # EKP results: Has the ensemble collapsed toward the truth?
     @info string(
-        "\nEKP ensemble mean at last stage (original space): ",
-        $"mean(transform_unconstrained_to_constrained(priors, get_u_final(ekobj)), dims = 2)",
+        "EKP ensemble mean at last stage (original space): ",
+        "$(mean(transform_unconstrained_to_constrained(priors, get_u_final(ekobj)), dims = 2))",
     )
 
     if return_ekobj

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -179,15 +179,11 @@ Outputs:
  - The time-shifted ReferenceModel.
 """
 function time_shift_reference_model(m::ReferenceModel, Δt_y::FT, Δt_Σ::FT) where {FT <: Real}
-    les_filename = get_stats_path(y_dir(m))
-
-    ds = NCDataset(get_stats_path(y_dir(m)), "r")
-    t = ds.group["profiles"]["t"][:]
+    t = nc_fetch(y_dir(m), "t")
     t_end = t[end]
     t_start = t_end - Δt_y
     Σ_t_start = t_end - Δt_Σ
 
-    close(ds)
     @assert t_start > 0 "t_start must be positive after time shift, but $t_start was given."
     @assert Σ_t_start > 0 "Σ_t_start must be positive after time shift, but $Σ_t_start was given."
     @info string(

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -186,8 +186,8 @@ function get_obs(
     normalize::Bool;
     z_scm::Union{Vector{FT}, Nothing},
 ) where {FT <: Real}
-    y_names = isa(y_type, LES) ? get_les_names(m) : m.y_names
-    Σ_names = isa(Σ_type, LES) ? get_les_names(m) : m.y_names
+    y_names = isa(y_type, LES) ? get_les_names(m, m.y_dir) : m.y_names
+    Σ_names = isa(Σ_type, LES) ? get_les_names(m, m.Σ_dir) : m.y_names
     get_obs(m, y_names, Σ_names, normalize, z_scm = z_scm)
 end
 
@@ -265,7 +265,7 @@ function get_profile(
     z_scm::Union{Vector{Float64}, Nothing} = nothing,
 )
 
-    t = nc_fetch(sim_dir, "timeseries", "t")
+    t = nc_fetch(sim_dir, "t")
     dt = length(t) > 1 ? abs(t[2] - t[1]) : 0.0
     y = zeros(0)
 
@@ -329,7 +329,7 @@ function get_time_covariance(
     z_scm::Union{Array{Float64, 1}, Nothing} = nothing,
 )
     sim_dir = Σ_dir(m)
-    t = nc_fetch(sim_dir, "timeseries", "t")
+    t = nc_fetch(sim_dir, "t")
     # Find closest interval in data
     ti_index = argmin(broadcast(abs, t .- get_t_start_Σ(m)))
     tf_index = argmin(broadcast(abs, t .- get_t_end_Σ(m)))

--- a/test/LESUtils/runtests.jl
+++ b/test/LESUtils/runtests.jl
@@ -1,10 +1,27 @@
 using Test
+using NCDatasets
 using CalibrateEDMF.LESUtils
 
 
 @testset "LESUtils" begin
-    scm_names = ["total_flux_qt", "total_flux_h", "u_mean"]
+    scm_names = ["total_flux_qt", "total_flux_h", "u_mean", "foo"]
+    tmpdir = mktempdir()
+    mkdir(joinpath(tmpdir, "stats"))
+    ds = NCDataset(joinpath(tmpdir, "stats", "test.nc"), "c")
 
-    @test get_les_names(scm_names, "GABLS") == ["resolved_z_flux_qt", "resolved_z_flux_theta", "u_translational_mean"]
-    @test get_les_names(scm_names, "foo") == ["resolved_z_flux_qt", "resolved_z_flux_thetali", "u_translational_mean"]
+    defDim(ds, "t", 10)
+    defDim(ds, "z", 20)
+
+    defGroup(ds, "profiles")
+    defVar(ds.group["profiles"], "qt_flux_z", Float32, ("t", "z"))
+    defVar(ds.group["profiles"], "resolved_z_flux_thetali", Float32, ("t", "z"))
+    defVar(ds.group["profiles"], "u_translational_mean", Float32, ("t", "z"))
+    defGroup(ds, "timeseries")
+    defVar(ds.group["timeseries"], "foo", Float32, ("t",))
+    close(ds)
+
+    @test find_alias(("u_mean", "u_translational_mean"), tmpdir) == "u_translational_mean"
+    @test find_alias(("foo",), tmpdir) == "foo"
+    @test_throws ErrorException find_alias(("vorticity",), tmpdir)
+    @test get_les_names(scm_names, tmpdir) == ["qt_flux_z", "resolved_z_flux_thetali", "u_translational_mean", "foo"]
 end


### PR DESCRIPTION
This PR makes use of the TC.jl variable alias dictionary housed in `TC.jl/src/name_aliases.jl`.

Instead of checking which variable exists in the netCDF file every time before fetching, we first look up the aliases present in our ReferenceModel data, and we pass that to the rest of the functions, so that lookup is constant in time afterwards, and we don't have to extend support to tuples of strings.