### PR TITLE
Add config defaults to pipeline

### DIFF
--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -32,6 +32,8 @@ function get_config()
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
     config["reference"] = get_reference_config(Bomex())
+    # Define reference used for validation
+    config["validation"] = get_reference_config(LesDrivenScm())
     # Define the parameter priors
     config["prior"] = get_prior_config()
     # Define the kalman process
@@ -68,7 +70,6 @@ function get_process_config()
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     config["noisy_obs"] = false
     config["Δt"] = 1.0 # Artificial time stepper of the EKI.
-    config["batch_size"] = nothing
     return config
 end
 
@@ -90,6 +91,7 @@ function get_reference_config(::Bomex)
     # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
     # config["Σ_t_start"] = [...]
     # config["Σ_t_end"] = [...]
+    config["batch_size"] = nothing
     return config
 end
 
@@ -111,6 +113,7 @@ function get_reference_config(::LesDrivenScm)
     # Use full LES timeseries for covariance
     config["Σ_t_start"] = [-5.75 * 24 * 3600]
     config["Σ_t_end"] = [6.0 * 3600]
+    config["batch_size"] = nothing
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
@@ -31,7 +31,8 @@ parsed_args = parse_args(ARGS, s)
 version = parsed_args["version"]
 outdir_path = parsed_args["job_dir"]
 include(joinpath(outdir_path, "config.jl"))
-namelist_args = get_config()["scm"]["namelist_args"]
+config = get_config()
+namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 
 scm_args = load(scm_init_path(outdir_path, version))
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
@@ -32,7 +32,8 @@ outdir_path = parsed_args["job_dir"]
 include(joinpath(outdir_path, "config.jl"))
 
 scm_args = load(scm_init_path(outdir_path, version))
-namelist_args = get_config()["scm"]["namelist_args"]
+config = get_config()
+namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 model_evaluator = scm_args["model_evaluator"]
 sim_dirs, g_scm, g_scm_pca = run_SCM(model_evaluator, namelist_args = namelist_args)
 

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -55,8 +55,8 @@ mutable struct NetCDFIO_Diags
             d_full = full_length(ref_stats)
             d = pca_length(ref_stats)
             C = length(ref_stats.pca_vec)
-            batch_size =
-                isnothing(config["process"]["batch_size"]) ? length(ref_stats.pca_vec) : config["process"]["batch_size"]
+            batch_size = get_entry(config["process"], "batch_size", length(ref_stats.pca_vec))
+            batch_size = isnothing(batch_size) ? length(ref_stats.pca_vec) : batch_size
 
             particle = Array(1:N_ens)
             out = Array(1:d)

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -385,3 +385,13 @@ function expand_dict_entry(dict, key, N)
     @assert length(r) == N
     r
 end
+
+"Dictionary entry getter that throws a warning if the default is used."
+function get_entry(dict, key, default)
+    try
+        return dict[key]
+    catch e
+        @warn "Key $key not found in dictionary. Returning default value."
+        get(dict, key, default)
+    end
+end

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -16,18 +16,21 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
 @testset "NetCDFIO_Diags" begin
     # Choose same SCM to speed computation
     data_dir = mktempdir()
+    t_max = 2 * 3600.0
+    namelist_args =
+        [("time_stepping", "t_max", t_max), ("time_stepping", "dt", 10.0), ("grid", "dz", 100.0), ("grid", "nz", 30)]
     scm_dirs = repeat([joinpath(data_dir, "Output.Bomex.000000")], 2)
     kwargs_ref_model = Dict(
         :y_names => [["u_mean"], ["v_mean"]],
         :y_dir => scm_dirs,
         :scm_dir => scm_dirs,
         :case_name => repeat(["Bomex"], 2),
-        :t_start => repeat([4.0 * 3600], 2),
-        :t_end => repeat([6.0 * 3600], 2),
+        :t_start => repeat([t_max - 2.0 * 3600], 2),
+        :t_end => repeat([t_max], 2),
     )
     # Generate ref_stats
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
     ref_stats = ReferenceStatistics(ref_models, true, true; y_type = SCM(), Σ_type = SCM())
     # Generate config
     config = Dict()

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -24,7 +24,9 @@ include("config.jl")
         ref_config["t_start"][1],
         ref_config["t_end"][1],
     )
-    run_reference_SCM(ref_model, run_single_timestep = false)
+    namelist_args = config["scm"]["namelist_args"]
+    # Generate "true" data
+    run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = namelist_args)
     # Initialize calibration setup
     init_calibration(config; mode = "hpc")
     res_dir_list = glob("results_*_SCM*", config["output"]["outdir_root"])
@@ -43,7 +45,6 @@ include("config.jl")
     end
 
     # Re-use previous simulation
-    config["output"]["overwrite_scm_file"] = false
     res_dict = init_calibration(config; mode = "pmap")
 
     ekobj = res_dict["ekobj"]

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -9,16 +9,20 @@ using CalibrateEDMF.TurbulenceConvectionUtils
     # Choose same SCM to speed computation
     data_dir = mktempdir()
     scm_dirs = repeat([joinpath(data_dir, "Output.Bomex.000000")], 2)
+    # Reduce resolution and t_max to speed computation as well
+    t_max = 4 * 3600.0
+    namelist_args =
+        [("time_stepping", "t_max", t_max), ("time_stepping", "dt", 10.0), ("grid", "dz", 100.0), ("grid", "nz", 30)]
     kwargs_ref_model = Dict(
         :y_names => [["u_mean"], ["v_mean"]],
         :y_dir => scm_dirs,
         :scm_dir => scm_dirs,
         :case_name => repeat(["Bomex"], 2),
-        :t_start => repeat([4.0 * 3600], 2),
-        :t_end => repeat([6.0 * 3600], 2),
+        :t_start => repeat([t_max - 2.0 * 3600], 2),
+        :t_end => repeat([t_max], 2),
     )
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
 
     # Test only tikhonov vs PCA and tikhonov
     pca_list = [false, true]


### PR DESCRIPTION
This PR:

- Adds defaults to many config values, such that if the key is not found in the config dict, the default is used. This is performed with the function `get_entry`, which wraps around Julia's native `get` to add a warning message if the default is accessed.
- Reduces the time and space resolution of simulations in the tests so that they run faster.
- Increases code coverage to include the `ReferenceModelBatch` construct.