### PR TITLE
Make time shift consistent with requested times in LesDrivenSCM, add pca diag.

### DIFF
--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -54,7 +54,7 @@ function get_regularization_config()
     config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
     config["normalize"] = true  # whether to normalize data by pooled variance
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
-    config["tikhonov_noise"] = 10.0 # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
     config["dim_scaling"] = true # Tikhonov regularization
     return config
 end
@@ -116,8 +116,9 @@ function get_reference_config(::LesDrivenScm)
     config["scm_parent_dir"] = repeat(["scm_init"], 3)
     config["t_start"] = repeat([3.0 * 3600], 3)
     config["t_end"] = repeat([6.0 * 3600], 3)
-    # config["Σ_t_start"] = [...]
-    # config["Σ_t_end"] = [...]
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], 3)
+    config["Σ_t_end"] = repeat([6.0 * 3600], 3)
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -105,8 +105,9 @@ function get_reference_config(::LesDrivenScm)
     config["scm_parent_dir"] = ["scm_init"]
     config["t_start"] = [3.0 * 3600]
     config["t_end"] = [6.0 * 3600]
-    # config["Σ_t_start"] = [...]
-    # config["Σ_t_end"] = [...]
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = [-5.75 * 24 * 3600]
+    config["Σ_t_end"] = [6.0 * 3600]
     return config
 end
 

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -59,7 +59,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
 
     # Similarly, generate `Σ_t_start` and `Σ_t_end`
     Σ_t_start = expand_dict_entry(config["reference"], "Σ_t_start", n_cases)
-    Σ_t_end = expand_dict_entry(config["reference"], "Σ_t_start", n_cases)
+    Σ_t_end = expand_dict_entry(config["reference"], "Σ_t_end", n_cases)
 
     # Construct reference models
     kwargs_ref_model = Dict(

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -166,26 +166,26 @@ function construct_reference_models(kwarg_ld::Dict{Symbol, Vector{T} where T})::
 end
 
 """
-    time_shift_reference_model(m::ReferenceModel, Δt_y::FT, Δt_Σ::FT) where {FT <: Real}
+    time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
 
 Returns a time-shifted ReferenceModel, considering an interval relative to the last
 available time step of the original model.
 
 Inputs:
  - m     :: A ReferenceModel.
- - Δt_y  :: The time interval between t_start and t_end of the new model.
- - Δt_Σ  :: The time interval between Σ_t_start and Σ_t_end of the new model.
+ - Δt  :: [LES last time - SCM start time (LES timeframe)]
 Outputs:
  - The time-shifted ReferenceModel.
 """
-function time_shift_reference_model(m::ReferenceModel, Δt_y::FT, Δt_Σ::FT) where {FT <: Real}
+function time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
     t = nc_fetch(y_dir(m), "t")
-    t_end = t[end]
-    t_start = t_end - Δt_y
-    Σ_t_start = t_end - Δt_Σ
+    t_end = t[end] - Δt + get_t_end(m)
+    Σ_t_end = t[end] - Δt + get_t_end_Σ(m)
+    t_start = t[end] - Δt + get_t_start(m)
+    Σ_t_start = t[end] - Δt + get_t_start_Σ(m)
 
-    @assert t_start > 0 "t_start must be positive after time shift, but $t_start was given."
-    @assert Σ_t_start > 0 "Σ_t_start must be positive after time shift, but $Σ_t_start was given."
+    @assert t_start >= 0 "t_start must be positive after time shift, but $t_start was given."
+    @assert Σ_t_start >= 0 "Σ_t_start must be positive after time shift, but $Σ_t_start was given."
     @info string(
         "Shifting time windows for ReferenceModel $(m.case_name)",
         "to ty=($t_start, $t_end), tΣ=($Σ_t_start, $t_end).",
@@ -200,7 +200,7 @@ function time_shift_reference_model(m::ReferenceModel, Δt_y::FT, Δt_Σ::FT) wh
         t_end;
         Σ_dir = Σ_dir(m),
         Σ_t_start = Σ_t_start,
-        Σ_t_end = t_end,
+        Σ_t_end = Σ_t_end,
     )
 end
 

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -52,8 +52,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
             dim_scaling::Bool = false,
             y_type::ModelType = LES(),
             Σ_type::ModelType = LES(),
-            Δt_y::FT = 3 * 3600,
-            Δt_Σ::FT = 6 * 3600,
+            Δt::FT = 6 * 3600,
         )
 
     Constructs the ReferenceStatistics defining the inverse problem.
