### PR TITLE
handle vector of prior mean, constraints consistently

### DIFF
--- a/src/DistributionUtils.jl
+++ b/src/DistributionUtils.jl
@@ -47,13 +47,13 @@ Output:
 function construct_priors(
     params::Dict{String, Vector{Constraint}};
     unconstrained_σ::Float64 = 1.0,
-    prior_mean::Union{Vector{Float64}, Nothing} = nothing,
+    prior_mean::Union{Dict{String, Vector{Float64}}, Nothing} = nothing,
     outdir_path::String = pwd(),
     to_file::Bool = true,
 )
     # if parameter vectors found => flatten
     if any(1 .< [length(val) for val in collect(values(params))])
-        u_names, constraints = flatten_param_dict(params)
+        u_names, constraints = flatten_config_dict(params)
     else
         u_names = collect(keys(params))
         constraints = collect(values(params))
@@ -65,40 +65,47 @@ function construct_priors(
     if isnothing(prior_mean)
         distributions = repeat([Parameterized(Normal(0.0, unconstrained_σ))], n_param)
     else
+        if any(1 .< [length(val) for val in collect(values(prior_mean))])
+            u_names_mean, prior_mean = flatten_config_dict(prior_mean)
+            @assert u_names_mean == u_names
+        else
+            prior_mean = collect(values(prior_mean))
+        end
         @assert length(prior_mean) == n_param
-        uncons_prior_mean = [c[1].constrained_to_unconstrained(μ_cons) for (μ_cons, c) in zip(prior_mean, constraints)]
-        distributions = [Parameterized(Normal(uncons_μ, unconstrained_σ)) for uncons_μ in uncons_prior_mean]
+        uncons_prior_mean =
+            [c[1].constrained_to_unconstrained(μ_cons[1]) for (μ_cons, c) in zip(prior_mean, constraints)]
+        distributions = [Parameterized(Normal(uncons_μ[1], unconstrained_σ)) for uncons_μ in uncons_prior_mean]
     end
     to_file ? jldsave(joinpath(outdir_path, "prior.jld2"); distributions, constraints, u_names) : nothing
     return ParameterDistribution(distributions, constraints, u_names)
 end
 
 """
-    flatten_param_dict(param_dict::Dict{String, Vector{Constraint}})
+    flatten_config_dict(param_dict::Dict{String, Vector{T}})
 
-For parameter names that correspond to vectors, assign unique name to each vector component.
+For parameter names that correspond to vectors, assign a unique name to each vector component and treat as independent parameter.
 Inputs:
     param_dict :: Dictionary of parameter names to constraints.
 Outputs:
     u_names :: Vector{String} :: vector of parameter names
-    constraints :: Vector{Vector{Constraint}} :: vector of constraints
+    values :: Vector{Vector{T}} :: vector
 """
-function flatten_param_dict(param_dict::Dict{String, Vector{Constraint}})
+function flatten_config_dict(param_dict::Dict{String, Vector{T}}) where {T}
 
     u_names = Vector{String}()
-    constraints = Vector{Vector{Constraint}}()
+    values = Vector{Vector{T}}()
     for (param, value) in param_dict
         if length(value) > 1
             for j in 1:length(value)
                 push!(u_names, "$(param)_{$j}")
-                push!(constraints, [value[j]])
+                push!(values, [value[j]])
             end
         else
             push!(u_names, param)
-            push!(constraints, value)
+            push!(values, value)
         end
     end
-    return (u_names, constraints)
+    return (u_names, values)
 end
 
 """

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -57,7 +57,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
 
     params = config["prior"]["constraints"]
     unc_σ = get_entry(config["prior"], "unconstrained_σ", 1.0)
-    prior_μ_dict = get_entry(config["prior"], "prior_mean", nothing)
+    prior_μ = get_entry(config["prior"], "prior_mean", nothing)
 
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 
@@ -105,9 +105,8 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         y_ref_type,
     )
 
-    if !isnothing(prior_μ_dict)
-        @assert collect(keys(params)) == collect(keys(prior_μ_dict))
-        prior_μ = collect(values(prior_μ_dict))
+    if !isnothing(prior_μ)
+        @assert collect(keys(params)) == collect(keys(prior_μ))
     else
         prior_μ = nothing
     end

--- a/test/DistributionUtils/runtests.jl
+++ b/test/DistributionUtils/runtests.jl
@@ -25,15 +25,48 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     @test priors2.names != priors1.names
     @test priors2.constraints != priors1.constraints
 
-    μ_correct = [0.4, 0.5]
-    μ_incorrect1 = [0.0, 2.5] # Out of bounds
-    μ_incorrect2 = [0.1] # Incorrect shape
+    μ_correct = Dict("foo" => [0.4], "bar" => [0.5])
+    μ_incorrect1 = Dict("foo" => [0.0], "bar" => [2.5]) # Out of bounds
+    μ_incorrect2 = Dict("foo" => [0.1]) # Incorrect shape
     priors3 = construct_priors(params, outdir_path = tmpdir, prior_mean = μ_correct)
 
     @test !isempty(readdir(tmpdir))
     @test readdir(tmpdir)[1] == "prior.jld2"
     @test_throws AssertionError construct_priors(params, outdir_path = tmpdir, prior_mean = μ_incorrect2)
     @test_throws DomainError construct_priors(params, outdir_path = tmpdir, prior_mean = μ_incorrect1)
+end
+
+@testset "Prior Vectors" begin
+    tmpdir = mktempdir()
+    unc_σ = 0.5
+
+    # vector and float -> correct
+    params = Dict("foo" => [bounded(0.1, 1.0)], "bar_vect" => [no_constraint(), bounded(-3.0, 3.0), no_constraint()])
+    prior_μ = Dict("foo" => [0.4], "bar_vect" => [1.0, 2.0, 3.0])
+    priors = construct_priors(params, outdir_path = tmpdir, unconstrained_σ = unc_σ, prior_mean = prior_μ)
+
+    @test priors.names == ["bar_vect_{1}", "bar_vect_{2}", "bar_vect_{3}", "foo"]
+    @test priors.constraints == [no_constraint(), bounded(-3.0, 3.0), no_constraint(), bounded(0.1, 1.0)]
+    @test priors.distributions[1].distribution.μ == 1.0
+    @test priors.distributions[2].distribution.μ ==
+          params["bar_vect"][2].constrained_to_unconstrained(prior_μ["bar_vect"][2])
+    @test priors.distributions[4].distribution.μ == params["foo"][1].constrained_to_unconstrained(prior_μ["foo"][1])
+
+    # length mismatch [length(bar_vect mu) != length(bar_vect constraint)]
+    params = Dict("foo" => [bounded(0.1, 1.0)], "bar_vect" => [repeat([no_constraint()], 3)...])
+    prior_μ = Dict("foo" => [0.4], "bar_vect" => ones(2))
+    @test_throws AssertionError construct_priors(
+        params,
+        outdir_path = tmpdir,
+        unconstrained_σ = unc_σ,
+        prior_mean = prior_μ,
+    )
+
+    # unspecified prior mean should yield μ=0
+    params = Dict("foo" => [bounded(0.1, 1.0)], "bar_vect" => [repeat([no_constraint()], 3)...])
+    priors = construct_priors(params, outdir_path = tmpdir, unconstrained_σ = unc_σ)
+    @test [priors.distributions[i].distribution.μ for i in 1:length(priors.distributions)] == zeros(length(priors.distributions))
+
 end
 
 @testset "Transformations" begin
@@ -48,13 +81,13 @@ end
 
 end
 
-@testset "Vectors" begin
+@testset "flatten_config_dict" begin
     foo_constraint = [bounded(0.1, 1.0)]
     bar_constraint = [bounded(0.2, 2.0)]
     vect_constraint = [repeat([bounded(-1.0, 1.0)], 2)..., bounded(-0.5, 0.5)]
 
     params = Dict("foo" => foo_constraint, "bar" => bar_constraint, "vect" => vect_constraint)
-    flattened_names, flattened_values = DistributionUtils.flatten_param_dict(params)
+    flattened_names, flattened_values = DistributionUtils.flatten_config_dict(params)
     @test flattened_names == ["bar", "vect_{1}", "vect_{2}", "vect_{3}", "foo"]
     @test flattened_values[1] == bar_constraint
     @test flattened_values[2][1] == vect_constraint[1]

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -40,9 +40,9 @@ run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = nameli
 
     # Different configurations
     prior_means = [
-        Dict("entrainment_factor" => 0.15, "detrainment_factor" => 0.4),
+        Dict("entrainment_factor" => [0.15], "detrainment_factor" => [0.4]),
         nothing,
-        Dict("entrainment_factor" => 0.1, "detrainment_factor" => 0.2),
+        Dict("entrainment_factor" => [0.1], "detrainment_factor" => [0.2]),
     ]
     batch_sizes = [nothing, 1, nothing]
     augments = [true, true, false]


### PR DESCRIPTION
Allow for vector of prior means + make data structures for prior means + constraints consistent. This will require prior means to be specified with a `Vector{Float64}` in the config file in the same manner as constraints. (ie `"surface_area" => [0.1]`)