### PR TITLE
Add validation capabilities to pipeline.

### DIFF
--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -32,8 +32,6 @@ function get_config()
     config["regularization"] = get_regularization_config()
     # Define reference used in the inverse problem 
     config["reference"] = get_reference_config(Bomex())
-    # Define reference used for validation
-    config["validation"] = get_reference_config(LesDrivenScm())
     # Define the parameter priors
     config["prior"] = get_prior_config()
     # Define the kalman process

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
@@ -12,9 +12,10 @@ s = ArgParseSettings()
     "--job_id"
     help = "Job identifier"
     arg_type = String
-    default = "default_id"
+    default = "12345"
 end
 parsed_args = parse_args(ARGS, s)
 include(parsed_args["config"])
+config = get_config()
 
-init_calibration(get_config(); job_id = parsed_args["job_id"], config_path = parsed_args["config"])
+init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])

--- a/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
@@ -11,7 +11,6 @@ const src_dir = dirname(pathof(CalibrateEDMF))
 include(joinpath(src_dir, "helper_funcs.jl"))
 # Import EKP modules
 using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
-using EnsembleKalmanProcesses.Observations
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using JLD2
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#SBATCH --time=1:00:00   # walltime
-#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --time=4:00:00   # walltime
+#SBATCH --ntasks=2       # number of processor cores (i.e. tasks)
 #SBATCH --nodes=1         # number of nodes
 #SBATCH --mem-per-cpu=6G   # memory per CPU core
 #SBATCH -J "scm_run"   # job name
@@ -14,6 +14,10 @@ run_num=${SLURM_ARRAY_TASK_ID}
 job_dir=$(head $job_id".txt" | tail -1)
 version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
 
-julia --project  single_scm_eval.jl --version $version --job_dir $job_dir
+julia --project single_scm_eval.jl --version $version --job_dir $job_dir --mode "train" &
+P1=$!
+julia --project single_scm_eval.jl --version $version --job_dir $job_dir --mode "validation" &
+P2=$!
+wait $P1 $P2
 echo "SCM simulation for ${version} in iteration ${iteration_} finished"
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -2,7 +2,6 @@
 
 # Import modules to all processes
 using ArgParse
-using Distributions
 using CalibrateEDMF
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.Pipeline

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
@@ -1,156 +1,51 @@
 # This is an example on training the TurbulenceConvection.jl implementation
-# of the EDMF scheme with data generated using PyCLES or TurbulenceConvection.jl
-# (perfect model setting).
+# of the EDMF scheme with data generated using PyCLES (an LES solver) or
+# TurbulenceConvection.jl (perfect model setting).
 #
-# This example is fully parallelized and can be run in the Caltech Central
-# cluster with the included script. Parallelization of the calibration
-# process is carried out by Julia's pmap() function.
+# This example parallelizes forward model evaluations using Julia's pmap() function.
+# This parallelization strategy is efficient for small ensembles (N_ens < 20). For
+# calibration processes involving a larger number of ensemble members, parallelization
+# using HPC resources directly is advantageous.
 
 # Import modules to all processes
 @everywhere using Pkg
 @everywhere Pkg.activate("../../..")
+@everywhere using ArgParse
 @everywhere using CalibrateEDMF
-@everywhere using CalibrateEDMF.ReferenceModels
-@everywhere using CalibrateEDMF.ReferenceStats
-@everywhere using CalibrateEDMF.LESUtils
-@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
+@everywhere using CalibrateEDMF.DistributionUtils
 @everywhere using CalibrateEDMF.Pipeline
 @everywhere const src_dir = dirname(pathof(CalibrateEDMF))
 @everywhere include(joinpath(src_dir, "helper_funcs.jl"))
 # Import EKP modules
 @everywhere using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
-@everywhere using EnsembleKalmanProcesses.Observations
 @everywhere using EnsembleKalmanProcesses.ParameterDistributionStorage
 # include(joinpath(@__DIR__, "../../../src/viz/ekp_plots.jl"))
 using JLD2
 
-# Include calibration config file to define problem
-include(joinpath(dirname(pwd()), "config.jl"))
-
-function run_calibrate(config; return_ekobj = false)
-
-    N_iter = config["process"]["N_iter"]
-    Δt = config["process"]["Δt"]
-    # Adds noise to deterministic maps in EKI
-    deterministic_forward_map = config["process"]["noisy_obs"]
-
-    perform_PCA = config["regularization"]["perform_PCA"]
-
-    save_eki_data = config["output"]["save_eki_data"]
-    save_ensemble_data = config["output"]["save_ensemble_data"]
-
-    init_dict = init_calibration(config, mode = "pmap")
-    ekobj = init_dict["ekobj"]
-    algo = ekobj.process
-    priors = init_dict["priors"]
-    ref_models = init_dict["ref_models"]
-    ref_stats = init_dict["ref_stats"]
-    d = length(ref_stats.y)
-    N_par, N_ens = size(ekobj.u[1])
-    outdir_path = init_dict["outdir_path"]
-    C = sum(ref_model -> length(get_t_start(ref_model)), ref_models)
-
-    # Precondition prior
-    @everywhere precondition_param(x::Vector{FT}) where {FT <: Real} = precondition(x, $priors, $ref_models, $ref_stats)
-    if isa(algo, Inversion) || isa(algo, Sampler)
-        precond_params = pmap(precondition_param, [c[:] for c in eachcol(get_u_final(ekobj))])
-        ekobj = generate_ekp(hcat(precond_params...), ref_stats, algo, outdir_path = outdir_path)
-    end
-
-    # EKP iterations
-    g_ens = zeros(d, N_ens)
-    norm_err_list = []
-    g_big_list = []
-    Δt_scaled = Δt / C # Scale artificial timestep by batch size
-    for i in 1:N_iter
-        # Parameters are transformed to constrained space when used as input to TurbulenceConvection.jl
-        params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
-        params = [c[:] for c in eachcol(params_cons_i)]
-        mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
-        g_output_list = pmap(run_SCM, mod_evaluators; retry_delays = zeros(5)) # Outer dim is params iterator
-        (sim_dirs_arr, g_ens_arr, g_ens_arr_pca) = ntuple(l -> getindex.(g_output_list, l), 3) # Outer dim is G̃, G 
-        @info "\n\nEKP evaluation $i finished. Updating ensemble ...\n"
-        for j in 1:N_ens
-            g_ens[:, j] = perform_PCA ? g_ens_arr_pca[j] : g_ens_arr[j]
-        end
-
-        if isa(algo, Inversion)
-            update_ensemble!(ekobj, g_ens, Δt_new = Δt_scaled, deterministic_forward_map = deterministic_forward_map)
-        else
-            update_ensemble!(ekobj, g_ens)
-        end
-        @info "\nEnsemble updated. Saving results to file...\n"
-
-        # Get normalized error for full dimensionality output
-        push!(norm_err_list, compute_mse(g_ens_arr, ref_stats.y_full))
-        norm_err_arr = hcat(norm_err_list...)' # N_iter, N_ens
-        # Store full dimensionality output
-        push!(g_big_list, g_ens_arr)
-
-        # Convert to arrays
-        phi_params = Array{Array{Float64, 2}, 1}(transform_unconstrained_to_constrained(priors, get_u(ekobj)))
-        phi_params_arr = zeros(i + 1, N_par, N_ens)
-        g_big_arr = zeros(i, N_ens, full_length(ref_stats))
-        for (k, elem) in enumerate(phi_params)
-            phi_params_arr[k, :, :] = elem
-            if k < i + 1
-                g_big_arr[k, :, :] = hcat(g_big_list[k]...)'
-            end
-        end
-        if save_eki_data
-            # Save calibration process information to JLD2 file
-            save(
-                joinpath(outdir_path, "calibration_results_iter_$i.jld2"),
-                "ekp_u",
-                transform_unconstrained_to_constrained(priors, get_u(ekobj)),
-                "ekp_g",
-                get_g(ekobj),
-                "truth_mean",
-                ekobj.obs_mean,
-                "truth_cov",
-                ekobj.obs_noise_cov,
-                "ekp_err",
-                ekobj.err,
-                "truth_mean_big",
-                ref_stats.y_full,
-                "truth_cov_big",
-                ref_stats.Γ_full,
-                "P_pca",
-                ref_stats.pca_vec,
-                "pool_var",
-                ref_stats.norm_vec,
-                "g_big",
-                g_big_list,
-                "g_big_arr",
-                g_big_arr,
-                "norm_err",
-                norm_err_list,
-                "norm_err_arr",
-                norm_err_arr,
-                "phi_params",
-                phi_params_arr,
-            )
-        end
-
-        # make ekp plots
-        # make_ekp_plots(outdir_path, priors.names)
-
-        if save_ensemble_data
-            eki_iter_path = joinpath(outdir_path, "EKI_iter_$i")
-            mkpath(eki_iter_path)
-            save_full_ensemble_data(eki_iter_path, sim_dirs_arr, ref_models)
-        end
-    end
-    # EKP results: Has the ensemble collapsed toward the truth?
-    @info string(
-        "EKP ensemble mean at last stage (original space): ",
-        "$(mean(transform_unconstrained_to_constrained(priors, get_u_final(ekobj)), dims = 2))",
-    )
-
-    if return_ekobj
-        return ekobj, outdir_path
-    end
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--config"
+    help = "Inverse problem config file path"
+    arg_type = String
 end
