### PR TITLE
Simplify pipeline, avoid preconditioning for unscented inversion.

### DIFF
--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -28,7 +28,7 @@ function get_config()
     config = Dict()
     # Flags for saving output data
     config["output"] = get_output_config()
-    # Define preconditioning and regularization of inverse problem
+    # Define regularization of inverse problem
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
     config["reference"] = get_reference_config(LesDrivenScm())
@@ -56,7 +56,6 @@ function get_regularization_config()
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 10.0 # Tikhonov regularization
     config["dim_scaling"] = true # Tikhonov regularization
-    config["precondition"] = true # Application of prior preconditioning
     return config
 end
 
@@ -105,7 +104,7 @@ function get_reference_config(::LesDrivenScm)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
     config["y_reference_type"] = LES()
     config["Σ_reference_type"] = LES()
-    config["y_names"] = repeat([["thetal_mean", "ql_mean", "qt_mean", "s_mean", "s_mean"]], 3)
+    config["y_names"] = repeat([["thetal_mean", "ql_mean", "qt_mean", "s_mean"]], 3)
     les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip")
     config["y_dir"] = [
         get_cfsite_les_dir(17; les_kwargs...),
@@ -136,6 +135,19 @@ function get_prior_config()
         "pressure_normalmode_drag_coeff" => [bounded(5.0, 15.0)],
         "static_stab_coeff" => [bounded(0.1, 0.8)],
     )
-    config["unconstrained_σ"] = 0.5
+    # Tight initial bounds for Unscented
+    # config["constraints"] = Dict(
+    #     # entrainment parameters
+    #     "entrainment_factor" => [bounded(0.1, 0.15)],
+    #     "detrainment_factor" => [bounded(0.4, 0.6)],
+    #     "sorting_power" => [bounded(1.5, 2.5)],
+    #     "tke_ed_coeff" => [bounded(0.1, 0.15)],
+    #     "tke_diss_coeff" => [bounded(0.2, 0.25)],
+    #     "pressure_normalmode_adv_coeff" => [bounded(0.0, 0.5)],
+    #     "pressure_normalmode_buoy_coeff1" => [bounded(0.1, 0.2)],
+    #     "pressure_normalmode_drag_coeff" => [bounded(9.0, 11.0)],
+    #     "static_stab_coeff" => [bounded(0.1, 0.8)],
+    # )
+    config["unconstrained_σ"] = 1.0
     return config
 end

--- a/experiments/les_strats/tc_calibrate.jl
+++ b/experiments/les_strats/tc_calibrate.jl
@@ -1,6 +1,4 @@
 # Import modules to all processes
-
-# Import modules to all processes
 @everywhere using Pkg
 @everywhere Pkg.activate("../..")
 @everywhere using CalibrateEDMF
@@ -24,42 +22,33 @@ include(joinpath(dirname(src_dir), "experiments", "les_strats", "config.jl"))
 function run_calibrate(config; return_ekobj = false)
 
     N_iter = config["process"]["N_iter"]
-    N_ens = config["process"]["N_ens"]
-    algo_name = config["process"]["algorithm"]
     Δt = config["process"]["Δt"]
     # Adds noise to deterministic maps in EKI
     deterministic_forward_map = config["process"]["noisy_obs"]
+
     perform_PCA = config["regularization"]["perform_PCA"]
-    # For now this is not used, pmap does not work within if scopes
-    apply_preconditioning = config["regularization"]["precondition"]
 
     save_eki_data = config["output"]["save_eki_data"]
     save_ensemble_data = config["output"]["save_ensemble_data"]
 
-    init_dict = init_calibration(N_ens, N_iter, config, mode = "pmap")
+    init_dict = init_calibration(config, mode = "pmap")
     ekobj = init_dict["ekobj"]
+    algo = ekobj.process
     priors = init_dict["priors"]
     ref_models = init_dict["ref_models"]
     ref_stats = init_dict["ref_stats"]
-    d = init_dict["d"]
-    n_param = init_dict["n_param"]
+    d = length(ref_stats.y)
+    N_par, N_ens = size(ekobj.u[1])
     outdir_path = init_dict["outdir_path"]
     C = sum(ref_model -> length(get_t_start(ref_model)), ref_models)
