### PR TITLE
Add more diagnostics, modify relative covariance conditioning, ensure type in NetCDF output.

### DIFF
--- a/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
@@ -38,6 +38,6 @@ if [ "$it" = "1" ]; then
 else
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n single_scm_eval.sbatch $it $job_id)
 fi
-id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $config $job_id)
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
 done
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
@@ -17,4 +17,4 @@ end
 parsed_args = parse_args(ARGS, s)
 include(parsed_args["config"])
 
-init_calibration(get_config(); job_id = parsed_args["job_id"])
+init_calibration(get_config(); job_id = parsed_args["job_id"], config_path = parsed_args["config"])

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -63,7 +63,7 @@ function ek_update(
     ref_models = mod_evaluator.ref_models
     _, N_ens = size(get_u_final(ekobj))
     @assert N_ens == length(versions)
-    C = sum(ref_model -> length(get_t_start(ref_model)), ref_models)
+    C = length(ref_stats.pca_vec)
     Δt_scaled = Δt / C # Scale artificial timestep by batch size
 
     g = zeros(pca_length(ref_stats), N_ens)
@@ -135,21 +135,18 @@ s = ArgParseSettings()
     "--iteration"
     help = "Calibration iteration number"
     arg_type = Int
-    "--config"
-    help = "Inverse problem config file"
-    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String
     default = "output"
 end
 parsed_args = parse_args(ARGS, s)
-
-include(parsed_args["config"])
-
 # Recover inputs for update
 iteration = parsed_args["iteration"]
 outdir_path = parsed_args["job_dir"]
+
+include(joinpath(outdir_path, "config.jl"))
+
 versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
 ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.sbatch
@@ -8,9 +8,8 @@
 
 module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 iteration_=${1?Error: no iteration given}
-config=${2?Error: no config file given}
-job_id=${3?Error: no job ID given}
+job_id=${2?Error: no job ID given}
 job_dir=$(head $job_id".txt" | tail -1)
 
-julia --project step_ekp.jl --iteration $iteration_ --config $config --job_dir $job_dir
+julia --project step_ekp.jl --iteration $iteration_ --job_dir $job_dir
 echo "Ensemble at iteration ${iteration_} stepped forward."

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -130,6 +130,20 @@ function get_height(sim_dir::String; get_faces::Bool = false)
     return z
 end
 
+"""
+    get_dz(sim_dir::String)
+
+Returns the vertical grid size of the given configuration.
+
+Inputs:
+ - sim_dir :: Name of simulation directory.
+Output:
+ - The vertical grid size.
+"""
+function get_dz(sim_dir::String)
+    z = get_height(sim_dir)
+    return z[2] - z[1]
+end
 
 """
     normalize_profile(profile_vec, n_vars, var_vec)
@@ -140,10 +154,9 @@ in var_vec.
 """
 function normalize_profile(profile_vec, n_vars, var_vec)
     y = deepcopy(profile_vec)
-    dim_variable = Integer(length(profile_vec) / n_vars)
+    var_dof = Integer(length(profile_vec) / n_vars)
     for i in 1:n_vars
-        y[(dim_variable * (i - 1) + 1):(dim_variable * i)] =
-            y[(dim_variable * (i - 1) + 1):(dim_variable * i)] ./ sqrt(var_vec[i])
+        y[(var_dof * (i - 1) + 1):(var_dof * i)] = y[(var_dof * (i - 1) + 1):(var_dof * i)] ./ sqrt(var_vec[i])
     end
     return y
 end

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -42,7 +42,7 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
     @test isempty(diags.vars)
 
     # Test reference diagnostics
-    io_reference(diags, ref_stats)
+    io_reference(diags, ref_stats, ref_models)
     NC.Dataset(diags.filepath, "r") do root_grp
         ref_grp = root_grp.group["reference"]
         @test ref_grp["Gamma"] ≈ ref_stats.Γ

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -15,7 +15,7 @@ include("config.jl")
 @testset "Pipeline" begin
     config = get_config()
     init_calibration(config; mode = "hpc")
-    res_dir_list = glob("results_*_SCM", config["output"]["outdir_root"])
+    res_dir_list = glob("results_*_SCM*", config["output"]["outdir_root"])
     res_dir = res_dir_list[1]
     # Check for output
     @test all(isdir.(config["reference"]["scm_parent_dir"]))


### PR DESCRIPTION
This PR:

- Adds more NetCDF diagnostics, ensuring type stability (before, variables were cast to floats).
- Modifies the "relative" Tikhonov regularization mode, now the `tikhonov_noise` has the interpretation of the maximum condition number of the covariance matrix in the inverse problem, which defaults to 10*sqrt(eps(FT)) to ensure stability when the "relative" mode is chosen.
- Writes the config file to the output file, so that the calibration process is fully determined from the contents of the output directory. It also adds a random number to the output directory to allow for multiple calibration processes to be run at the same time without enlarging further the name of the output file.