### PR TITLE
Update Readme, add codecov tracking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A package to calibrate turbulence and convection parameterizations.
 | **Docs Build**       | [![docs build][docs-bld-img]][docs-bld-url]   |
 | **Documentation**    | [![dev][docs-dev-img]][docs-dev-url]          |
 | **GHA CI**           | [![gha ci][gha-ci-img]][gha-ci-url]           |
+| **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 | **Bors enabled**     | [![bors][bors-img]][bors-url]                 |
 
 [docs-bld-img]: https://github.com/CliMA/CalibrateEDMF.jl/actions/workflows/docs.yml/badge.svg
@@ -18,28 +19,35 @@ A package to calibrate turbulence and convection parameterizations.
 [gha-ci-img]: https://github.com/CliMA/CalibrateEDMF.jl/actions/workflows/ci.yml/badge.svg
 [gha-ci-url]: https://github.com/CliMA/CalibrateEDMF.jl/actions/workflows/ci.yml
 
+[codecov-img]: https://codecov.io/gh/CliMA/CalibrateEDMF.jl/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/CalibrateEDMF.jl
+
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/37644
 
 # Installation
 
-To use the package, clone this repo and the `TurbulenceConvection.jl` repo from GitHub.
+To use the package, clone this repo
 
   >> git clone https://github.com/CliMA/CalibrateEDMF.jl.git
 
-  >> git clone https://github.com/CliMA/TurbulenceConvection.jl 
-
-Before calibration, we need to compile the project. For the time being `TurbulenceConvection.jl` is not a published package, so this dependency is added manually by
+Before calibration, we need to compile the project.
 
 >> julia --project
 
 >> julia> ]
 
->> pkg> dev path/to/TurbulenceConvection.jl
-
 >> pkg> instantiate
 
-Since both `TurbulenceConvection.jl` and `EnsembleKalmanProcesses.jl` are under rapid development, the latest version of `TurbulenceConvection.jl` may not be compatible with the published version of `EnsembleKalmanProcesses.jl`. If this is the case, clone the latest `EnsembleKalmanProcesses.jl` version from GitHub and try the following,
+# Installation in dev mode
+
+Since both `TurbulenceConvection.jl` and `EnsembleKalmanProcesses.jl` are under rapid development, we may want to access a recent unpublished version of these packages when working with `CalibrateEDMF.jl`, or even use a version with local changes. If this is the case, clone the latest `EnsembleKalmanProcesses.jl` (resp. `EnsembleKalmanProcesses.jl`) version from GitHub (whichever you want to dev with),
+
+  >> git clone https://github.com/CliMA/EnsembleKalmanProcesses.jl.git
+
+  >> git clone https://github.com/CliMA/TurbulenceConvection.jl 
+
+and try the following,
 
 >> julia --project
 
@@ -49,7 +57,9 @@ Since both `TurbulenceConvection.jl` and `EnsembleKalmanProcesses.jl` are under 
 
 >> pkg> instantiate
 
-CalibrateEDMF.jl also depends on PyPlot. If you are using PyPlot for the first time, just do
+This will link CalibrateEDMF to your local version of `EnsembleKalmanProcesses.jl` (resp. `EnsembleKalmanProcesses.jl`), allowing rapid prototyping across packages.
+
+If you want to use PyPlot with CalibrateEDMF.jl, and you are using PyPlot for the first time, just do
 
 >> julia --project
 


### PR DESCRIPTION
- Update readme to reflect that we now use published versions of TC.jl and EKP.jl, while retaining dev mode instructions.
- Add codecov tracking.