+parsed_args = parse_args(ARGS, s)
+include(parsed_args["config"])
+config = get_config()
 
-### RUN SIMULATION ###
-run_calibrate(get_config())
+# Initialize calibration process
+outdir_path = init_calibration(config; config_path = parsed_args["config"], mode = "pmap")
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+
+# Dispatch SCM eval functions to workers
+@everywhere scm_eval_train(version) = versioned_model_eval(version, $outdir_path, "train", $config)
+@everywhere scm_eval_validation(version) = versioned_model_eval(version, $outdir_path, "validation", $config)
+
+# Calibration process
+N_iter = config["process"]["N_iter"]
+for iteration in 1:N_iter
+    versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+    ekp = load(ekobj_path(outdir_path, iteration))["ekp"]
+    pmap(scm_eval_train, versions)
+    pmap(scm_eval_validation, versions)
+    ek_update(ekp, priors, iteration, config, versions, outdir_path)
+end

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate_script
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate_script
@@ -11,4 +11,4 @@ module purge
 module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.API.precompile()'
 
-julia --project -p 20 calibrate.jl
+julia --project -p 20 calibrate.jl --config ../config.jl

--- a/src/LESUtils.jl
+++ b/src/LESUtils.jl
@@ -95,7 +95,7 @@ function get_cfsite_les_dir(
     cfsite_number = string(cfsite_number)
     month = string(month, pad = 2)
     root_dir = "/central/groups/esm/zhaoyi/GCMForcedLES/cfsite/$month/$forcing_model/$experiment/"
-    rel_dir = join(["Output.cfsite$cfsite_number", forcing_model, experiment, "2004-2008.07.4x"], "_")
+    rel_dir = join(["Output.cfsite$cfsite_number", forcing_model, experiment, "2004-2008.$month.4x"], "_")
     return joinpath(root_dir, rel_dir)
 end
 

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -13,7 +13,8 @@ const NC = NCDatasets
 export NetCDFIO_Diags
 export open_files, close_files, write_iteration
 export init_iteration_io, init_particle_diags, init_metrics, init_ensemble_diags
-export io_reference, io_diagnostics
+export init_val_diagnostics
+export io_reference, io_diagnostics, io_val_diagnostics
 
 
 mutable struct NetCDFIO_Diags
@@ -30,6 +31,7 @@ mutable struct NetCDFIO_Diags
         ref_stats::ReferenceStatistics,
         ekp::EnsembleKalmanProcess,
         priors::ParameterDistribution,
+        val_ref_stats::Union{ReferenceStatistics, Nothing} = nothing,
     )
 
         # Initialize properties with valid type:
@@ -55,7 +57,7 @@ mutable struct NetCDFIO_Diags
             d_full = full_length(ref_stats)
             d = pca_length(ref_stats)
             C = length(ref_stats.pca_vec)
-            batch_size = get_entry(config["process"], "batch_size", length(ref_stats.pca_vec))
+            batch_size = get_entry(config["reference"], "batch_size", length(ref_stats.pca_vec))
             batch_size = isnothing(batch_size) ? length(ref_stats.pca_vec) : batch_size
 
             particle = Array(1:N_ens)
@@ -97,6 +99,17 @@ mutable struct NetCDFIO_Diags
             NC.defVar(particle_grp, "param", param, ("param",))
             NC.defDim(particle_grp, "iteration", Inf)
             NC.defVar(particle_grp, "iteration", Int16, ("iteration",))
+
+            if !isnothing(val_ref_stats)
+                d_full_val = full_length(val_ref_stats)
+                d_val = pca_length(val_ref_stats)
+                out_val = Array(1:d_val)
+                out_full_val = Array(1:d_full_val)
+                NC.defDim(particle_grp, "out_full_val", d_full_val)
+                NC.defVar(particle_grp, "out_full_val", out_full_val, ("out_full_val",))
+                NC.defDim(particle_grp, "out_val", d_val)
+                NC.defVar(particle_grp, "out_val", out_val, ("out_val",))
+            end
 
             # Calibration metrics
             metric_grp = NC.defGroup(root_grp, "metrics")
@@ -203,6 +216,24 @@ function io_dictionary_metrics(ekp::EnsembleKalmanProcess, mse_full::Vector{FT})
     return io_dict
 end
 
