### PR TITLE
Handle parameter names corresponding to vectors

### DIFF
--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -96,7 +96,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     )
 
     # Dimensionality
-    n_param = length(collect(keys(params)))
+    n_param = sum(map(length, collect(values(params))))
     d = length(ref_stats.y)
     if algo_name == "Unscented"
         N_ens = 2 * n_param + 1


### PR DESCRIPTION
In preparation for function learning we'll need to seamlessly deal with parameter names that correspond to vectors. This is handled here by treating each vector component as a unique parameter in EKP.