### PR TITLE
Add failsafe UKI update.

### DIFF
--- a/ekp_experimental/failsafe_inversion.jl
+++ b/ekp_experimental/failsafe_inversion.jl
@@ -8,6 +8,7 @@ using Statistics
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using EnsembleKalmanProcesses.DataStorage
+import EnsembleKalmanProcesses.EnsembleKalmanProcessModule: update_ensemble_prediction!, construct_mean, construct_cov
 
 """
      split_indices_by_success(g::Array{FT, 2}) where {FT <: Real}
@@ -153,4 +154,174 @@ function update_ensemble!(
             "\nConsider reducing the EK time step.",
         )
     end
+end
+
+
+function update_ensemble_analysis!(
+    uki::EnsembleKalmanProcess{FT, IT, Unscented},
+    u_p::Matrix{FT},
+    g::Matrix{FT},
+    failure_handler::Union{String, Nothing},
+) where {FT <: AbstractFloat, IT <: Int}
+
+    obs_mean = uki.obs_mean
+    Σ_ν = uki.process.Σ_ν_scale * uki.obs_noise_cov
+
+    ############# Prediction step:
+
+    u_p_mean = construct_mean(uki, u_p)
+    uu_p_cov = construct_cov(uki, u_p, u_p_mean)
+
+    ###########  Analysis step
+
+    #get successes and failures
+    successful_ens, failed_ens = split_indices_by_success(g)
+
+    if length(failed_ens) == 0 || isnothing(failure_handler)
+
+        g_mean = construct_mean(uki, g)
+        gg_cov = construct_cov(uki, g, g_mean) + Σ_ν
+        ug_cov = construct_cov(uki, u_p, u_p_mean, g, g_mean)
+
+        # Ignore failed particles and perform analysis using successful particles.
+    elseif failure_handler == "sample_succ_gauss"
+
+        g_mean = construct_failsafe_mean(uki, g, successful_ens)
+        gg_cov = construct_failsafe_cov(uki, g, g_mean, successful_ens) + Σ_ν
+        ug_cov = construct_failsafe_cov(uki, u_p, u_p_mean, g, g_mean, successful_ens)
+        println("Particle failure(s) detected. Handler used: $failure_handler.")
+
+    else
+        throw(ArgumentError("Failure handler $failure_handler not recognized."))
+    end
+
+    tmp = ug_cov / gg_cov
+
+    u_mean = u_p_mean + tmp * (obs_mean - g_mean)
+    uu_cov = uu_p_cov - tmp * ug_cov'
+
+    ########### Save results
+    push!(uki.process.obs_pred, g_mean) # N_ens x N_data
+    push!(uki.process.u_mean, u_mean) # N_ens x N_params
+    push!(uki.process.uu_cov, uu_cov) # N_ens x N_data
+
+    push!(uki.g, DataContainer(g, data_are_columns = true))
+
+    compute_error!(uki)
+end
+
+"""
+Failsafe construct_mean `x_mean` from ensemble `x`.
+"""
+function construct_failsafe_mean(
+    uki::EnsembleKalmanProcess{FT, IT, Unscented},
+    x::Matrix{FT},
+    successful_indices::Union{Vector{IT}, Vector{Any}},
+) where {FT <: AbstractFloat, IT <: Int}
+    N_x, N_ens = size(x)
+
+    @assert(uki.N_ens == N_ens)
+
+    x_mean = zeros(FT, N_x)
+
+    mean_weights = deepcopy(uki.process.mean_weights)
+
+    # Rescale weights to sum to unity if center did not fail
+    if 1 in successful_indices
+        mean_weights = mean_weights ./ sum(mean_weights[successful_indices])
+        # Equally weighted mean if center particle failed
+    else
+        mean_weights .= 1 / length(successful_indices)
+    end
+    for i in 1:N_ens
+        if i in successful_indices
+            x_mean += mean_weights[i] * x[:, i]
+        end
+    end
+
+    return x_mean
+end
+
+"""
+Failsafe construct_cov `xx_cov` from ensemble `x` and mean `x_mean`.
+"""
+function construct_failsafe_cov(
+    uki::EnsembleKalmanProcess{FT, IT, Unscented},
+    x::Matrix{FT},
+    x_mean::Array{FT},
+    successful_indices::Union{Vector{IT}, Vector{Any}},
+) where {FT <: AbstractFloat, IT <: Int}
+    N_ens, N_x = uki.N_ens, size(x_mean, 1)
+
+    cov_weights = deepcopy(uki.process.cov_weights)
+
+    # Rescale non-center sigma weights to sum to original value
+    orig_weight_sum = sum(cov_weights[2:end])
+    sum_indices = filter(x -> x > 1, successful_indices)
+    succ_weight_sum = sum(cov_weights[sum_indices])
+    cov_weights[2:end] = cov_weights[2:end] .* (orig_weight_sum / succ_weight_sum)
+
+    xx_cov = zeros(FT, N_x, N_x)
+
+    for i in 1:N_ens
+        if i in successful_indices
+            xx_cov .+= cov_weights[i] * (x[:, i] - x_mean) * (x[:, i] - x_mean)'
+        end
+    end
+
+    return xx_cov
+end
+
+"""
+Failsafe construct_cov `xy_cov` from ensemble x and mean `x_mean`, ensemble `obs_mean` and mean `y_mean`.
+"""
+function construct_failsafe_cov(
+    uki::EnsembleKalmanProcess{FT, IT, Unscented},
+    x::Matrix{FT},
+    x_mean::Array{FT},
+    obs_mean::Matrix{FT},
+    y_mean::Array{FT},
+    successful_indices::Union{Vector{IT}, Vector{Any}},
+) where {FT <: AbstractFloat, IT <: Int}
+    N_ens, N_x, N_y = uki.N_ens, size(x_mean, 1), size(y_mean, 1)
+
+    cov_weights = deepcopy(uki.process.cov_weights)
+
+    # Rescale non-center sigma weights to sum to original value
+    orig_weight_sum = sum(cov_weights[2:end])
+    sum_indices = filter(x -> x > 1, successful_indices)
+    succ_weight_sum = sum(cov_weights[sum_indices])
+    cov_weights[2:end] = cov_weights[2:end] .* (orig_weight_sum / succ_weight_sum)
+
+    xy_cov = zeros(FT, N_x, N_y)
+
+    for i in 1:N_ens
+        if i in successful_indices
+            xy_cov .+= cov_weights[i] * (x[:, i] - x_mean) * (obs_mean[:, i] - y_mean)'
+        end
+    end
+
+    return xy_cov
+end
+
+function update_ensemble!(
+    uki::EnsembleKalmanProcess{FT, IT, Unscented},
+    g_in::Matrix{FT};
+    failure_handler::Union{String, Nothing} = nothing,
+) where {FT <: AbstractFloat, IT <: Int}
+    #catch works when g_in non-square 
+    if !(size(g_in)[2] == uki.N_ens)
+        throw(DimensionMismatch("ensemble size in EnsembleKalmanProcess and g_in do not match, try transposing or check ensemble size"))
+    end
+
+    u_p_old = get_u_final(uki)
+
+    #perform analysis on the model runs
+    update_ensemble_analysis!(uki, u_p_old, g_in, failure_handler)
+    #perform new prediction output to model parameters u_p
+    u_p = update_ensemble_prediction!(uki.process)
+
+    push!(uki.u, DataContainer(u_p, data_are_columns = true))
+
+    return u_p
 end

--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -80,6 +80,7 @@ function get_process_config()
     config["Δt"] = 1.0
     # Whether to augment the outputs with the parameters for regularization
     config["augmented"] = false
+    config["failure_handler"] = "sample_succ_gauss"
     return config
 end
 


### PR DESCRIPTION
Adds a conditional-on-success failure handling method to the Unscented Kalman Inversion.

The handler is applied during the analysis step, by computing the ill-defined means and covariances over the successful particles. In order to preserve the sum of the weighting scheme, the weights at each successful sigma point are scaled up.

Consider a set of sigma points {θ_j}={θ_succ_j} U {θ_fail_j}, from which we have to estimate E[G], Cov(G, G) and Cov(G, θ) for the UI update rules. These would generally be computed through the quadrature rules of UKI (possibly modified following Huang et al 2021).

In the case of failed particles, i.e. {θ_fail_j} is not the empty set, for the mean of the forward model eval we do:

- E[G] ≈ ∑_succ [(∑W_j) / (∑_succ W_j) * W_j * G(θ_succ_j)] if the center particle did not fail (rescaled quadrature).
- E[G] ≈ ∑_succ G(θ_succ_j) / len({θ_succ_j}) if the center particle failed (arithmetic mean).

The second option is needed because in the modified unscented transform, W_1 = 1 and all other weights are zero.

For the covariances we scale up the weights of the off-centered sigma points and compute over the successful particles,

- Cov(G, θ) = ∑_succ [(∑_(j>1) Wc_j) / (∑_(succ, j>1) Wc_j) * Wc_j * (G(θ_succ_j) - G(m)) * (θ_succ_j - m)]
- Cov(G, G) = Wc_1 * (G(m) -E[ G]) * (G(m) -E[ G]) + ∑_succ_(j>1) [(∑_(j>1) Wc_j) / (∑_(succ, j>1) Wc_j) * Wc_j * (G(θ_succ_j) - E[G]) * (G(θ_succ_j) - E[G])]

Note that the term Wc_1 * (G(m) -E[ G]) * (G(m) -E[ G]) disappears when using the modified unscented transform because we take E[G]≈G(m). Also, notice that the rescaling is computed over the off-centered sigma points to remain consistent for both Cov(G, θ) and Cov(G, G).