+function io_dictionary_val_metrics()
+    io_dict = Dict(
+        "val_mse_full_mean" => (; dims = ("iteration",), group = "metrics", type = Float64),
+        "val_mse_full_min" => (; dims = ("iteration",), group = "metrics", type = Float64),
+        "val_mse_full_max" => (; dims = ("iteration",), group = "metrics", type = Float64),
+    )
+    return io_dict
+end
+function io_dictionary_val_metrics(mse_full::Vector{FT}) where {FT <: Real}
+    orig_dict = io_dictionary_val_metrics()
+    io_dict = Dict(
+        "val_mse_full_mean" => Base.setindex(orig_dict["val_mse_full_mean"], mean(mse_full), :field),
+        "val_mse_full_min" => Base.setindex(orig_dict["val_mse_full_min"], minimum(mse_full), :field),
+        "val_mse_full_max" => Base.setindex(orig_dict["val_mse_full_max"], maximum(mse_full), :field),
+    )
+    return io_dict
+end
+
 function io_dictionary_particle_state()
     io_dict = Dict(
         "u" => (; dims = ("particle", "param", "iteration"), group = "particle_diags", type = Float64),
@@ -257,6 +288,29 @@ function io_dictionary_particle_eval(ekp::EnsembleKalmanProcess, mse_full::Vecto
     return io_dict
 end
 
+function io_dictionary_val_particle_eval()
+    io_dict = Dict(
+        "val_g" => (; dims = ("particle", "out_val", "iteration"), group = "particle_diags", type = Float64),
+        "val_g_full" => (; dims = ("particle", "out_full_val", "iteration"), group = "particle_diags", type = Float64),
+        "val_mse_full" => (; dims = ("particle", "iteration"), group = "particle_diags", type = Float64),
+    )
+    return io_dict
+end
+function io_dictionary_val_particle_eval(g::Array{FT, 2}, g_full::Array{FT, 2}, mse_full::Vector{FT}) where {FT <: Real}
+    orig_dict = io_dictionary_val_particle_eval()
+    io_dict = Dict(
+        "val_g" => Base.setindex(orig_dict["val_g"], g', :field),
+        "val_g_full" => Base.setindex(orig_dict["val_g_full"], g_full', :field),
+        "val_mse_full" => Base.setindex(orig_dict["val_mse_full"], mse_full, :field),
+    )
+    return io_dict
+end
+function io_dictionary_val_particle_eval(mse_full::Vector{FT}) where {FT <: Real}
+    orig_dict = io_dictionary_val_particle_eval()
+    io_dict = Dict("val_mse_full" => Base.setindex(orig_dict["val_mse_full"], mse_full, :field))
+    return io_dict
+end
+
 """
     io_dictionary_ensemble()
 
@@ -282,57 +336,57 @@ function io_dictionary_ensemble(ekp::EnsembleKalmanProcess, priors::ParameterDis
     return io_dict
 end
 
-function open_files(self)
-    self.root_grp = NC.Dataset(self.filepath, "a")
-    self.ensemble_grp = self.root_grp.group["ensemble_diags"]
-    self.particle_grp = self.root_grp.group["particle_diags"]
-    self.metric_grp = self.root_grp.group["metrics"]
-    vars = self.vars
+function open_files(diags)
+    diags.root_grp = NC.Dataset(diags.filepath, "a")
+    diags.ensemble_grp = diags.root_grp.group["ensemble_diags"]
+    diags.particle_grp = diags.root_grp.group["particle_diags"]
+    diags.metric_grp = diags.root_grp.group["metrics"]
+    vars = diags.vars
 
     # Hack to avoid https://github.com/Alexander-Barth/NCDatasets.jl/issues/135
     vars["ensemble_diags"] = Dict{String, Any}()
-    for k in keys(self.ensemble_grp)
-        vars["ensemble_diags"][k] = self.ensemble_grp[k]
+    for k in keys(diags.ensemble_grp)
+        vars["ensemble_diags"][k] = diags.ensemble_grp[k]
     end
     vars["particle_diags"] = Dict{String, Any}()
-    for k in keys(self.particle_grp)
-        vars["particle_diags"][k] = self.particle_grp[k]
+    for k in keys(diags.particle_grp)
+        vars["particle_diags"][k] = diags.particle_grp[k]
     end
     vars["metrics"] = Dict{String, Any}()
-    for k in keys(self.metric_grp)
-        vars["metrics"][k] = self.metric_grp[k]
+    for k in keys(diags.metric_grp)
+        vars["metrics"][k] = diags.metric_grp[k]
     end
 end
 
-function close_files(self::NetCDFIO_Diags)
-    close(self.root_grp)
+function close_files(diags::NetCDFIO_Diags)
+    close(diags.root_grp)
 end
 
-
-function add_field(self::NetCDFIO_Diags, var_name::String; dims, group, type)
-    NC.Dataset(self.filepath, "a") do root_grp
+"""Adds a given field to an existing NetCDF Dataset."""
+function add_field(diags::NetCDFIO_Diags, var_name::String; dims, group, type)
+    NC.Dataset(diags.filepath, "a") do root_grp
         grp = root_grp.group[group]
         new_var = NC.defVar(grp, var_name, type, dims)
     end
 end
 
-function write_current(self::NetCDFIO_Diags, var_name::String, data; group)
-    var = self.vars[group][var_name]
+"""Writes current field `data` to an existing variable in a NetCDF Dataset."""
+function write_current(diags::NetCDFIO_Diags, var_name::String, data; group)
+    var = diags.vars[group][var_name]
     last_dim = length(size(var))
     last_dim_end = size(var, last_dim)
     selectdim(var, last_dim, last_dim_end) .= data
 end
 
-function write_current_dict(self::NetCDFIO_Diags, io_dict)
-    open_files(self)
+"""Writes all current fields in a given io_dict to an existing NetCDF Dataset."""
+function write_current_dict(diags::NetCDFIO_Diags, io_dict)
     for var in keys(io_dict)
-        write_current(self, var, io_dict[var].field; group = io_dict[var].group)
+        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
     end
-    close_files(self)
 end
 
-function write_ref(self::NetCDFIO_Diags, var_name::String, data)
-    NC.Dataset(self.filepath, "a") do root_grp
+function write_ref(diags::NetCDFIO_Diags, var_name::String, data)
+    NC.Dataset(diags.filepath, "a") do root_grp
         reference_grp = root_grp.group["reference"]
         var = reference_grp[var_name]
         var .= data
@@ -347,11 +401,19 @@ function io_reference(diags::NetCDFIO_Diags, ref_stats::ReferenceStatistics, ref
     end
 end
 
+function init_io_dict(diags::NetCDFIO_Diags, io_dict)
+    for var in keys(io_dict)
+        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group, type = io_dict[var].type)
+    end
+end
+
 function init_ensemble_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
     io_dict = io_dictionary_ensemble(ekp, priors)
     init_io_dict(diags, io_dict)
     # Write initial ensemble_state to file.
+    open_files(diags)
     write_current_dict(diags, io_dict)
+    close_files(diags)
 end
 
 function init_particle_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
@@ -360,7 +422,9 @@ function init_particle_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, 
     io_dict = io_dictionary_particle_state(ekp, priors)
     init_io_dict(diags, io_dict)
     # Write initial particle_state to file.
+    open_files(diags)
     write_current_dict(diags, io_dict)
+    close_files(diags)
 end
 
 function init_metrics(diags::NetCDFIO_Diags)
@@ -368,30 +432,54 @@ function init_metrics(diags::NetCDFIO_Diags)
     init_io_dict(diags, io_dict)
 end
 
-function init_io_dict(diags::NetCDFIO_Diags, io_dict)
-    for var in keys(io_dict)
-        add_field(diags, var; dims = io_dict[var].dims, group = io_dict[var].group, type = io_dict[var].type)
-    end
+function init_val_metrics(diags::NetCDFIO_Diags)
+    io_dict = io_dictionary_val_metrics()
+    init_io_dict(diags, io_dict)
+end
+
+function init_val_particle_diags(diags::NetCDFIO_Diags)
+    io_dict = io_dictionary_val_particle_eval()
+    init_io_dict(diags, io_dict)
+end
+
+function init_val_diagnostics(diags::NetCDFIO_Diags)
+    init_val_metrics(diags)
+    init_val_particle_diags(diags)
 end
 
 function io_metrics(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, mse_full::Vector{FT}) where {FT <: Real}
     io_dict = io_dictionary_metrics(ekp, mse_full)
-    for var in keys(io_dict)
-        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
-    end
+    write_current_dict(diags, io_dict)
+end
+
+function io_val_metrics(diags::NetCDFIO_Diags, mse_full::Vector{FT}) where {FT <: Real}
+    io_dict = io_dictionary_val_metrics(mse_full)
+    write_current_dict(diags, io_dict)
 end
 
 function io_ensemble_diags(diags::NetCDFIO_Diags, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
     io_dict = io_dictionary_ensemble(ekp, priors)
-    for var in keys(io_dict)
-        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
-    end
+    write_current_dict(diags, io_dict)
 end
 
-function io_particle_diags(
+function io_val_particle_diags(
+    diags::NetCDFIO_Diags,
+    mse_full::Vector{FT},
+    g::Union{Array{FT, 2}, Nothing} = nothing,
+    g_full::Union{Array{FT, 2}, Nothing} = nothing,
+) where {FT <: Real}
+    # Write eval diagnostics to file
+    if !isnothing(g_full)
+        io_dict = io_dictionary_val_particle_eval(g, g_full, mse_full)
+    else
+        io_dict = io_dictionary_val_particle_eval(mse_full)
+    end
+    write_current_dict(diags, io_dict)
+end
+
+function io_particle_diags_eval(
     diags::NetCDFIO_Diags,
     ekp::EnsembleKalmanProcess,
-    priors::ParameterDistribution,
     mse_full::Vector{FT},
     g_full::Union{Array{FT, 2}, Nothing} = nothing,
 ) where {FT <: Real}
@@ -401,15 +489,16 @@ function io_particle_diags(
     else
         io_dict = io_dictionary_particle_eval(ekp, mse_full)
     end
-    for var in keys(io_dict)
-        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
-    end
-    # Write state diagnostics of next iteration to file
-    write_iteration(diags)
+    write_current_dict(diags, io_dict)
+end
+
+function io_particle_diags_state(
+    diags::NetCDFIO_Diags,
+    ekp::EnsembleKalmanProcess,
+    priors::ParameterDistribution,
+) where {FT <: Real}
     io_dict = io_dictionary_particle_state(ekp, priors)
-    for var in keys(io_dict)
-        write_current(diags, var, io_dict[var].field; group = io_dict[var].group)
-    end
+    write_current_dict(diags, io_dict)
 end
 
 function io_diagnostics(
@@ -422,29 +511,43 @@ function io_diagnostics(
     open_files(diags)
     io_metrics(diags, ekp, mse_full)
     io_ensemble_diags(diags, ekp, priors)
-    io_particle_diags(diags, ekp, priors, mse_full, g_full)
+    io_particle_diags_eval(diags, ekp, mse_full, g_full)
+    write_iteration(diags)
+    io_particle_diags_state(diags, ekp, priors)
     close_files(diags)
 end
 
-function init_iteration_io(self::NetCDFIO_Diags)
-    open_files(self)
-    ensemble_t = self.ensemble_grp["iteration"]
-    @inbounds ensemble_t[1] = 0
-    particle_t = self.particle_grp["iteration"]
-    @inbounds particle_t[1] = 0
-    metric_t = self.metric_grp["iteration"]
-    @inbounds metric_t[1] = 0
-    close_files(self)
+function io_val_diagnostics(
+    diags::NetCDFIO_Diags,
+    mse_full::Vector{FT},
+    g::Union{Array{FT, 2}, Nothing} = nothing,
+    g_full::Union{Array{FT, 2}, Nothing} = nothing,
+) where {FT <: Real}
+    open_files(diags)
+    io_val_metrics(diags, mse_full)
+    io_val_particle_diags(diags, mse_full, g, g_full)
+    close_files(diags)
 end
 
-function write_iteration(self::NetCDFIO_Diags)
-    ensemble_t = self.ensemble_grp["iteration"]
+function init_iteration_io(diags::NetCDFIO_Diags)
+    open_files(diags)
+    ensemble_t = diags.ensemble_grp["iteration"]
+    @inbounds ensemble_t[1] = 0
+    particle_t = diags.particle_grp["iteration"]
+    @inbounds particle_t[1] = 0
+    metric_t = diags.metric_grp["iteration"]
+    @inbounds metric_t[1] = 0
+    close_files(diags)
+end
+
+function write_iteration(diags::NetCDFIO_Diags)
+    ensemble_t = diags.ensemble_grp["iteration"]
     @inbounds ensemble_t[end + 1] = ensemble_t[end] + 1
 
-    particle_t = self.particle_grp["iteration"]
+    particle_t = diags.particle_grp["iteration"]
     @inbounds particle_t[end + 1] = particle_t[end] + 1
 
-    metric_t = self.metric_grp["iteration"]
+    metric_t = diags.metric_grp["iteration"]
     @inbounds metric_t[end + 1] = metric_t[end] + 1
 end
 

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -16,7 +16,7 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
 using EnsembleKalmanProcesses.Observations
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 
-export init_calibration, ek_update
+export init_calibration, ek_update, versioned_model_eval
 
 """
     init_calibration(job_id::String, config::Dict{Any, Any})
@@ -33,21 +33,12 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     @assert mode in ["hpc", "pmap"]
 
     ref_config = config["reference"]
-    n_cases = length(ref_config["case_name"])
     y_ref_type = ref_config["y_reference_type"]
-    Σ_ref_type = get_entry(ref_config, "Σ_reference_type", y_ref_type)
-    Σ_dir = expand_dict_entry(ref_config, "Σ_dir", n_cases)
-    Σ_t_start = expand_dict_entry(ref_config, "Σ_t_start", n_cases)
-    Σ_t_end = expand_dict_entry(ref_config, "Σ_t_end", n_cases)
     batch_size = get_entry(ref_config, "batch_size", nothing)
+    kwargs_ref_model = get_ref_model_kwargs(ref_config)
 
     reg_config = config["regularization"]
-    perform_PCA = get_entry(reg_config, "perform_PCA", true)
-    variance_loss = get_entry(reg_config, "variance_loss", 1.0e-2)
-    normalize = get_entry(reg_config, "normalize", true)
-    tikhonov_mode = get_entry(reg_config, "tikhonov_mode", "relative")
-    tikhonov_noise = get_entry(reg_config, "tikhonov_noise", 1.0e-6)
-    dim_scaling = get_entry(reg_config, "dim_scaling", true)
+    kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
 
     out_config = config["output"]
     save_eki_data = get_entry(out_config, "save_eki_data", true)
@@ -66,6 +57,8 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
 
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 
+    val_config = get(config, "validation", nothing)
+
     # Dimensionality
     n_param = sum(map(length, collect(values(params))))
     if algo_name == "Unscented"
@@ -73,8 +66,104 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         @warn "Number of ensemble members overwritten to 2p + 1 for Unscented Kalman Inversion."
     end
 
-    # Construct reference models
-    kwargs_ref_model = Dict(
+    # Minibatch mode
+    if !isnothing(batch_size)
+        @info "Training using mini-batches."
+        ref_model_batch = construct_ref_model_batch(kwargs_ref_model)
+        global_ref_models = deepcopy(ref_model_batch.ref_models)
+        # Create input scm stats and namelist file if files don't already exist
+        run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
+        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
+        ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
+        # Generate global reference statistics for diagnostics
+        io_ref_stats = ReferenceStatistics(global_ref_models; kwargs_ref_stats...)
+        io_ref_models = global_ref_models
+    else
+        ref_models = construct_reference_models(kwargs_ref_model)
+        # Create input scm stats and namelist file if files don't already exist
+        run_reference_SCM.(ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
+        ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
+        io_ref_stats = ref_stats
+        io_ref_models = ref_models
+    end
+
+    outdir_path = create_output_dir(
+        ref_stats,
+        outdir_root,
+        algo_name,
+        Δt,
+        n_param,
+        N_ens,
+        N_iter,
+        batch_size,
+        config_path,
+        y_ref_type,
+    )
+
+    priors = construct_priors(params, outdir_path = outdir_path, unconstrained_σ = unc_σ)
+    # parameters are sampled in unconstrained space
+    if algo_name == "Inversion" || algo_name == "Sampler"
+        algo = algo_name == "Inversion" ? Inversion() : Sampler(vcat(get_mean(priors)...), get_cov(priors))
+        initial_params = construct_initial_ensemble(priors, N_ens, rng_seed = rand(1:1000))
+        ekobj = generate_ekp(initial_params, ref_stats, algo, outdir_path = outdir_path)
+    elseif algo_name == "Unscented"
+        algo = Unscented(vcat(get_mean(priors)...), get_cov(priors), 1.0, 1)
+        ekobj = generate_ekp(ref_stats, algo, outdir_path = outdir_path)
+    end
+
+    params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
+    params = [c[:] for c in eachcol(params_cons_i)]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    versions = generate_scm_input(mod_evaluators, outdir_path)
+    # Store version identifiers for this ensemble in a common file
+    write_versions(versions, 1, outdir_path = outdir_path)
+    # Store ReferenceModelBatch
+    if !isnothing(batch_size)
+        write_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
+    end
+
+    # Initialize validation
+    val_ref_models, val_ref_stats = isnothing(val_config) ? repeat([nothing], 2) :
+        init_validation(
+        val_config,
+        reg_config,
+        ekobj,
+        priors,
+        versions,
+        outdir_path,
+        overwrite = overwrite_scm_file,
+        namelist_args = namelist_args,
+    )
+
+    # Diagnostics IO
+    init_diagnostics(
+        config,
+        outdir_path,
+        io_ref_models,
+        io_ref_stats,
+        ekobj,
+        priors,
+        val_ref_models,
+        val_ref_stats,
+        !isnothing(val_config),
+    )
+
+    if mode == "hpc"
+        open("$(job_id).txt", "w") do io
+            write(io, "$(outdir_path)\n")
+        end
+    elseif mode == "pmap"
+        return outdir_path
+    end
+end
+
+function get_ref_model_kwargs(ref_config::Dict{Any, Any})
+    n_cases = length(ref_config["case_name"])
+    Σ_dir = expand_dict_entry(ref_config, "Σ_dir", n_cases)
+    Σ_t_start = expand_dict_entry(ref_config, "Σ_t_start", n_cases)
+    Σ_t_end = expand_dict_entry(ref_config, "Σ_t_end", n_cases)
+    return Dict(
         :y_names => ref_config["y_names"],
         # Reference path specification
         :y_dir => ref_config["y_dir"],
@@ -89,48 +178,44 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         :Σ_t_start => Σ_t_start,
         :Σ_t_end => Σ_t_end,
     )
+end
 
-    # Minibatch mode
-    if !isnothing(batch_size)
-        @info "Training using mini-batches."
-        ref_model_batch = construct_ref_model_batch(kwargs_ref_model)
-        global_ref_models = deepcopy(ref_model_batch.ref_models)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
-        # Generate global reference statistics
-        global_ref_stats = ReferenceStatistics(
-            global_ref_models,
-            perform_PCA,
-            normalize,
-            variance_loss = variance_loss,
-            tikhonov_noise = tikhonov_noise,
-            tikhonov_mode = tikhonov_mode,
-            dim_scaling = dim_scaling,
-            y_type = y_ref_type,
-            Σ_type = Σ_ref_type,
-        )
-        ref_models = get_minibatch!(ref_model_batch, batch_size)
-        ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
-    else
-        ref_models = construct_reference_models(kwargs_ref_model)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
-    end
-    # Generate reference statistics
-    ref_stats = ReferenceStatistics(
-        ref_models,
-        perform_PCA,
-        normalize,
-        variance_loss = variance_loss,
-        tikhonov_noise = tikhonov_noise,
-        tikhonov_mode = tikhonov_mode,
-        dim_scaling = dim_scaling,
-        y_type = y_ref_type,
-        Σ_type = Σ_ref_type,
+function get_ref_stats_kwargs(ref_config::Dict{Any, Any}, reg_config::Dict{Any, Any})
+    y_ref_type = ref_config["y_reference_type"]
+    Σ_ref_type = get_entry(ref_config, "Σ_reference_type", y_ref_type)
+    perform_PCA = get_entry(reg_config, "perform_PCA", true)
+    variance_loss = get_entry(reg_config, "variance_loss", 1.0e-2)
+    normalize = get_entry(reg_config, "normalize", true)
+    tikhonov_mode = get_entry(reg_config, "tikhonov_mode", "relative")
+    tikhonov_noise = get_entry(reg_config, "tikhonov_noise", 1.0e-6)
+    dim_scaling = get_entry(reg_config, "dim_scaling", true)
+    return Dict(
+        :perform_PCA => perform_PCA,
+        :normalize => normalize,
+        :variance_loss => variance_loss,
+        :tikhonov_noise => tikhonov_noise,
+        :tikhonov_mode => tikhonov_mode,
+        :dim_scaling => dim_scaling,
+        :y_type => y_ref_type,
+        :Σ_type => Σ_ref_type,
     )
+end
 
+"Create the calibration output directory and copy the config file into it"
+function create_output_dir(
+    ref_stats::ReferenceStatistics,
+    outdir_root::String,
+    algo_name::String,
+    Δt::FT,
+    n_param::IT,
+    N_ens::IT,
+    N_iter::IT,
+    batch_size::Union{IT, Nothing},
+    config_path::Union{String, Nothing},
+    y_ref_type,
+) where {FT <: Real, IT <: Integer}
     # Output path
-    d = isnothing(batch_size) ? "d$(length(ref_stats.y))" : "mb"
+    d = isnothing(batch_size) ? "d$(pca_length(ref_stats))" : "mb"
     outdir_path = joinpath(
         outdir_root,
         "results_$(algo_name)_dt$(Δt)_p$(n_param)_e$(N_ens)_i$(N_iter)_$(d)_$(typeof(y_ref_type))_$(rand(11111:99999))",
@@ -140,59 +225,105 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     if !isnothing(config_path)
         cp(config_path, joinpath(outdir_path, "config.jl"))
     end
+    return outdir_path
+end
 
-    priors = construct_priors(params, outdir_path = outdir_path, unconstrained_σ = unc_σ)
-    # parameters are sampled in unconstrained space
-    if algo_name == "Inversion" || algo_name == "Sampler"
-        algo = algo_name == "Inversion" ? Inversion() : Sampler(vcat(get_mean(priors)...), get_cov(priors))
-        initial_params = construct_initial_ensemble(priors, N_ens, rng_seed = rand(1:1000))
-        ekobj = generate_ekp(initial_params, ref_stats, algo, outdir_path = outdir_path)
-    elseif algo_name == "Unscented"
-        algo = Unscented(vcat(get_mean(priors)...), get_cov(priors), 1.0, 1)
-        ekobj = generate_ekp(ref_stats, algo, outdir_path = outdir_path)
-    end
+"Initialize the validation process."
+function init_validation(
+    val_config::Dict{Any, Any},
+    reg_config::Dict{Any, Any},
+    ekp::EnsembleKalmanProcess,
+    priors::ParameterDistribution,
+    versions::Vector{IT},
+    outdir_path::String;
+    overwrite::Bool = false,
+    namelist_args = nothing,
+) where {FT <: Real, IT <: Integer}
 
-    # Diagnostics IO
+    kwargs_ref_model = get_ref_model_kwargs(val_config)
+    kwargs_ref_stats = get_ref_stats_kwargs(val_config, reg_config)
+    batch_size = get_entry(val_config, "batch_size", nothing)
+
     if !isnothing(batch_size)
-        init_diagnostics(config, outdir_path, global_ref_stats, global_ref_models, ekobj, priors)
+        @info "Validation using mini-batches."
+        ref_model_batch = construct_ref_model_batch(kwargs_ref_model)
+        run_reference_SCM.(ref_model_batch.ref_models, overwrite = overwrite, namelist_args = namelist_args)
+        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
+        write_val_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
     else
-        init_diagnostics(config, outdir_path, ref_stats, ref_models, ekobj, priors)
+        ref_models = construct_reference_models(kwargs_ref_model)
+        run_reference_SCM.(ref_models, overwrite = overwrite, namelist_args = namelist_args)
     end
+    ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
+    params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp))
+    params = [c[:] for c in eachcol(params_cons_i)]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    [
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version)
+        for (model_evaluator, version) in zip(mod_evaluators, versions)
+    ]
+    return ref_models, ref_stats
+end
 
-    if mode == "hpc"
-        open("$(job_id).txt", "w") do io
-            write(io, "$(outdir_path)\n")
-        end
-        params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
-        params = [c[:] for c in eachcol(params_cons_i)]
-        mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
-        versions = generate_scm_input(mod_evaluators, outdir_path)
-        # Store version identifiers for this ensemble in a common file
-        write_versions(versions, 1, outdir_path = outdir_path)
-        # Store ReferenceModelBatch
-        if !isnothing(batch_size)
-            write_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
-        end
-    elseif mode == "pmap"
-        if !isnothing(batch_size)
-            return Dict(
-                "ekobj" => ekobj,
-                "priors" => priors,
-                "ref_stats" => ref_stats,
-                "ref_models" => ref_models,
-                "ref_model_batch" => ref_model_batch,
-                "outdir_path" => outdir_path,
-            )
-        else
-            return Dict(
-                "ekobj" => ekobj,
-                "priors" => priors,
-                "ref_stats" => ref_stats,
-                "ref_models" => ref_models,
-                "outdir_path" => outdir_path,
-            )
-        end
+"""
+    update_validation(
+        val_config::Dict{Any, Any},
+        reg_config::Dict{Any, Any},
+        ekp_old::EnsembleKalmanProcess,
+        priors::ParameterDistribution,
+        versions::Vector{String},
+        outdir_path::String,
+        iteration::IT
+        )
+
+Updates the validation diagnostics and writes to file the validation ModelEvaluators
+for the next calibration step.
+
+Inputs:
+
+ - val_config    :: Validation model configuration.
+ - reg_config    :: Regularization configuration.
+ - ekp_old       :: EnsembleKalmanProcess updated using the past forward model evaluations.
+ - priors        :: The priors over parameter space.
+ - versions      :: String versions identifying the forward model evaluations.
+ - outdir_path   :: Output path directory.
+"""
+function update_validation(
+    val_config::Dict{Any, Any},
+    reg_config::Dict{Any, Any},
+    ekp_old::EnsembleKalmanProcess,
+    priors::ParameterDistribution,
+    versions::Vector{String},
+    outdir_path::String,
+    iteration::IT,
+) where {IT <: Integer}
+
+    batch_size = get_entry(val_config, "batch_size", nothing)
+
+    if !isnothing(batch_size)
+        ref_model_batch = load(joinpath(outdir_path, "val_ref_model_batch.jld2"))["ref_model_batch"]
+        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
+        kwargs_ref_stats = get_ref_stats_kwargs(val_config, reg_config)
+        ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
+        rm(joinpath(outdir_path, "val_ref_model_batch.jld2"))
+        write_val_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
+    else
+        mod_evaluator = load(scm_val_output_path(outdir_path, versions[1]))["model_evaluator"]
+        ref_models = mod_evaluator.ref_models
+        ref_stats = mod_evaluator.ref_stats
     end
+    params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp_old))
+    params = [c[:] for c in eachcol(params_cons_i)]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    # Save new ModelEvaluators using the new versions
+    versions = readlines(joinpath(outdir_path, "versions_$(iteration + 1).txt"))
+    [
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version)
+        for (model_evaluator, version) in zip(mod_evaluators, versions)
+    ]
+    return
 end
 
 """
@@ -227,7 +358,7 @@ function ek_update(
     versions::Vector{String},
     outdir_path::String,
 )
-    # Get dimensionality
+    # Get config
     proc_config = config["process"]
     N_iter = proc_config["N_iter"]
     algo_name = get_entry(proc_config, "algorithm", "Inversion")
@@ -250,9 +381,12 @@ function ek_update(
     else
         update_ensemble!(ekobj, g)
     end
-    # Diagnostics IO
-    update_diagnostics(outdir_path, ekobj, priors, ref_stats, g_full, batch_size)
 
+    # Diagnostics IO
+    val_config = get(config, "validation", nothing)
+    update_diagnostics(outdir_path, ekobj, priors, ref_stats, g_full, batch_size, versions, val_config)
+
+    # Prepare updated EKP and ReferenceModelBatch if minibatching.
     if !isnothing(batch_size)
         ref_model_batch = load(joinpath(outdir_path, "ref_model_batch.jld2"))["ref_model_batch"]
         ekp, ref_models, ref_stats, ref_model_batch =
@@ -262,8 +396,17 @@ function ek_update(
     else
         ekp = ekobj
     end
+
+    # Write to file new EKP and ModelEvaluators
     jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
     write_model_evaluators(ekp, priors, ref_models, ref_stats, outdir_path, iteration)
+
+    # Update validation ModelEvaluators
+    if !isnothing(val_config)
+        reg_config = config["regularization"]
+        update_validation(val_config, reg_config, ekobj, priors, versions, outdir_path, iteration)
+    end
+
     return
 end
 
@@ -280,23 +423,59 @@ Outputs:
  - g            :: Forward model evaluations in the reduced space of the inverse problem.
  - g_full       :: Forward model evaluations in the original physical space.
 """
-function get_ensemble_g_eval(outdir_path::String, versions::Vector{String})
+function get_ensemble_g_eval(outdir_path::String, versions::Vector{String}; validation::Bool = false)
+    # Find train/validation path
+    scm_path(x) = validation ? scm_val_output_path(outdir_path, x) : scm_output_path(outdir_path, x)
+    init_path(x) = validation ? scm_val_init_path(outdir_path, x) : scm_init_path(outdir_path, x)
     # Get array sizes with first file
-    scm_outputs = load(scm_output_path(outdir_path, versions[1]))
+    scm_outputs = load(scm_path(versions[1]))
     d = length(scm_outputs["g_scm_pca"])
     d_full = length(scm_outputs["g_scm"])
     N_ens = length(versions)
     g = zeros(d, N_ens)
     g_full = zeros(d_full, N_ens)
     for (ens_index, version) in enumerate(versions)
-        scm_outputs = load(scm_output_path(outdir_path, version))
+        scm_outputs = load(scm_path(version))
         g[:, ens_index] = scm_outputs["g_scm_pca"]
         g_full[:, ens_index] = scm_outputs["g_scm"]
         # Clean up
-        rm(scm_output_path(outdir_path, version))
-        rm(scm_init_path(outdir_path, version))
+        rm(scm_path(version))
+        rm(init_path(version))
     end
     return g, g_full
+end
+
+"""
+   versioned_model_eval(version::Union{String, Int}, outdir_path::String, mode::String, config::Dict{Any, Any})
+
+Performs or omits a model evaluation given the parsed mode and provided config,
+ and writes to file the model output.
+
+Inputs:
+ - version       :: The version associated with the ModelEvaluator to be used.
+ - outdir_path   :: The path to the results directory of the calibration process.
+ - mode          :: Whether the ModelEvaluator is used for training or validation.
+ - config        :: The general configuration dictionary.
+"""
+function versioned_model_eval(version::Union{String, Int}, outdir_path::String, mode::String, config::Dict{Any, Any})
+    @assert mode in ["train", "validation"]
+    # Omits validation if unsolicited
+    if mode == "validation" && isnothing(get(config, "validation", nothing))
+        return
+    elseif mode == "validation"
+        input_path = scm_val_init_path(outdir_path, version)
+        output_path = scm_val_output_path(outdir_path, version)
+    else
+        input_path = scm_init_path(outdir_path, version)
+        output_path = scm_output_path(outdir_path, version)
+    end
+    # Load inputs
+    scm_args = load(input_path)
+    namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+    model_evaluator = scm_args["model_evaluator"]
+    # Eval
+    sim_dirs, g_scm, g_scm_pca = run_SCM(model_evaluator, namelist_args = namelist_args)
+    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
 end
 
 """
@@ -336,28 +515,10 @@ function update_minibatch_inverse_problem(
     ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
 
     ref_config = config["reference"]
-    y_ref_type = ref_config["y_reference_type"]
-    Σ_ref_type = get_entry(ref_config, "Σ_reference_type", y_ref_type)
-
     reg_config = config["regularization"]
-    perform_PCA = get_entry(reg_config, "perform_PCA", true)
-    variance_loss = get_entry(reg_config, "variance_loss", 1.0e-2)
-    normalize = get_entry(reg_config, "normalize", true)
-    tikhonov_mode = get_entry(reg_config, "tikhonov_mode", "relative")
-    tikhonov_noise = get_entry(reg_config, "tikhonov_noise", 1.0e-6)
-    dim_scaling = get_entry(reg_config, "dim_scaling", true)
+    kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
 
-    ref_stats = ReferenceStatistics(
-        ref_models,
-        perform_PCA,
-        normalize,
-        variance_loss = variance_loss,
-        tikhonov_noise = tikhonov_noise,
-        tikhonov_mode = tikhonov_mode,
-        dim_scaling = dim_scaling,
-        y_type = y_ref_type,
-        Σ_type = Σ_ref_type,
-    )
+    ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
     if isa(ekp_old.process, Inversion) || isa(ekp_old.process, Sampler)
         ekp = generate_ekp(get_u_final(ekp_old), ref_stats, ekp_old.process, outdir_path = outdir_path)
     elseif isa(ekp_old.process, Unscented)
@@ -429,26 +590,32 @@ Creates a diagnostics netcdf file.
 function init_diagnostics(
     config::Dict{Any, Any},
     outdir_path::String,
-    ref_stats::ReferenceStatistics,
     ref_models::Vector{ReferenceModel},
+    ref_stats::ReferenceStatistics,
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
+    val_ref_models::Union{Vector{ReferenceModel}, Nothing},
+    val_ref_stats::Union{ReferenceStatistics, Nothing},
+    validation::Bool = false,
 )
-    diags = NetCDFIO_Diags(config, outdir_path, ref_stats, ekp, priors)
+    diags = NetCDFIO_Diags(config, outdir_path, ref_stats, ekp, priors, val_ref_stats)
     # Write reference
     io_reference(diags, ref_stats, ref_models)
-    # Add metric fields
-    init_metrics(diags)
     # Add diags, write first state diags
     init_iteration_io(diags)
+    init_metrics(diags)
     init_ensemble_diags(diags, ekp, priors)
     init_particle_diags(diags, ekp, priors)
+    if validation
+        init_val_diagnostics(diags)
+    end
 end
 
 """
     update_diagnostics(outdir_path::String, ekp::EnsembleKalmanProcess, priors::ParameterDistribution)
 
-Appends current iteration diagnostics to a diagnostics netcdf file.
+Appends diagnostics of the current iteration evaluations (i.e., forward model output metrics)
+and the next iteration state (i.e., parameters and parameter metrics) to a diagnostics netcdf file.
 
     Inputs:
     - outdir_path :: Path of results directory.
@@ -456,6 +623,9 @@ Appends current iteration diagnostics to a diagnostics netcdf file.
     - priors:: Prior distributions of the parameters.
     - ref_stats :: ReferenceStatistics.
     - g_full :: The forward model evaluation in primitive space.
+    - batch_size :: The number of evaluations per minibatch, if minibatching.
+    - versions :: Version identifiers of the forward model evaluations at the current iteration.
+    - val_config :: The validation configuration, if given.
 """
 function update_diagnostics(
     outdir_path::String,
@@ -464,14 +634,38 @@ function update_diagnostics(
     ref_stats::ReferenceStatistics,
     g_full::Array{FT, 2},
     batch_size::Union{Int, Nothing},
+    versions::Union{Vector{Int}, Vector{String}},
+    val_config::Union{Dict{Any, Any}, Nothing} = nothing,
 ) where {FT <: Real}
-    # Compute diagnostics
+
+    if !isnothing(val_config)
+        update_val_diagnostics(outdir_path, versions, val_config)
+    end
     mse_full = compute_mse(g_full, ref_stats.y_full)
     diags = NetCDFIO_Diags(joinpath(outdir_path, "Diagnostics.nc"))
     if isnothing(batch_size)
         io_diagnostics(diags, ekp, priors, mse_full, g_full)
     else
         io_diagnostics(diags, ekp, priors, mse_full)
+    end
+end
+
+function update_val_diagnostics(
+    outdir_path::String,
+    versions::Union{Vector{Int}, Vector{String}},
+    val_config::Dict{Any, Any},
+) where {FT <: Real}
+    batch_size = get_entry(val_config, "batch_size", nothing)
+    mod_evaluator = load(scm_val_output_path(outdir_path, versions[1]))["model_evaluator"]
+    ref_stats = mod_evaluator.ref_stats
+    g, g_full = get_ensemble_g_eval(outdir_path, versions, validation = true)
+    # Compute diagnostics
+    mse_full = compute_mse(g_full, ref_stats.y_full)
+    diags = NetCDFIO_Diags(joinpath(outdir_path, "Diagnostics.nc"))
+    if isnothing(batch_size)
+        io_val_diagnostics(diags, mse_full, g, g_full)
+    else
+        io_val_diagnostics(diags, mse_full)
     end
 end
 

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -10,7 +10,7 @@ export y_dir, Σ_dir, scm_dir, num_vars, uuid
 export data_directory, namelist_directory
 export construct_reference_models, construct_ref_model_batch
 export get_minibatch!, reshuffle_on_epoch_end, write_ref_model_batch
-export time_shift_reference_model
+export time_shift_reference_model, write_val_ref_model_batch
 
 """
     struct ReferenceModel
@@ -279,6 +279,9 @@ end
 
 function write_ref_model_batch(ref_model_batch::ReferenceModelBatch; outdir_path::String = pwd())
     jldsave(joinpath(outdir_path, "ref_model_batch.jld2"); ref_model_batch)
+end
+function write_val_ref_model_batch(ref_model_batch::ReferenceModelBatch; outdir_path::String = pwd())
+    jldsave(joinpath(outdir_path, "val_ref_model_batch.jld2"); ref_model_batch)
 end
 
 end # module

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -42,18 +42,17 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
 
     """
         ReferenceStatistics(
-            RM::Vector{ReferenceModel},
-            perform_PCA::Bool,
-            normalize::Bool,
-            FT::DataType = Float64;
-            variance_loss::Float64 = 0.1,
-            tikhonov_noise::Float64 = 0.0,
+            RM::Vector{ReferenceModel};
+            perform_PCA::Bool = true,
+            normalize::Bool = true,
+            variance_loss::FT = 0.1,
+            tikhonov_noise::FT = 0.0,
             tikhonov_mode::String = "absolute",
             dim_scaling::Bool = false,
             y_type::ModelType = LES(),
             Σ_type::ModelType = LES(),
-            Δt::FT = 6 * 3600,
-        )
+            Δt::FT = 6 * 3600.0,
+        ) where {FT <: Real}
 
     Constructs the ReferenceStatistics defining the inverse problem.
 
@@ -76,9 +75,9 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
      - A ReferenceStatistics struct.
     """
     function ReferenceStatistics(
-        RM::Vector{ReferenceModel},
-        perform_PCA::Bool,
-        normalize::Bool;
+        RM::Vector{ReferenceModel};
+        perform_PCA::Bool = true,
+        normalize::Bool = true,
         variance_loss::FT = 0.1,
         tikhonov_noise::FT = 0.0,
         tikhonov_mode::String = "absolute",

--- a/src/helper_funcs.jl
+++ b/src/helper_funcs.jl
@@ -362,6 +362,8 @@ end
 
 scm_init_path(root, version; prefix = "scm_initializer_") = jld2_path(root, version, prefix)
 scm_output_path(root, version; prefix = "scm_output_") = jld2_path(root, version, prefix)
+scm_val_init_path(root, version; prefix = "scm_val_initializer_") = jld2_path(root, version, prefix)
+scm_val_output_path(root, version; prefix = "scm_val_output_") = jld2_path(root, version, prefix)
 ekobj_path(root, iter; prefix = "ekobj_iter_") = jld2_path(root, iter, prefix)
 
 

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -31,7 +31,7 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
     # Generate ref_stats
     ref_models = construct_reference_models(kwargs_ref_model)
     run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
-    ref_stats = ReferenceStatistics(ref_models, true, true; y_type = SCM(), Σ_type = SCM())
+    ref_stats = ReferenceStatistics(ref_models, y_type = SCM(), Σ_type = SCM())
     # Generate config
     config = Dict()
     config["process"] = Dict()
@@ -39,7 +39,7 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
     config["process"]["batch_size"] = nothing
     config["prior"] = Dict()
     config["prior"]["constraints"] = Dict("foo" => [bounded(0.0, 0.5)], "bar" => [bounded(0.0, 0.5)])
-
+    config["reference"] = Dict()
     priors = construct_priors(config["prior"]["constraints"])
     ekp = EnsembleKalmanProcess(rand(2, 10), ref_stats.y, ref_stats.Γ, Inversion())
     diags = NetCDFIO_Diags(config, data_dir, ref_stats, ekp, priors)

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -31,9 +31,9 @@ using CalibrateEDMF.TurbulenceConvectionUtils
     dim_list = [false, true]
     for (pca, norm, tikhonov_mode, dim_scaling) in zip(pca_list, norm_list, mode_list, dim_list)
         ref_stats = ReferenceStatistics(
-            ref_models,
-            pca,
-            norm;
+            ref_models;
+            perform_PCA = pca,
+            normalize = norm,
             variance_loss = 0.1,
             tikhonov_noise = 0.1,
             tikhonov_mode = tikhonov_mode,
@@ -58,9 +58,9 @@ using CalibrateEDMF.TurbulenceConvectionUtils
 
     # Verify that incorrect definitions throw error
     @test_throws AssertionError ReferenceStatistics(
-        ref_models,
-        false,
-        false;
+        ref_models;
+        perform_PCA = false,
+        normalize = false,
         tikhonov_mode = "relative",
         y_type = SCM(),
         Σ_type = SCM(),


### PR DESCRIPTION
This PR adds validation capabilities to the calibration pipeline. Validation is activated if there exists a `config["validation"]` dictionary that points to a valid reference configuration. In that case, the selected reference configuration is used for validation throughout the calibration process.

The validation forward model evaluations are run as independent `single_scm_run.jl` evaluations. They are called in parallel using hpc resources when calling `single_scm_rub.sbatch`, so the validation evaluations are embarrassingly parallel with respect to calibration. In the pmap pipeline, the training/validation pmap calls are serialized.

In addition, this PR:

- Unifies even further the HPC and pmap pipelines. Now most functionality is shared between them.
- Fixes a bug in the cfSite getter, where the month was hardcoded to be July.