### PR TITLE
Enable augmentation of output with parameters for l2 regularization

### DIFF
--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -55,12 +55,18 @@ end
 
 function get_regularization_config()
     config = Dict()
+    # Regularization of observations: mean and covariance
     config["perform_PCA"] = true # Performs PCA on data
     config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
     config["normalize"] = true  # whether to normalize data by pooled variance
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
-    config["dim_scaling"] = true # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean
+    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = nothing
     return config
 end
 
@@ -70,7 +76,10 @@ function get_process_config()
     config["N_ens"] = 13
     config["algorithm"] = "Unscented" # "Sampler", "Unscented", "Inversion"
     config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
-    config["Δt"] = 1.0 # Artificial time stepper of the EKI.
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = false
     return config
 end
 

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -52,12 +52,18 @@ end
 
 function get_regularization_config()
     config = Dict()
+    # Regularization of observations: mean and covariance
     config["perform_PCA"] = true # Performs PCA on data
     config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
     config["normalize"] = true  # whether to normalize data by pooled variance
     config["tikhonov_mode"] = "relative" # Tikhonov regularization
     config["tikhonov_noise"] = 1.0e-4 # Tikhonov regularization
     config["dim_scaling"] = false # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean
+    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = nothing
     return config
 end
 
@@ -67,7 +73,10 @@ function get_process_config()
     config["N_ens"] = 5
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     config["noisy_obs"] = false
-    config["Δt"] = 1.0 # Artificial time stepper of the EKI.
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = false
     return config
 end
 

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -238,10 +238,11 @@ function io_dictionary_particle_eval(
     ekp::EnsembleKalmanProcess,
     g_full::Matrix{FT},
     mse_full::Vector{FT},
-) where {FT <: Real}
+    d::IT,
+) where {FT <: Real, IT <: Integer}
     orig_dict = io_dictionary_particle_eval()
     io_dict = Dict(
-        "g" => Base.setindex(orig_dict["g"], get_g_final(ekp)', :field),
+        "g" => Base.setindex(orig_dict["g"], get_g_final(ekp)'[:, 1:d], :field),
         "g_full" => Base.setindex(orig_dict["g_full"], g_full', :field),
         "mse_full" => Base.setindex(orig_dict["mse_full"], mse_full, :field),
     )

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -327,9 +327,11 @@ function io_particle_diags_eval(
     mse_full::Vector{FT},
     g_full::Union{Matrix{FT}, Nothing} = nothing,
 ) where {FT <: Real}
+    # Dimension of the outputs - not augmented
+    d = length(diags.ensemble_grp["out"])
     # Write eval diagnostics to file
     if !isnothing(g_full)
-        io_dict = io_dictionary_particle_eval(ekp, g_full, mse_full)
+        io_dict = io_dictionary_particle_eval(ekp, g_full, mse_full, d)
     else
         io_dict = io_dictionary_particle_eval(ekp, mse_full)
     end

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -35,14 +35,36 @@ namelist_args = config["scm"]["namelist_args"]
 # Generate "true" data
 run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = namelist_args)
 
-@testset "init_calibration_pmap" begin
-    ### Test pmap pipeline
-    prior_means = [Dict("entrainment_factor" => 0.15, "detrainment_factor" => 0.4), nothing]
-    batch_sizes = [1, nothing]
-    for (prior_mean, batch_size) in zip(prior_means, batch_sizes)
+# Test a range of calibration initializations
+@testset "init_calibration" begin
+
+    # Different configurations
+    prior_means = [
+        Dict("entrainment_factor" => 0.15, "detrainment_factor" => 0.4),
+        nothing,
+        Dict("entrainment_factor" => 0.1, "detrainment_factor" => 0.2),
+    ]
+    batch_sizes = [nothing, 1, nothing]
+    augments = [true, true, false]
+    norms = [true, false, true]
+    dim_scalings = [true, false, false]
+    tikhonov_modes = ["relative", "absolute", "relative"]
+    modes = ["pmap", "hpc", "pmap"]
+    validations = [config["reference"], config["reference"], nothing]
+    algos = ["Sampler", "Unscented", "Inversion"]
+
+    for (prior_mean, batch_size, augment, norm, dim_scaling, tikhonov_mode, mode, validation, algo) in
+        zip(prior_means, batch_sizes, augments, norms, dim_scalings, tikhonov_modes, modes, validations, algos)
         config["prior"]["prior_mean"] = prior_mean
         config["reference"]["batch_size"] = batch_size
-        outdir_path = init_calibration(config; config_path = joinpath(test_dir, "config.jl"), mode = "pmap")
+        config["process"]["augmented"] = augment
+        config["process"]["algorithm"] = algo
+        config["regularization"]["normalize"] = norm
+        config["regularization"]["dim_scaling"] = dim_scaling
+        config["regularization"]["tikhonov_mode"] = tikhonov_mode
+        config["validation"] = validation
+
+        outdir_path = init_calibration(config; config_path = joinpath(test_dir, "config.jl"), mode = mode)
 
         @test isdir(outdir_path)
         @test isfile(joinpath(outdir_path, "prior.jld2"))
@@ -61,85 +83,89 @@ end
 @testset "Pipeline" begin
 
     ###  Test HPC pipeline
-    init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"))
-    res_dir_list = glob("results_*_SCM*", config["output"]["outdir_root"])
-    res_dir = res_dir_list[1]
+    outdir_path = init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"))
 
     # Check for output
     @test all(isdir.(config["reference"]["scm_parent_dir"]))
-    @test length(res_dir_list) == 1
-    @test isdir(res_dir)
-    @test isfile(joinpath(res_dir, "prior.jld2"))
-    @test isfile(joinpath(res_dir, "ekobj_iter_1.jld2"))
-    @test isfile(joinpath(res_dir, "versions_1.txt"))
+    @test isdir(outdir_path)
+    @test isfile(joinpath(outdir_path, "prior.jld2"))
+    @test isfile(joinpath(outdir_path, "ekobj_iter_1.jld2"))
+    @test isfile(joinpath(outdir_path, "versions_1.txt"))
 
-    ekobj = load(ekobj_path(res_dir, 1))["ekp"]
-    versions = readlines(joinpath(res_dir, "versions_1.txt"))
+    ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
+    versions = readlines(joinpath(outdir_path, "versions_1.txt"))
     for i in 1:config["process"]["N_ens"]
-        @test isfile(joinpath(res_dir, "scm_initializer_$(versions[i]).jld2"))
+        @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
 
     # Run one simulation and perturb results to emulate ensemble
-    scm_args = load(scm_init_path(res_dir, versions[1]))
-    priors = deserialize_prior(load(joinpath(res_dir, "prior.jld2")))
+    scm_args = load(scm_init_path(outdir_path, versions[1]))
+    priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
     model_evaluator = scm_args["model_evaluator"]
     model_evaluator = precondition(model_evaluator, priors, namelist_args = namelist_args)
     sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator, namelist_args = namelist_args)
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
-        jldsave(scm_output_path(res_dir, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
-        @test isfile(joinpath(res_dir, "scm_output_$version.jld2"))
+        jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+        @test isfile(joinpath(outdir_path, "scm_output_$version.jld2"))
     end
 
-    ek_update(ekobj, priors, 1, config, versions, res_dir)
+    ek_update(ekobj, priors, 1, config, versions, outdir_path)
 
     # Test ek_update output
-    @test isfile(joinpath(res_dir, "ekobj_iter_2.jld2"))
-    @test isfile(joinpath(res_dir, "versions_2.txt"))
-    versions = readlines(joinpath(res_dir, "versions_2.txt"))
+    @test isfile(joinpath(outdir_path, "ekobj_iter_2.jld2"))
+    @test isfile(joinpath(outdir_path, "versions_2.txt"))
+    versions = readlines(joinpath(outdir_path, "versions_2.txt"))
     for i in 1:config["process"]["N_ens"]
-        @test isfile(joinpath(res_dir, "scm_initializer_$(versions[i]).jld2"))
+        @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
-    rm(res_dir, recursive = true)
+    rm(outdir_path, recursive = true)
 end
 
-@testset "Pipeline_val_minibatch" begin
+@testset "Pipeline_with_validation" begin
 
     config["reference"]["batch_size"] = 1
     config["process"]["algorithm"] = "Unscented"
     config["validation"] = config["reference"]
     config["validation"]["batch_size"] = 1
+    config["process"]["augmented"] = true
+    config["regularization"]["l2_reg"] = 0.5
     init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"))
-    res_dir_list = glob("results_*_SCM*", config["output"]["outdir_root"])
-    res_dir = res_dir_list[1]
-    versions = readlines(joinpath(res_dir, "versions_1.txt"))
+    outdir_path_list = glob("results_*_SCM*", config["output"]["outdir_root"])
+    outdir_path = outdir_path_list[1]
+    versions = readlines(joinpath(outdir_path, "versions_1.txt"))
 
     # Run one simulation and perturb results to emulate ensemble
-    scm_args = load(scm_init_path(res_dir, versions[1]))
+    scm_args = load(scm_init_path(outdir_path, versions[1]))
     model_evaluator = scm_args["model_evaluator"]
     sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator, namelist_args = namelist_args)
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
-        jldsave(scm_output_path(res_dir, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
-        jldsave(scm_val_output_path(res_dir, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
-        @test isfile(joinpath(res_dir, "scm_output_$version.jld2"))
+        jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+        jldsave(scm_val_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+        @test isfile(joinpath(outdir_path, "scm_output_$version.jld2"))
+        @test isfile(joinpath(outdir_path, "scm_val_output_$version.jld2"))
     end
-    @test isfile(joinpath(res_dir, "ref_model_batch.jld2"))
-    ref_model_batch = load(joinpath(res_dir, "ref_model_batch.jld2"))["ref_model_batch"]
+    @test isfile(joinpath(outdir_path, "ref_model_batch.jld2"))
+    ref_model_batch = load(joinpath(outdir_path, "ref_model_batch.jld2"))["ref_model_batch"]
     @test isa(ref_model_batch.ref_models, Vector{ReferenceModel})
     @test isa(ref_model_batch.eval_order, Vector{Int64})
+    @test isfile(joinpath(outdir_path, "val_ref_model_batch.jld2"))
+    val_ref_model_batch = load(joinpath(outdir_path, "ref_model_batch.jld2"))["ref_model_batch"]
+    @test isa(val_ref_model_batch.ref_models, Vector{ReferenceModel})
+    @test isa(val_ref_model_batch.eval_order, Vector{Int64})
 
-    priors = deserialize_prior(load(joinpath(res_dir, "prior.jld2")))
-    ekobj = load(ekobj_path(res_dir, 1))["ekp"]
-    ek_update(ekobj, priors, 1, config, versions, res_dir)
+    priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+    ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
+    ek_update(ekobj, priors, 1, config, versions, outdir_path)
 
     # Test ek_update output
-    @test isfile(joinpath(res_dir, "ekobj_iter_2.jld2"))
-    @test isfile(joinpath(res_dir, "versions_2.txt"))
-    versions = readlines(joinpath(res_dir, "versions_2.txt"))
+    @test isfile(joinpath(outdir_path, "ekobj_iter_2.jld2"))
+    @test isfile(joinpath(outdir_path, "versions_2.txt"))
+    versions = readlines(joinpath(outdir_path, "versions_2.txt"))
     for i in 1:config["process"]["N_ens"]
-        @test isfile(joinpath(res_dir, "scm_initializer_$(versions[i]).jld2"))
+        @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
 end


### PR DESCRIPTION
This PR enables augmentation of the observational vector `y` with the mean of the prior over the parameters theta. This augmentation acts as an L2 regularizer on the loss. The covariance used to modulate the L2 regularization magnitude is taken as:

- The prior covariance if unspecified, and `augmented` is set to true.
- A diagonal matrix with diagonal elements equal to `l2_reg` if `l2_reg` is given, and it is a float.
-`l2_reg` if it is a matrix.