### PR TITLE
ignore vscode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# editor settings
+.vscode


### PR DESCRIPTION
This PR adds an entry for the directory `.vscode` in `.gitignore` to ignore edits to local editor settings.