### PR TITLE
Add minibatching option, ReferenceModelBatch struct.

### DIFF
--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -68,6 +68,7 @@ function get_process_config()
     config["algorithm"] = "Unscented" # "Sampler", "Unscented", "Inversion"
     config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
     config["Δt"] = 1.0 # Artificial time stepper of the EKI.
+    config["batch_size"] = nothing
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -68,6 +68,7 @@ function get_process_config()
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     config["noisy_obs"] = false
     config["Δt"] = 1.0 # Artificial time stepper of the EKI.
+    config["batch_size"] = nothing
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -12,6 +12,7 @@ using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.Pipeline
 using CalibrateEDMF.NetCDFIO
 const src_dir = dirname(pathof(CalibrateEDMF))
 include(joinpath(src_dir, "helper_funcs.jl"))
@@ -21,113 +22,6 @@ using EnsembleKalmanProcesses.Observations
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using JLD2
 using Base
-
-
-"""
-    ek_update(
-        ekobj::EnsembleKalmanProcess,
-        priors::ParameterDistribution,
-        iteration::Int64,
-        config::Dict{Any, Any},
-        versions::Vector{String},
-        outdir_path::String,
-    )
-
-Updates an EnsembleKalmanProcess using forward model evaluations stored
-in output files defined by their `versions`, and generates the parameters
-for the next ensemble for forward model evaluations. The updated EnsembleKalmanProcess
-and new ModelEvaluator are both written to file.
-
-Inputs:
-
- - ekobj         :: EnsembleKalmanProcess to be updated.
- - priors        :: Priors over parameters, used for unconstrained-constrained mappings.
- - iteration     :: Current iteration of the calibration process.
- - config        :: Process configuration dictionary.
- - versions      :: String versions identifying the forward model evaluations.
- - outdir_path   :: Output path directory.
-"""
-function ek_update(
-    ekobj::EnsembleKalmanProcess,
-    priors::ParameterDistribution,
-    iteration::Int64,
-    config::Dict{Any, Any},
-    versions::Vector{String},
-    outdir_path::String,
-)
-    Δt = config["Δt"]
-    deterministic_forward_map = config["noisy_obs"]
-    # Get dimensionality
-    mod_evaluator = load(scm_output_path(outdir_path, versions[1]))["model_evaluator"]
-    ref_stats = mod_evaluator.ref_stats
-    ref_models = mod_evaluator.ref_models
-    _, N_ens = size(get_u_final(ekobj))
-    @assert N_ens == length(versions)
-    C = length(ref_stats.pca_vec)
-    Δt_scaled = Δt / C # Scale artificial timestep by batch size
-
-    g = zeros(pca_length(ref_stats), N_ens)
-    g_full = zeros(full_length(ref_stats), N_ens)
-    for (ens_index, version) in enumerate(versions)
-        scm_outputs = load(scm_output_path(outdir_path, version))
-        g[:, ens_index] = scm_outputs["g_scm_pca"]
-        g_full[:, ens_index] = scm_outputs["g_scm"]
-        # Clean up
-        rm(scm_output_path(outdir_path, version))
-        rm(scm_init_path(outdir_path, version))
-    end
-
-    # Advance EKP
-    if isa(ekobj.process, Inversion)
-        update_ensemble!(ekobj, g, Δt_new = Δt_scaled, deterministic_forward_map = deterministic_forward_map)
-    else
-        update_ensemble!(ekobj, g)
-    end
-    ekp = ekobj
-    jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
-
-    # Get new step
-    params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
-    params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
-    versions = map(mod_eval -> generate_scm_input(mod_eval, outdir_path), mod_evaluators)
-    # Store version identifiers for this ensemble in a common file
-    write_versions(versions, iteration + 1, outdir_path = outdir_path)
-
-    # Diagnostics IO
-    update_diagnostics(outdir_path, ekp, priors, ref_stats, g_full)
-    return
-end
-
-"""
-    update_diagnostics(outdir_path::String, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
-
-Appends current iteration diagnostics to a diagnostics netcdf file.
-
-    Inputs:
-    - outdir_path :: Path of results directory.
-    - ekp :: Current EnsembleKalmanProcess.
-    - priors:: Prior distributions of the parameters.
-    - ref_stats :: ReferenceStatistics.
-    - g_full :: The forward model evaluation in primitive space.
-"""
-function update_diagnostics(
-    outdir_path::String,
-    ekp::EnsembleKalmanProcess,
-    priors::ParameterDistribution,
-    ref_stats::ReferenceStatistics,
-    g_full::Array{FT, 2},
-) where {FT <: Real}
-
-    # Compute diagnostics
-    error_full = compute_mse(g_full, ref_stats.y_full)
-    diags = NetCDFIO_Diags(joinpath(outdir_path, "Diagnostics.nc"))
-    open_files(diags)
-    io_metrics(diags, ekp, error_full)
-    io_particle_diags(diags, ekp, priors, g_full, error_full)
-    close_files(diags)
-end
-
 
 # Read iteration number of ensemble to be recovered
 s = ArgParseSettings()
@@ -150,5 +44,5 @@ include(joinpath(outdir_path, "config.jl"))
 versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
 ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
-process_config = get_config()["process"]
-ek_update(ekobj, priors, iteration, process_config, versions, outdir_path)
+config = get_config()
+ek_update(ekobj, priors, iteration, config, versions, outdir_path)

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -63,6 +63,7 @@ function get_process_config()
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     config["noisy_obs"] = false
     config["Δt"] = 1.0 # Artificial time stepper of the EKI.
+    config["batch_size"] = nothing
     return config
 end
 


### PR DESCRIPTION
This PR adds the option to minibatch ReferenceModels during the calibration process. Batching is controlled through the ReferenceModelBatch struct, which stores the global vector of ReferenceModels to evaluate, and a vector of pointers to ReferenceModels that dictates the evaluation order for every epoch.

The current implementation is operational for the hpc pipeline for now, and for Ensemble Kalman Inversion. In addition, the netcdf diagnostics file for minibatched simulations does not include model evaluation output, only the errors.