@@ -71,8 +70,8 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
      - dim_scaling      :: Whether to scale covariance blocks by their size.
      - y_type           :: Type of reference mean data. Either LES() or SCM().
      - Σ_type           :: Type of reference covariance data. Either LES() or SCM().
-     - Δt_y             :: Time window for LES mean evaluation in LES_driven_SCM configurations.
-     - Δt_Σ             :: Time window for LES covariance evaluation in LES_driven_SCM configurations.
+     - Δt               :: [LES last time - SCM start time (LES timeframe)] for
+       LES_driven_SCM cases.
     Outputs:
      - A ReferenceStatistics struct.
     """
@@ -86,8 +85,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         dim_scaling::Bool = false,
         y_type::ModelType = LES(),
         Σ_type::ModelType = LES(),
-        Δt_y::FT = 3 * 3600.0,
-        Δt_Σ::FT = 6 * 3600.0,
+        Δt::FT = 6 * 3600.0,
     ) where {FT <: Real}
         # Init arrays
         y = FT[]
@@ -98,7 +96,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         norm_vec = Vector[]
 
         for m in RM
-            model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, Δt_y, Δt_Σ) : m
+            model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, Δt) : m
             # Get (interpolated and pool-normalized) observations, get pool variance vector
             z_scm = get_height(scm_dir(model))
             y_, y_var_, pool_var = get_obs(model, y_type, Σ_type, normalize, z_scm = z_scm)

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -33,22 +33,22 @@ end
         :scm_dir => scm_dirs,
         :case_name => repeat(["Bomex"], 2),
         :t_start => [4.0 * 3600, 4.0 * 3600],
-        :t_end => [6.0 * 3600, 6.0 * 3600],
+        :t_end => [5.0 * 3600, 5.0 * 3600],
+        :Σ_t_start => [2.0 * 3600, 2.0 * 3600],
+        :Σ_t_end => [4.5 * 3600, 4.5 * 3600],
     )
     ref_models = construct_reference_models(kwargs_ref_model)
     run_SCM(ref_models, overwrite = false)
-    Δt_y = 3600.0
-    Δt_Σ = 5400.0
-    ref_model = time_shift_reference_model(ref_models[1], Δt_y, Δt_Σ)
+    Δt = 5.0 * 3600
+    ref_model = time_shift_reference_model(ref_models[1], Δt)
 
-    @test get_t_start(ref_model) == 21600.0 - Δt_y
-    @test get_t_start_Σ(ref_model) == 21600.0 - Δt_Σ
-    @test get_t_end(ref_model) == get_t_end_Σ(ref_model)
-    @test get_t_end(ref_model) == 21600.0
+    @test get_t_start(ref_model) == 21600.0 - Δt + 4.0 * 3600
+    @test get_t_start_Σ(ref_model) == 21600.0 - Δt + 2.0 * 3600
+    @test get_t_end_Σ(ref_model) == 21600.0 - Δt + 4.5 * 3600
+    @test get_t_end(ref_model) == 21600.0 - Δt + 5.0 * 3600
 
-    Δt_y = 2 * 21600.0
-    Δt_Σ = 2 * 21600.0
-    @test_throws AssertionError time_shift_reference_model(ref_models[2], Δt_y, Δt_Σ)
+    Δt = 2 * 21600.0
+    @test_throws AssertionError time_shift_reference_model(ref_models[2], Δt)
 
 
 end


### PR DESCRIPTION
This PR modifies the time shift function so that the time intervals are not fixed for `y` and `Σ`, but actually given by the requested time interval in the config file (which is written with respect to the `t=0` of the SCM).

In addition,

- I have modified the `Σ` time interval for the `LesDrivenScm` config file to encompass the whole LES time series. Note that the rank of the covariance matrix is at most the number of samples in time, and since the LES output for the LesDrivenScm case is so coarse, otherwise you end up with just a few points! Taking the whole time series ensures that you get 828 sample points.
- I have added a diagnostic for the PCA projection matrix.
- I have fixed a bug in the Pipeline, although I think it was only wrong in a corner case.