### PR TITLE
Add NetCDFIO module, output to NetCDF.

### DIFF
--- a/src/CalibrateEDMF.jl
+++ b/src/CalibrateEDMF.jl
@@ -7,6 +7,7 @@ include("ReferenceModels.jl")
 include("LESUtils.jl")
 include("ReferenceStats.jl")
 include("TurbulenceConvectionUtils.jl")
+include("NetCDFIO.jl")
 include("Pipeline.jl")
 
 end # module

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -1,0 +1,282 @@
+module NetCDFIO
+
+using NCDatasets
+using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+
+using ..ReferenceStats
+const NC = NCDatasets
+
+export NetCDFIO_Diags
+export open_files, close_files, write_iteration
+export init_iteration_io, io_reference, init_particle_diags, io_particle_diags
+export init_metrics, io_metrics
+
+
+mutable struct NetCDFIO_Diags
+    root_grp::NC.NCDataset{Nothing}
+    ensemble_grp::NC.NCDataset{NC.NCDataset{Nothing}}
+    particle_grp::NC.NCDataset{NC.NCDataset{Nothing}}
+    metric_grp::NC.NCDataset{NC.NCDataset{Nothing}}
+    outdir_path::String
+    filepath::String
+    vars::Dict{String, Any} # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+    function NetCDFIO_Diags(config::Dict{Any, Any}, outdir_path::String, ref_stats::ReferenceStatistics)
+
+        # Initialize properties with valid type:
+        tmp = tempname()
+        root_grp = NC.Dataset(tmp, "c")
+        NC.defGroup(root_grp, "ensemble_diags")
+        NC.defGroup(root_grp, "particle_diags")
+        NC.defGroup(root_grp, "metrics")
+        ensemble_grp = root_grp.group["ensemble_diags"]
+        particle_grp = root_grp.group["particle_diags"]
+        metric_grp = root_grp.group["metrics"]
+        close(root_grp)
+
+        filepath = joinpath(outdir_path, "Diagnostics.nc")
+
+        # Remove the NC file if it already exists.
+        isfile(filepath) && rm(filepath; force = true)
+
+        NC.Dataset(filepath, "c") do root_grp
+
+            # Fetch dimensionality
+            N_ens = config["process"]["N_ens"]
+            d_full = full_length(ref_stats)
+            d = pca_length(ref_stats)
+            p = length(collect(keys(config["prior"]["constraints"])))
+
+            particle = Array(1:N_ens)
+            out = Array(1:d)
+            out_full = Array(1:d_full)
+            param = Array(1:p)
+
+            # Ensemble diagnostics (over all particles)
+            ensemble_grp = NC.defGroup(root_grp, "ensemble_diags")
+            NC.defDim(ensemble_grp, "out_full", d_full)
+            NC.defVar(ensemble_grp, "out_full", out_full, ("out_full",))
+            NC.defDim(ensemble_grp, "out", d)
+            NC.defVar(ensemble_grp, "out", out, ("out",))
+            NC.defDim(ensemble_grp, "param", p)
+            NC.defVar(ensemble_grp, "param", param, ("param",))
+            NC.defDim(ensemble_grp, "iteration", Inf)
+            NC.defVar(ensemble_grp, "iteration", Int16, ("iteration",))
+
+            # Reference model and stats diagnostics
+            reference_grp = NC.defGroup(root_grp, "reference")
+            NC.defDim(reference_grp, "out_full", d_full)
+            NC.defVar(reference_grp, "out_full", out_full, ("out_full",))
+            NC.defDim(reference_grp, "out", d)
+            NC.defVar(reference_grp, "out", out, ("out",))
+
+            # Particle diagnostics
+            particle_grp = NC.defGroup(root_grp, "particle_diags")
+            NC.defDim(particle_grp, "particle", N_ens)
+            NC.defVar(particle_grp, "particle", particle, ("particle",))
+            NC.defDim(particle_grp, "out_full", d_full)
+            NC.defVar(particle_grp, "out_full", out_full, ("out_full",))
+            NC.defDim(particle_grp, "out", d)
+            NC.defVar(particle_grp, "out", out, ("out",))
+            NC.defDim(particle_grp, "param", p)
+            NC.defVar(particle_grp, "param", param, ("param",))
+            NC.defDim(particle_grp, "iteration", Inf)
+            NC.defVar(particle_grp, "iteration", Int16, ("iteration",))
+
+            # Calibration metrics
+            metric_grp = NC.defGroup(root_grp, "metrics")
+            NC.defDim(metric_grp, "iteration", Inf)
+            NC.defVar(metric_grp, "iteration", Int16, ("iteration",))
+        end
+        vars = Dict{String, Any}()
+        return new(root_grp, ensemble_grp, particle_grp, metric_grp, outdir_path, filepath, vars)
+    end
+
+    function NetCDFIO_Diags(filepath::String)
+        vars = Dict{String, Any}()
+        diags = nothing
+        NC.Dataset(filepath, "r") do root_grp
+            ensemble_grp = root_grp.group["ensemble_diags"]
+            particle_grp = root_grp.group["particle_diags"]
+            metric_grp = root_grp.group["metrics"]
+            diags = new(root_grp, ensemble_grp, particle_grp, metric_grp, dirname(filepath), filepath, vars)
+        end
+        return diags
+    end
+end
+
+# IO DIctionaries
+
+function io_dictionary_reference(ref_stats::ReferenceStatistics)
+    io_dict = Dict(
+        "Gamma" => (; dims = ("out", "out"), group = "reference", field = ref_stats.Γ),
+        "Gamma_full" => (; dims = ("out_full", "out_full"), group = "reference", field = ref_stats.Γ_full),
+        "y" => (; dims = ("out",), group = "reference", field = ref_stats.y),
+        "y_full" => (; dims = ("out_full",), group = "reference", field = ref_stats.y_full),
+    )
+    return io_dict
+end
+
+function io_dictionary_metrics(ekp::EnsembleKalmanProcess)
+    try
+        return Dict("ekp_error" => (; dims = ("iteration",), group = "metrics", field = get_error(ekp)[end]))
+    catch e
+        # For EnsembleKalmanProcesses prior to evaluation of g.
+        if isa(e, BoundsError)
+            return Dict("ekp_error" => (; dims = ("iteration",), group = "metrics"))
+        else
+            throw(e)
+        end
+    end
+    return io_dict
+end
+
+function io_dictionary_particle_state(ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
+    u = get_u_final(ekp)
+    ϕ = transform_unconstrained_to_constrained(priors, u)
+    io_dict = Dict(
+        "u" => (; dims = ("particle", "param", "iteration"), group = "particle_diags", field = u'),
+        "phi" => (; dims = ("particle", "param", "iteration"), group = "particle_diags", field = ϕ'),
+    )
+    return io_dict
+end
+
+function io_dictionary_particle_eval(ekp::EnsembleKalmanProcess)
+    try
+        return Dict(
+            "g" => (; dims = ("particle", "out", "iteration"), group = "particle_diags", field = get_g_final(ekp)'),
+        )
+    catch e
+        # For EnsembleKalmanProcesses prior to evaluation of g.
+        if isa(e, BoundsError)
+            return Dict("g" => (; dims = ("particle", "out", "iteration"), group = "particle_diags"))
+        else
+            throw(e)
+        end
+    end
+end
+
+function open_files(self)
+    self.root_grp = NC.Dataset(self.filepath, "a")
+    self.ensemble_grp = self.root_grp.group["ensemble_diags"]
+    self.particle_grp = self.root_grp.group["particle_diags"]
+    self.metric_grp = self.root_grp.group["metrics"]
+    vars = self.vars
+
+    # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
+    vars["ensemble_diags"] = Dict{String, Any}()
+    for k in keys(self.ensemble_grp)
+        vars["ensemble_diags"][k] = self.ensemble_grp[k]
+    end
+    vars["particle_diags"] = Dict{String, Any}()
+    for k in keys(self.particle_grp)
+        vars["particle_diags"][k] = self.particle_grp[k]
+    end
+    vars["metrics"] = Dict{String, Any}()
+    for k in keys(self.metric_grp)
+        vars["metrics"][k] = self.metric_grp[k]
+    end
+end
+
+function close_files(self::NetCDFIO_Diags)
+    close(self.root_grp)
+end
+
+
+function add_field(self::NetCDFIO_Diags, var_name::String; dims, group)
+    NC.Dataset(self.filepath, "a") do root_grp
+        grp = root_grp.group[group]
+        new_var = NC.defVar(grp, var_name, Float64, dims)
+    end
+end
+
+
+function write_current(self::NetCDFIO_Diags, var_name::String, data; group)
+    var = self.vars[group][var_name]
+    last_dim = length(size(var))
+    last_dim_end = size(var, last_dim)
+    selectdim(var, last_dim, last_dim_end) .= data
+end
+
+function write_ref(self::NetCDFIO_Diags, var_name::String, data)
+    NC.Dataset(self.filepath, "a") do root_grp
+        reference_grp = root_grp.group["reference"]
+        var = reference_grp[var_name]
+        var .= data
+    end
+end
+
+function io_reference(diags::NetCDFIO_Diags, ref_stats::ReferenceStatistics)
+    io_dict = io_dictionary_reference(ref_stats)
+    for var in keys(io_dict)
+        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group)
+        write_ref(diags, var, io_dict[var].field)
+    end
+end
+
+function init_particle_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
+    io_dict = io_dictionary_particle_eval(ekp)
+    for var in keys(io_dict)
+        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group)
+    end
+    io_dict = io_dictionary_particle_state(ekp, priors)
+    for var in keys(io_dict)
+        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group)
+    end
+    open_files(diags)
+    for var in keys(io_dict)
+        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
+    end
+    close_files(diags)
+end
+
+function init_metrics(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess)
+    io_dict = io_dictionary_metrics(ekp)
+    for var in keys(io_dict)
+        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group)
+    end
+end
+
+function io_metrics(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess)
+    io_dict = io_dictionary_metrics(ekp)
+    for var in keys(io_dict)
+        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
+    end
+end
+
+function io_particle_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
+    # Write eval diagnostics to file
+    io_dict = io_dictionary_particle_eval(ekp)
+    for var in keys(io_dict)
+        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
+    end
+    # Write state diagnostics of next iteration to file
+    write_iteration(diags)
+    io_dict = io_dictionary_particle_state(ekp, priors)
+    for var in keys(io_dict)
+        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
+    end
+end
+
+function init_iteration_io(self::NetCDFIO_Diags)
+    ensemble_t = self.ensemble_grp["iteration"]
+    @inbounds ensemble_t[1] = 0
+    particle_t = self.particle_grp["iteration"]
+    @inbounds particle_t[1] = 0
+    metric_t = self.metric_grp["iteration"]
+    @inbounds metric_t[1] = 0
+end
+
+function write_iteration(self::NetCDFIO_Diags)
+    ensemble_t = self.ensemble_grp["iteration"]
+    @inbounds ensemble_t[end + 1] = ensemble_t[end] + 1
+
+    particle_t = self.particle_grp["iteration"]
+    @inbounds particle_t[end + 1] = particle_t[end] + 1
+
+    metric_t = self.metric_grp["iteration"]
+    @inbounds metric_t[end + 1] = metric_t[end] + 1
+end
+
+
+end # module

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -1,0 +1,59 @@
+using Test
+using LinearAlgebra
+using NCDatasets
+const NC = NCDatasets
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.NetCDFIO
+using CalibrateEDMF.TurbulenceConvectionUtils
+
+@testset "NetCDFIO_Diags" begin
+    # Choose same SCM to speed computation
+    data_dir = mktempdir()
+    scm_dirs = repeat([joinpath(data_dir, "Output.Bomex.000000")], 2)
+    kwargs_ref_model = Dict(
+        :y_names => [["u_mean"], ["v_mean"]],
+        :y_dir => scm_dirs,
+        :scm_dir => scm_dirs,
+        :case_name => repeat(["Bomex"], 2),
+        :t_start => repeat([4.0 * 3600], 2),
+        :t_end => repeat([6.0 * 3600], 2),
+    )
+    # Generate ref_stats
+    ref_models = construct_reference_models(kwargs_ref_model)
+    run_SCM(ref_models, overwrite = false)
+    ref_stats = ReferenceStatistics(ref_models, true, true; y_type = SCM(), Σ_type = SCM())
+    # Generate config
+    config = Dict()
+    config["process"] = Dict()
+    config["process"]["N_ens"] = 10
+    config["prior"] = Dict()
+    config["prior"]["constraints"] = Dict("foo" => 1, "bar" => 2)
+
+    diags = NetCDFIO_Diags(config, data_dir, ref_stats)
+
+    # Test constructor
+    @test isa(diags, NetCDFIO_Diags)
+    @test isempty(diags.vars)
+
+    # Test reference diagnostics
+    io_reference(diags, ref_stats)
+    NC.Dataset(diags.filepath, "r") do root_grp
+        ref_grp = root_grp.group["reference"]
+        @test ref_grp["Gamma"] ≈ ref_stats.Γ
+        @test ref_grp["Gamma_full"] ≈ ref_stats.Γ_full
+        @test ref_grp["y"] ≈ ref_stats.y
+        @test ref_grp["y_full"] ≈ ref_stats.y_full
+    end
+
+    # Test iteration-dependent diagnostics
+    open_files(diags)
+    init_iteration_io(diags)
+    write_iteration(diags)
+    close_files(diags)
+    NC.Dataset(diags.filepath, "r") do root_grp
+        ensemble_grp = root_grp.group["ensemble_diags"]
+        @test length(ensemble_grp["iteration"]) == 2
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ include(joinpath("TurbulenceConvectionUtils", "runtests.jl"))
 include(joinpath("ReferenceModels", "runtests.jl"))
 include(joinpath("ReferenceStats", "runtests.jl"))
 include(joinpath("Pipeline", "runtests.jl"))
+include(joinpath("NetCDFIO", "runtests.jl"))
 
 @testset "error_utils" begin
     foo = rand(5)


### PR DESCRIPTION
This PR adds the NetCDFIO module, based on the module of the same name from `TC.jl`. We want to ideally move all diagnostic output to this centralized file, since keeping track of many `jld2` files is more tedious, seems to have a larger memory overhead, and cannot be read from python directly. A step towards #91 .

1. The module defines diagnostic dictionaries associated with different groups (ensemble diagnostics, particle diagnostics, reference and metrics) with some examples (I have added just a few variables so far).

2. The module defines io functions for the different groups, trying to push all the diagnostic definition and writing to the backend.

I have also added a few tests, and the function is now used in the HPC pipeline.