-    sim_num = length(ref_models)
 
     # Precondition prior
     @everywhere precondition_param(x::Vector{FT}) where {FT <: Real} = precondition(x, $priors, $ref_models, $ref_stats)
-    precond_params = pmap(precondition_param, [c[:] for c in eachcol(get_u_final(ekobj))])
-    if algo_name == "Inversion" || algo_name == "Sampler"
-        algo = algo_name == "Inversion" ? Inversion() : Sampler(vcat(get_mean(priors)...), get_cov(priors))
+    if isa(algo, Inversion) || isa(algo, Sampler)
+        precond_params = pmap(precondition_param, [c[:] for c in eachcol(get_u_final(ekobj))])
         ekobj = generate_ekp(hcat(precond_params...), ref_stats, algo, outdir_path = outdir_path)
-    elseif algo_name == "Unscented"
-        algo = Unscented(vcat(get_mean(priors)...), get_cov(priors), 1.0, 0)
-        N_ens = 2 * n_param + 1
     end
 
-    # Define caller function
-    @everywhere g_(x::Vector{FT}) where {FT <: Real} = run_SCM(x, $priors.names, $ref_models, $ref_stats)
     # EKP iterations
     g_ens = zeros(N_ens, d)
     norm_err_list = []
@@ -68,24 +57,22 @@ function run_calibrate(config; return_ekobj = false)
     for i in 1:N_iter
         # Parameters are transformed to constrained space when used as input to TurbulenceConvection.jl
         params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
-        g_output_list = pmap(g_, [c[:] for c in eachcol(params_cons_i)]; retry_delays = zeros(5)) # Outer dim is params iterator
+        params = [c[:] for c in eachcol(params_cons_i)]
+        mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+        g_output_list = pmap(run_SCM, mod_evaluators; retry_delays = zeros(5)) # Outer dim is params iterator
         (sim_dirs_arr, g_ens_arr, g_ens_arr_pca) = ntuple(l -> getindex.(g_output_list, l), 3) # Outer dim is G̃, G 
         @info "\n\nEKP evaluation $i finished. Updating ensemble ...\n"
         for j in 1:N_ens
             g_ens[j, :] = perform_PCA ? g_ens_arr_pca[j] : g_ens_arr[j]
         end
 
