### PR TITLE
Enable learning at non-native vertical resolution.

### DIFF
--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -179,6 +179,7 @@ function get_ref_model_kwargs(ref_config::Dict{Any, Any})
     Σ_dir = expand_dict_entry(ref_config, "Σ_dir", n_cases)
     Σ_t_start = expand_dict_entry(ref_config, "Σ_t_start", n_cases)
     Σ_t_end = expand_dict_entry(ref_config, "Σ_t_end", n_cases)
+    n_obs = expand_dict_entry(ref_config, "n_obs", n_cases)
     rm_kwargs = Dict(
         :y_names => ref_config["y_names"],
         # Reference path specification
@@ -193,6 +194,7 @@ function get_ref_model_kwargs(ref_config::Dict{Any, Any})
         :t_end => ref_config["t_end"],
         :Σ_t_start => Σ_t_start,
         :Σ_t_end => Σ_t_end,
+        :n_obs => n_obs,
     )
     n_RM = length(rm_kwargs[:case_name])
     for (k, v) in pairs(rm_kwargs)

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -98,8 +98,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         for m in RM
             model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, Δt) : m
             # Get (interpolated and pool-normalized) observations, get pool variance vector
-            z_scm = get_height(scm_dir(model))
-            y_, y_var_, pool_var = get_obs(model, y_type, Σ_type, normalize, z_scm = z_scm)
+            y_, y_var_, pool_var = get_obs(model, y_type, Σ_type, normalize, z_scm = get_z_obs(m))
             push!(norm_vec, pool_var)
             if perform_PCA
                 y_pca, y_var_pca, P_pca = obs_PCA(y_, y_var_, variance_loss)
@@ -282,7 +281,7 @@ function get_profile(
             "Defaulting to penalized profiles...",
         )
         for i in 1:length(var_names)
-            var_ = get_height(sim_dir)
+            var_ = isnothing(z_scm) ? get_height(sim_dir) : z_scm
             append!(y, 1.0e5 * ones(length(var_[:])))
         end
         return y
@@ -296,7 +295,7 @@ function get_profile(
                 "Defaulting to penalized profiles...",
             )
             for i in 1:length(var_names)
-                var_ = get_height(sim_dir)
+                var_ = isnothing(z_scm) ? get_height(sim_dir) : z_scm
                 append!(y, 1.0e5 * ones(length(var_[:])))
             end
             return y

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -164,9 +164,9 @@ function eval_single_ref_model(
     # run TurbulenceConvection.jl. Get output directory for simulation data
     sim_dir, model_error = run_SCM_handler(m, tmpdir, u, u_names, namelist_args)
     if model_error
-        g_scm = fill(NaN, length(get_height(sim_dir)) * length(m.y_names))
+        g_scm = fill(NaN, length(get_z_obs(m)) * length(m.y_names))
     else
-        g_scm = get_profile(m, sim_dir, z_scm = get_height(sim_dir))
+        g_scm = get_profile(m, sim_dir, z_scm = get_z_obs(m))
         g_scm = normalize_profile(g_scm, length(m.y_names), RS.norm_vec[m_index])
     end
     # perform PCA reduction

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -72,9 +72,9 @@ function eval_single_ref_model(
     # run TurbulenceConvection.jl. Get output directory for simulation data
     sim_dir, model_error = run_SCM_handler(m, tmpdir, u, u_names, namelist_args)
     if model_error
-        g_scm = fill(NaN, length(get_height(sim_dir)) * length(m.y_names))
+        g_scm = fill(NaN, length(get_z_obs(m)) * length(m.y_names))
     else
-        g_scm = get_profile(m, sim_dir, z_scm = get_height(sim_dir))
+        g_scm = get_profile(m, sim_dir, z_scm = get_z_obs(m))
         g_scm = normalize_profile(g_scm, length(m.y_names), RS.norm_vec[m_index])
     end
     # perform PCA reduction

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -126,6 +126,7 @@ end
 @testset "Pipeline_with_validation" begin
 
     config["reference"]["batch_size"] = 1
+    config["reference"]["n_obs"] = [10]
     config["process"]["algorithm"] = "Unscented"
     config["validation"] = config["reference"]
     config["validation"]["batch_size"] = 1


### PR DESCRIPTION
Adds the option to calibrate at a non-native resolution (i.e., a resolution different than the reference SCM resolution).

This is done by storing a given number of observations, `n_obs`, in each ReferenceModel object. If not nothing, then calibration is done at `n_obs` spatial locations per field, uniformly spaced between the first and last points of the reference SCM vertical domain. This decouples the vertical spacing between the training and validation set as well.