### PR TITLE
refactor: run short simulation for reference SCM

### DIFF
--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -86,13 +86,14 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         :Σ_t_start => Σ_t_start,
         :Σ_t_end => Σ_t_end,
     )
+
     # Minibatch mode
     if !isnothing(batch_size)
         @info "Training using mini-batches."
         ref_model_batch = construct_ref_model_batch(kwargs_ref_model)
         global_ref_models = deepcopy(ref_model_batch.ref_models)
         # Create input scm stats and namelist file if files don't already exist
-        run_SCM(global_ref_models, overwrite = overwrite_scm_file)
+        run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file)
         # Generate global reference statistics
         global_ref_stats = ReferenceStatistics(
             global_ref_models,
@@ -109,7 +110,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     else
         ref_models = construct_reference_models(kwargs_ref_model)
         # Create input scm stats and namelist file if files don't already exist
-        run_SCM(ref_models, overwrite = overwrite_scm_file)
+        run_reference_SCM.(ref_models, overwrite = overwrite_scm_file)
     end
     # Generate reference statistics
     ref_stats = ReferenceStatistics(

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -324,17 +324,14 @@ Inputs:
  - var_names    :: List of variable names to be included.
  - z_scm        :: If given, interpolates covariance matrix to this locations.
 """
-function get_time_covariance(
-    m::ReferenceModel,
-    var_names::Vector{String};
-    z_scm::Union{Array{Float64, 1}, Nothing} = nothing,
-)
+function get_time_covariance(m::ReferenceModel, var_names::Vector{String}; z_scm::Vector{FT}) where {FT <: Real}
     sim_dir = Σ_dir(m)
     t = nc_fetch(sim_dir, "t")
     # Find closest interval in data
     ti_index = argmin(broadcast(abs, t .- get_t_start_Σ(m)))
     tf_index = argmin(broadcast(abs, t .- get_t_end_Σ(m)))
-    ts_vec = zeros(0, length(ti_index:tf_index))
+    N_samples = length(ti_index:tf_index)
+    ts_vec = zeros(0, N_samples)
     num_outputs = length(var_names)
     pool_var = zeros(num_outputs)
 

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -215,15 +215,25 @@ function get_stats_path(dir)
         return stat_files[1]
     catch e
         if isa(e, AssertionError)
-            @warn "No unique stats netCDF file found at $dir. Extending search to other files."
-            stat_files = readdir(stats, join = true) # WindowsOS/julia 1.6.0 relpath bug
-            if length(stat_files) == 1
-                return stat_files[1]
-            else
-                @error "No unique stats file found at $dir."
+            @warn "No unique stats netCDF file found in $stats. Extending search to other files."
+            try
+                stat_files = readdir(stats, join = true) # WindowsOS/julia 1.6.0 relpath bug
+                if length(stat_files) == 1
+                    return stat_files[1]
+                else
+                    @error "No unique stats file found at $dir."
+                end
+            catch f
+                if isa(f, Base.IOError)
+                    @warn "Extended search errored with: $f"
+                    return ""
+                else
+                    throw(f)
+                end
             end
         else
-            @error "An error occurred retrieving the stats path at $dir."
+            @warn "An error occurred retrieving the stats path at $dir. Throwing..."
+            throw(e)
         end
     end
 end

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -27,7 +27,7 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
     )
     # Generate ref_stats
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_SCM(ref_models, overwrite = false)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
     ref_stats = ReferenceStatistics(ref_models, true, true; y_type = SCM(), Σ_type = SCM())
     # Generate config
     config = Dict()

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -75,10 +75,10 @@ function get_reference_config(::Bomex)
     config["Σ_reference_type"] = SCM()
     config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean"]]
     ref_root_dir = mktempdir()
-    config["y_dir"] = [joinpath(ref_root_dir, "Output.Bomex.000000")]
-    config["scm_suffix"] = ["000000"]
+    config["y_dir"] = [joinpath(ref_root_dir, "Output.Bomex.ref")]
+    config["scm_suffix"] = ["scm"]
     config["scm_parent_dir"] = [ref_root_dir]
-    config["t_start"] = [4.0 * 3600]
+    config["t_start"] = [2.0 * 3600]
     config["t_end"] = [6.0 * 3600]
     return config
 end

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -14,6 +14,18 @@ include("config.jl")
 
 @testset "Pipeline" begin
     config = get_config()
+    # Generate reference data
+    ref_config = config["reference"]
+    ref_model = ReferenceModel(
+        ref_config["y_names"][1],
+        ref_config["y_dir"][1],
+        ref_config["y_dir"][1],
+        ref_config["case_name"][1],
+        ref_config["t_start"][1],
+        ref_config["t_end"][1],
+    )
+    run_reference_SCM(ref_model, run_single_timestep = false)
+    # Initialize calibration setup
     init_calibration(config; mode = "hpc")
     res_dir_list = glob("results_*_SCM*", config["output"]["outdir_root"])
     res_dir = res_dir_list[1]

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -38,7 +38,7 @@ end
         :Σ_t_end => [4.5 * 3600, 4.5 * 3600],
     )
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_SCM(ref_models, overwrite = false)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
     Δt = 5.0 * 3600
     ref_model = time_shift_reference_model(ref_models[1], Δt)
 

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -18,7 +18,7 @@ using CalibrateEDMF.TurbulenceConvectionUtils
         :t_end => repeat([6.0 * 3600], 2),
     )
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_SCM(ref_models, overwrite = false)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
 
     # Test only tikhonov vs PCA and tikhonov
     pca_list = [false, true]


### PR DESCRIPTION
Explicitly fetch/generate namelist from TC, then modify the time step in the namelist so that reference SCM simulation is only run 1 step forward. This generates the necessary z-levels, and cell/face variable info for calibration.

Depends on https://github.com/CliMA/TurbulenceConvection.jl/pull/525.

TODO: Check that TC doesn't write namelist to output directory, otherwise all calibration studies will have incorrect `t_max`.