-        # Get normalized error
-        if typeof(algo) == Inversion
+        if isa(algo, Inversion)
             update_ensemble!(
                 ekobj,
                 Array(g_ens'),
                 Δt_new = Δt_scaled,
                 deterministic_forward_map = deterministic_forward_map,
             )
-        elseif typeof(algo) == Unscented{Float64, Int64}
-            # TODO: Add Δt_new=Δt_scaled to EKP master branch (from ilopezgp/EKP.jl)
-            update_ensemble!(ekobj, Array(g_ens'))
         else
             update_ensemble!(ekobj, Array(g_ens'))
         end
@@ -99,7 +86,7 @@ function run_calibrate(config; return_ekobj = false)
 
         # Convert to arrays
         phi_params = Array{Array{Float64, 2}, 1}(transform_unconstrained_to_constrained(priors, get_u(ekobj)))
-        phi_params_arr = zeros(i + 1, n_param, N_ens)
+        phi_params_arr = zeros(i + 1, N_par, N_ens)
         g_big_arr = zeros(i, N_ens, full_length(ref_stats))
         for (k, elem) in enumerate(phi_params)
             phi_params_arr[k, :, :] = elem
@@ -148,13 +135,8 @@ function run_calibrate(config; return_ekobj = false)
             npzwrite(joinpath(outdir_path, "norm_err.npy"), norm_err_arr)
             npzwrite(joinpath(outdir_path, "g_big.npy"), g_big_arr)
             for (l, P_pca) in enumerate(ref_stats.pca_vec)
-                if C ≈ sim_num
-                    npzwrite(string(outdir_path, "/P_pca_", ref_models[l].case_name, ".npy"), P_pca)
-                    npzwrite(string(outdir_path, "/pool_var_", ref_models[l].case_name, ".npy"), ref_stats.norm_vec[l])
-                else
-                    npzwrite(joinpath(outdir_path, "P_pca_", l, ".npy"), P_pca)
-                    npzwrite(joinpath(outdir_path, "pool_var_", l, ".npy"), ref_stats.norm_vec[l])
-                end
+                npzwrite(string(outdir_path, "/P_pca_", ref_models[l].case_name, ".npy"), P_pca)
+                npzwrite(string(outdir_path, "/pool_var_", ref_models[l].case_name, ".npy"), ref_stats.norm_vec[l])
             end
         end
 

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -28,7 +28,7 @@ function get_config()
     config = Dict()
     # Flags for saving output data
     config["output"] = get_output_config()
-    # Define preconditioning and regularization of inverse problem
+    # Define regularization of inverse problem
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
     config["reference"] = get_reference_config(Bomex())
@@ -56,7 +56,6 @@ function get_regularization_config()
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 2.0 # Tikhonov regularization
     config["dim_scaling"] = false # Dimensional scaling of the loss
-    config["precondition"] = true # Application of prior preconditioning
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
@@ -28,7 +28,7 @@ julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
 julia --project -e 'using Pkg; Pkg.precompile()'
 
 # First call to calibrate.jl will create the ensemble files from the priors
-id_init_ens=$(sbatch --parsable -A esm init.sbatch $n $n_it $job_id)
+id_init_ens=$(sbatch --parsable -A esm init.sbatch $config $job_id)
 for it in $(seq 1 1 $n_it)
 do
 # Parallel runs of forward model
@@ -38,6 +38,6 @@ if [ "$it" = "1" ]; then
 else
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n single_scm_eval.sbatch $it $job_id)
 fi
-id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $config $job_id)
 done
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
@@ -4,22 +4,17 @@ using ArgParse
 using CalibrateEDMF
 using CalibrateEDMF.Pipeline
 
-# Include calibration config file to define problem
-include(joinpath(dirname(pwd()), "config.jl"))
-
 s = ArgParseSettings()
 @add_arg_table s begin
-    "--n_ens"
-    help = "Number of ensemble members."
-    arg_type = Int
-    "--n_it"
-    help = "Number of algorithm iterations."
-    arg_type = Int
+    "--config"
+    help = "Inverse problem config file"
+    arg_type = String
     "--job_id"
     help = "Job identifier"
     arg_type = String
     default = "default_id"
 end
 parsed_args = parse_args(ARGS, s)
+include(parsed_args["config"])
 
-init_calibration(parsed_args["n_ens"], parsed_args["n_it"], get_config(); job_id = parsed_args["job_id"])
+init_calibration(get_config(); job_id = parsed_args["job_id"])

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.sbatch
@@ -10,9 +10,8 @@
 module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.API.precompile()'
 
-n_ens=${1?Error: no ensemble size given}
-n_it=${2?Error: no iteration number given}
-job_id=${3?Error: no job ID given}
+config=${1?Error: no config file given}
+job_id=${2?Error: no job ID given}
 
-julia --project init.jl --n_ens $n_ens --n_it $n_it --job_id $job_id
+julia --project init.jl --config $config --job_id $job_id
 echo 'Ensemble initialized for calibration.'

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
@@ -31,12 +31,7 @@ version = parsed_args["version"]
 outdir_path = parsed_args["job_dir"]
 
 scm_args = load(scm_init_path(outdir_path, version))
+model_evaluator = scm_args["model_evaluator"]
+sim_dirs, g_scm, g_scm_pca = run_SCM(model_evaluator)
 
-sim_dirs, g_scm, g_scm_pca = run_SCM(
-    scm_args["u"],
-    scm_args["u_names"],
-    map(x -> deserialize_struct(x, ReferenceModel), scm_args["ref_models"]),
-    deserialize_struct(scm_args["ref_stats"], ReferenceStatistics),
-)
-
-jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, version)
+jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -20,38 +20,73 @@ using JLD2
 using Base
 
 
-function ek_update(iteration_::Int64, outdir_path::String)
-    # Recover versions from last iteration
-    versions = readlines(joinpath(outdir_path, "versions_$(iteration_).txt"))
-    ekobj = deserialize_struct(load(ekobj_path(outdir_path, iteration_))["ekp"], EnsembleKalmanProcess)
+"""
+    ek_update(
+        ekobj::EnsembleKalmanProcess,
+        priors::ParameterDistribution,
+        iteration::Int64,
+        config::Dict{Any, Any},
+        versions::Vector{String},
+        outdir_path::String,
+    )
+
+Updates an EnsembleKalmanProcess using forward model evaluations stored
+in output files defined by their `versions`, and generates the parameters
+for the next ensemble for forward model evaluations. The updated EnsembleKalmanProcess
+and new ModelEvaluator are both written to file.
+
+Inputs:
+
+ - ekobj         :: EnsembleKalmanProcess to be updated.
+ - priors        :: Priors over parameters, used for unconstrained-constrained mappings.
+ - iteration     :: Current iteration of the calibration process.
+ - config        :: Process configuration dictionary.
+ - versions      :: String versions identifying the forward model evaluations.
+ - outdir_path   :: Output path directory.
+"""
+function ek_update(
+    ekobj::EnsembleKalmanProcess,
+    priors::ParameterDistribution,
+    iteration::Int64,
+    config::Dict{Any, Any},
+    versions::Vector{String},
+    outdir_path::String,
+)
+    Δt = config["Δt"]
+    deterministic_forward_map = config["noisy_obs"]
+    # Get dimensionality
+    mod_evaluator = load(scm_output_path(outdir_path, versions[1]))["model_evaluator"]
     N_par, N_ens = size(ekobj.u[1])
     @assert N_ens == length(versions)
+    C = sum(ref_model -> length(get_t_start(ref_model)), mod_evaluator.ref_models)
+    Δt_scaled = Δt / C # Scale artificial timestep by batch size
 
-    scm_args = load(scm_init_path(outdir_path, versions[1]))
-    ref_stats = deserialize_struct(scm_args["ref_stats"], ReferenceStatistics)
-    ref_models = map(x -> deserialize_struct(x, ReferenceModel), scm_args["ref_models"])
     u = zeros(N_ens, N_par)
-    g = zeros(N_ens, pca_length(ref_stats))
+    g = zeros(N_ens, pca_length(mod_evaluator.ref_stats))
     for (ens_index, version) in enumerate(versions)
-        scm_args = load(scm_init_path(outdir_path, version))
         scm_outputs = load(scm_output_path(outdir_path, version))
-        u[ens_index, :] = scm_args["u"]
+        mod_evaluator = scm_outputs["model_evaluator"]
+        u[ens_index, :] = mod_evaluator.param_cons
         g[ens_index, :] = scm_outputs["g_scm_pca"]
     end
     g = Array(g')
     # Advance EKP
-    update_ensemble!(ekobj, g)
-    ekp = serialize_struct(ekobj)
-    jldsave(ekobj_path(outdir_path, iteration_ + 1); ekp)
+    if isa(ekobj.process, Inversion)
+        update_ensemble!(ekobj, g, Δt_new = Δt_scaled, deterministic_forward_map = deterministic_forward_map)
+    else
+        update_ensemble!(ekobj, g)
+    end
+    ekp = ekobj
+    jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
 
     # Get new step
-    priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
     params = [c[:] for c in eachcol(params_cons_i)]
-    versions = map(param -> generate_scm_input(param, priors.names, ref_models, ref_stats, outdir_path), params)
-
+    mod_evaluators =
+        [ModelEvaluator(param, get_name(priors), mod_evaluator.ref_models, mod_evaluator.ref_stats) for param in params]
+    versions = map(mod_eval -> generate_scm_input(mod_eval, outdir_path), mod_evaluators)
     # Store version identifiers for this ensemble in a common file
-    write_versions(versions, iteration_ + 1, outdir_path = outdir_path)
+    write_versions(versions, iteration + 1, outdir_path = outdir_path)
     return
 end
 
@@ -62,6 +97,9 @@ s = ArgParseSettings()
     "--iteration"
     help = "Calibration iteration number"
     arg_type = Int
+    "--config"
+    help = "Inverse problem config file"
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String
@@ -69,4 +107,13 @@ s = ArgParseSettings()
 end
 parsed_args = parse_args(ARGS, s)
 
-ek_update(parsed_args["iteration"], parsed_args["job_dir"])
+include(parsed_args["config"])
+
+# Recover inputs for update
+iteration = parsed_args["iteration"]
+outdir_path = parsed_args["job_dir"]
+versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
+process_config = get_config()["process"]
+ek_update(ekobj, priors, iteration, process_config, versions, outdir_path)

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.sbatch
@@ -8,8 +8,9 @@
 
 module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 iteration_=${1?Error: no iteration given}
-job_id=${2?Error: no job ID given}
+config=${2?Error: no config file given}
+job_id=${3?Error: no job ID given}
 job_dir=$(head $job_id".txt" | tail -1)
 
-julia --project step_ekp.jl --iteration $iteration_ --job_dir $job_dir
+julia --project step_ekp.jl --iteration $iteration_ --config $config --job_dir $job_dir
 echo "Ensemble at iteration ${iteration_} stepped forward."

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -378,26 +378,24 @@ function generate_ekp(
     outdir_path::String = pwd(),
     to_file::Bool = true,
 )
-    ekp_obj = EnsembleKalmanProcess(u, ref_stats.y, ref_stats.Γ, algo)
+    ekp = EnsembleKalmanProcess(u, ref_stats.y, ref_stats.Γ, algo)
     if to_file
-        ekp = serialize_struct(ekp_obj)
         jldsave(ekobj_path(outdir_path, 1); ekp)
     end
-    return ekp_obj
+    return ekp
 end
 
 function generate_ekp(
     ref_stats::ReferenceStatistics,
-    algo::Unscented{FT, IT};
+    algo::Unscented;
     outdir_path::String = pwd(),
     to_file::Bool = true,
-) where {FT <: Real, IT <: Integer}
-    ekp_obj = EnsembleKalmanProcess(ref_stats.y, ref_stats.Γ, algo)
+)
+    ekp = EnsembleKalmanProcess(ref_stats.y, ref_stats.Γ, algo)
     if to_file
-        ekp = serialize_struct(ekp_obj)
         jldsave(ekobj_path(outdir_path, 1); ekp)
     end
-    return ekp_obj
+    return ekp
 end
 
 end # module

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -25,7 +25,7 @@ function get_config()
     config = Dict()
     # Flags for saving output data
     config["output"] = get_output_config()
-    # Define preconditioning and regularization of inverse problem
+    # Define regularization of inverse problem
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
     config["reference"] = get_reference_config(Bomex())
@@ -53,7 +53,6 @@ function get_regularization_config()
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 2.0 # Tikhonov regularization
     config["dim_scaling"] = false # Dimensional scaling of the loss
-    config["precondition"] = true # Application of prior preconditioning
     return config
 end
 

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -14,7 +14,7 @@ include("config.jl")
 
 @testset "Pipeline" begin
     config = get_config()
-    init_calibration(config["process"]["N_ens"], config["process"]["N_iter"], config; mode = "hpc")
+    init_calibration(config; mode = "hpc")
     res_dir_list = glob("results_*_SCM", config["output"]["outdir_root"])
     res_dir = res_dir_list[1]
     # Check for output
@@ -32,10 +32,14 @@ include("config.jl")
 
     # Re-use previous simulation
     config["output"]["overwrite_scm_file"] = false
-    res_dict = init_calibration(config["process"]["N_ens"], config["process"]["N_iter"], config; mode = "pmap")
+    res_dict = init_calibration(config; mode = "pmap")
 
-    @test typeof(res_dict["ekobj"]) == EnsembleKalmanProcess{Float64, Int64, Inversion}
+    ekobj = res_dict["ekobj"]
+    N_par, N_ens = size(ekobj.u[1])
+
+    @test typeof(ekobj) == EnsembleKalmanProcess{Float64, Int64, Inversion}
     @test typeof(res_dict["ref_stats"]) == ReferenceStatistics{Float64}
     @test typeof(res_dict["ref_models"]) == Vector{ReferenceModel}
-    @test res_dict["n_param"] == 2
+    @test N_par == 2
+    @test N_ens == 5
 end


### PR DESCRIPTION
This PR simplifies the pipeline, and adds the ModelEvaluator struct, which houses all the information required to evaluate the SCM forward model.