### PR TITLE
Add global parallelism functionality.

### DIFF
--- a/experiments/scm_pycles_pipeline/global_parallel/ekp_par_calibration.sbatch
+++ b/experiments/scm_pycles_pipeline/global_parallel/ekp_par_calibration.sbatch
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#SBATCH --time=0:10:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH -J "ekp_call"   # job name
+
+config=${1?Error: no config file given}
+
+# Job identifier
+job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+# Get size of the ensemble from config, trim comments and whitespace
+n=$(grep N_ens ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Number of calibration iterations, trim comments and whitespace
+n_it=$(grep N_iter ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Number of parallel processes for SCM evaluation, split evenly between train and validation
+n_proc_scm=10
+echo "Initializing calibration with ${n} ensemble members and ${n_it} iterations."
+
+module purge
+module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
+export JULIA_MPI_BINARY=system
+export JULIA_CUDA_USE_BINARYBUILDER=false
+
+# run instantiate/precompile serial
+julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -e 'using Pkg; Pkg.precompile()'
+
+# First call to calibrate.jl will create the ensemble files from the priors
+id_init_ens=$(sbatch --parsable -A esm init.sbatch $config $job_id)
+for it in $(seq 1 1 $n_it)
+do
+# Parallel runs of forward model
+if [ "$it" = "1" ]; then
+    id_precond=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_init_ens --array=1-$n precondition_prior.sbatch $it $job_id)
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_precond --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+else
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+fi
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
+done
+

--- a/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.jl
@@ -1,0 +1,37 @@
+"""Evaluates a set of SCM configurations for a single parameter vector."""
+
+@everywhere using Pkg
+@everywhere Pkg.activate("../../..")
+@everywhere using ArgParse
+@everywhere using CalibrateEDMF
+@everywhere using CalibrateEDMF.Pipeline
+@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
+
+@everywhere src_dir = dirname(pathof(CalibrateEDMF))
+@everywhere include(joinpath(src_dir, "helper_funcs.jl"))
+@everywhere include(joinpath(src_dir, "parallel.jl"))
+using JLD2
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--version"
+    help = "Calibration process number"
+    arg_type = Int
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+    "--mode"
+    help = "Forward model evaluation mode: `train` or `validation`"
+    arg_type = String
+    default = "train"
+end
+parsed_args = parse_args(ARGS, s)
+outdir_path = parsed_args["job_dir"]
+include(joinpath(outdir_path, "config.jl"))
+
+config = get_config()
+version = parsed_args["version"]
+mode = parsed_args["mode"]
+versioned_model_eval_parallel(version, outdir_path, mode, config)

--- a/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.sbatch
+++ b/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00   # walltime
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "scm_run"   # job name
+
+module load julia/1.6.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+iteration_=${1?Error: no iteration given}
+job_id=${2?Error: no job ID given}
+n_proc_scm=${3?Error: number of processes not given}
+
+run_num=${SLURM_ARRAY_TASK_ID}
+job_dir=$(head $job_id".txt" | tail -1)
+version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
+
+julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train" &
+P1=$!
+julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation" &
+P2=$!
+wait $P1 $P2
+echo "SCM simulation for ${version} in iteration ${iteration_} finished"
+

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,0 +1,98 @@
+
+using Distributed
+using CalibrateEDMF
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.TurbulenceConvectionUtils
+using TurbulenceConvection
+include(joinpath(@__DIR__, "helper_funcs.jl"))
+
+export run_SCM_parallel, eval_single_ref_model, versioned_model_eval_parallel
+
+function run_SCM_parallel(ME::ModelEvaluator; error_check::Bool = false, namelist_args = nothing) where {FT <: Real}
+    return run_SCM_parallel(
+        ME.param_cons,
+        ME.param_names,
+        ME.ref_models,
+        ME.ref_stats,
+        error_check = error_check,
+        namelist_args = namelist_args,
+    )
+end
+
+function run_SCM_parallel(
+    u::Vector{FT},
+    u_names::Vector{String},
+    RM::Vector{ReferenceModel},
+    RS::ReferenceStatistics;
+    error_check::Bool = false,
+    namelist_args = nothing,
+) where {FT <: Real}
+
+    mkpath(joinpath(pwd(), "tmp"))
+    result_arr = pmap(x -> eval_single_ref_model(x..., RS, u, u_names, namelist_args), enumerate(RM))
+    # Unpack
+    sim_dirs, g_scm, g_scm_pca, sim_errors = (getindex.(result_arr, i) for i in 1:4)
+    g_scm = vcat(g_scm...)
+    g_scm_pca = vcat(g_scm_pca...)
+    model_error = any(sim_errors)
+
+    # penalize nan-values in output
+    any(isnan.(g_scm)) && warn("NaN-values in output data")
+    g_scm[isnan.(g_scm)] .= 1e5
+    g_scm_pca[isnan.(g_scm_pca)] .= 1e5
+    @info "Length of g_scm (full): $(length(g_scm))"
+    @info "Length of g_scm (pca) : $(length(g_scm_pca))"
+    if error_check
+        return sim_dirs, g_scm, g_scm_pca, model_error
+    else
+        return sim_dirs, g_scm, g_scm_pca
+    end
+end
+
+function eval_single_ref_model(
+    m_index::IT,
+    m::ReferenceModel,
+    RS::ReferenceStatistics,
+    u::Vector{FT},
+    u_names::Vector{String},
+    namelist_args = nothing,
+) where {FT <: Real, IT <: Int}
+    # create temporary directory to store SCM data in
+    tmpdir = mktempdir(joinpath(pwd(), "tmp"))
+    # run TurbulenceConvection.jl. Get output directory for simulation data
+    sim_dir, model_error = run_SCM_handler(m, tmpdir, u, u_names, namelist_args)
+    g_scm = get_profile(m, sim_dir, z_scm = get_height(sim_dir))
+    g_scm = normalize_profile(g_scm, length(m.y_names), RS.norm_vec[m_index])
+    # perform PCA reduction
+    g_scm_pca = RS.pca_vec[m_index]' * g_scm
+    return sim_dir, g_scm, g_scm_pca, model_error
+end
+
+function versioned_model_eval_parallel(
+    version::Union{String, Int},
+    outdir_path::String,
+    mode::String,
+    config::Dict{Any, Any},
+)
+    @assert mode in ["train", "validation"]
+    # Omits validation if unsolicited
+    if mode == "validation" && isnothing(get(config, "validation", nothing))
+        return
+    elseif mode == "validation"
+        input_path = scm_val_init_path(outdir_path, version)
+        output_path = scm_val_output_path(outdir_path, version)
+    else
+        input_path = scm_init_path(outdir_path, version)
+        output_path = scm_output_path(outdir_path, version)
+    end
+    # Load inputs
+    scm_args = load(input_path)
+    namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+    model_evaluator = scm_args["model_evaluator"]
+    # Eval
+    sim_dirs, g_scm, g_scm_pca = run_SCM_parallel(model_evaluator, namelist_args = namelist_args)
+    # Store output and delete input
+    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+    rm(input_path)
+end


### PR DESCRIPTION
This PR adds functionality for parallelism across simulations. An example of the setup is included in `scm_pycles_pipeline/global_parallelism`.

Closes #83 .