### PR TITLE
change function inputs

### DIFF
--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -30,10 +30,10 @@ mutable struct NetCDFIO_Diags
         config::Dict{Any, Any},
         outdir_path::String,
         ref_stats::ReferenceStatistics,
-        ekp::EnsembleKalmanProcess,
+        N_ens::IT,
         priors::ParameterDistribution,
         val_ref_stats::Union{ReferenceStatistics, Nothing} = nothing,
-    )
+    ) where {IT <: Integer}
 
         # Initialize properties with valid type:
         tmp = tempname()
@@ -54,7 +54,7 @@ mutable struct NetCDFIO_Diags
         NC.Dataset(filepath, "c") do root_grp
 
             # Fetch dimensionality
-            p, N_ens = size(get_u_final(ekp))
+            p = get_total_dimension(priors)
             d_full = full_length(ref_stats)
             d = pca_length(ref_stats)
             C = length(ref_stats.pca_vec)

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -704,7 +704,8 @@ function init_diagnostics(
     validation::Bool = false,
 )
     write_full_stats = get_entry(config["reference"], "write_full_stats", true)
-    diags = NetCDFIO_Diags(config, outdir_path, ref_stats, ekp, priors, val_ref_stats)
+    N_ens = size(get_u_final(ekp), 2)
+    diags = NetCDFIO_Diags(config, outdir_path, ref_stats, N_ens, priors, val_ref_stats)
     # Write prior and reference diagnostics
     io_prior(diags, priors)
     io_reference(diags, ref_stats, ref_models, write_full_stats)

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -48,7 +48,8 @@ using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
     config["reference"] = Dict()
     priors = construct_priors(config["prior"]["constraints"])
     ekp = EnsembleKalmanProcess(rand(2, 10), ref_stats.y, ref_stats.Γ, Inversion())
-    diags = NetCDFIO_Diags(config, data_dir, ref_stats, ekp, priors)
+    N_ens = size(get_u_final(ekp), 2)
+    diags = NetCDFIO_Diags(config, data_dir, ref_stats, N_ens, priors)
 
     # Test constructor
     @test isa(diags, NetCDFIO_Diags)


### PR DESCRIPTION
I am changing the input vars for NetCDFIO_Diags so that in my future PR with grid search I can all 'NetCDFIO_Diags' without 'ekp' as input