### PR TITLE
Refactor diagnostic dictionaries, add more NetCDF diagnostics.

### DIFF
--- a/experiments/les_strats/tc_calibrate.jl
+++ b/experiments/les_strats/tc_calibrate.jl
@@ -74,7 +74,7 @@ function run_calibrate(config; return_ekobj = false)
         @info "\nEnsemble updated. Saving results to file...\n"
 
         # Get normalized error for full dimensionality output
-        push!(norm_err_list, compute_errors(g_ens_arr, ref_stats.y_full))
+        push!(norm_err_list, compute_mse(g_ens_arr, ref_stats.y_full))
         norm_err_arr = hcat(norm_err_list...)' # N_iter, N_ens
         # Store full dimensionality output
         push!(g_big_list, g_ens_arr)

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
@@ -82,7 +82,7 @@ function run_calibrate(config; return_ekobj = false)
         @info "\nEnsemble updated. Saving results to file...\n"
 
         # Get normalized error for full dimensionality output
-        push!(norm_err_list, compute_errors(g_ens_arr, ref_stats.y_full))
+        push!(norm_err_list, compute_mse(g_ens_arr, ref_stats.y_full))
         norm_err_arr = hcat(norm_err_list...)' # N_iter, N_ens
         # Store full dimensionality output
         push!(g_big_list, g_ens_arr)

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -172,11 +172,11 @@ function init_diagnostics(
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
 )
-    diags = NetCDFIO_Diags(config, outdir_path, ref_stats)
+    diags = NetCDFIO_Diags(config, outdir_path, ref_stats, ekp)
     # Write reference
     io_reference(diags, ref_stats)
     # Add metric fields
-    init_metrics(diags, ekp)
+    init_metrics(diags)
     # Add diags, write first ensemble diags
     open_files(diags)
     init_iteration_io(diags)

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -1,12 +1,15 @@
 using Test
 using LinearAlgebra
 using NCDatasets
+using Random
 const NC = NCDatasets
 using CalibrateEDMF.ModelTypes
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.NetCDFIO
 using CalibrateEDMF.TurbulenceConvectionUtils
+
+using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
 
 @testset "NetCDFIO_Diags" begin
     # Choose same SCM to speed computation
@@ -31,7 +34,8 @@ using CalibrateEDMF.TurbulenceConvectionUtils
     config["prior"] = Dict()
     config["prior"]["constraints"] = Dict("foo" => 1, "bar" => 2)
 
-    diags = NetCDFIO_Diags(config, data_dir, ref_stats)
+    ekp = EnsembleKalmanProcess(rand(2, 10), ref_stats.y, ref_stats.Γ, Inversion())
+    diags = NetCDFIO_Diags(config, data_dir, ref_stats, ekp)
 
     # Test constructor
     @test isa(diags, NetCDFIO_Diags)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@ using CalibrateEDMF
 const src_dir = dirname(pathof(CalibrateEDMF))
 include(joinpath(src_dir, "helper_funcs.jl"))
 
-
 include(joinpath("DistributionUtils", "runtests.jl"))
 include(joinpath("LESUtils", "runtests.jl"))
 include(joinpath("TurbulenceConvectionUtils", "runtests.jl"))
@@ -15,10 +14,28 @@ include(joinpath("Pipeline", "runtests.jl"))
 include(joinpath("NetCDFIO", "runtests.jl"))
 
 @testset "error_utils" begin
+    # Vector of vectors vs vector
     foo = rand(5)
     foo_vec = [foo, foo]
     foo_vec2 = [foo .+ 1.0, foo .+ 2.0]
 
-    @test compute_errors(foo_vec, foo) ≈ [0, 0]
-    @test compute_errors(foo_vec2, foo) != [sqrt(5), 2 * sqrt(5)]
+    @test compute_mse(foo_vec, foo) ≈ [0, 0]
+    @test compute_mse(foo_vec2, foo) ≈ [1, 4]
+
+    # Matrices vs vector
+    foo = rand(5)
+    bar = zeros(5, 2)
+    bar2 = zeros(2, 5)
+    bar3 = zeros(5, 2)
+    bar4 = zeros(6, 2)
+    for i in 1:size(bar, 2)
+        bar[:, i] = foo
+        bar2[i, :] = foo
+        bar3[:, i] = foo .+ i
+    end
+
+    @test compute_mse(bar, foo) ≈ [0, 0]
+    @test compute_mse(bar2, foo) ≈ [0, 0]
+    @test compute_mse(bar3, foo) ≈ [1, 4]
+    @test_throws BoundsError compute_mse(bar4, foo)
 end


### PR DESCRIPTION
This PR refactors the diagnostics dictionaries, detaching the fields from the rest of the definition, so that the dictionaries can be called at initialization time when the fields are not known.

It also adds a few NetCDF diagnostics related to model error.