### PR TITLE
Add batch-specific diagnostics.

### DIFF
--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -53,28 +53,32 @@ mutable struct NetCDFIO_Diags
 
         NC.Dataset(filepath, "c") do root_grp
 
-            # Fetch dimensionality
+            # Parameter dimension
             p = ndims(priors)
+            # Output dimension for global problem: full and low-dim encoding
             d_full = full_length(ref_stats)
             d = pca_length(ref_stats)
+
+            # Number of configurations, and fields per configuration
             C = length(ref_stats.pca_vec)
             f = length(ref_stats.norm_vec[1])
+            # Number of configuration per batch
             batch_size = get_entry(config["reference"], "batch_size", length(ref_stats.pca_vec))
             batch_size = isnothing(batch_size) ? length(ref_stats.pca_vec) : batch_size
+            # Output dimension for batched problem, low-dim enconding varies per batch
+            d_full_batch = Int(d_full * batch_size / C)
 
             particle = Array(1:N_ens)
-            out = Array(1:d)
+            param = priors.names
             out_full = Array(1:d_full)
+            out = Array(1:d)
             configuration = Array(1:C)
             field = Array(1:f)
-            param = priors.names
+            batch_index = Array(1:batch_size)
+            out_full_batch = Array(1:d_full_batch)
 
             # Ensemble diagnostics (over all particles)
             ensemble_grp = NC.defGroup(root_grp, "ensemble_diags")
-            NC.defDim(ensemble_grp, "out_full", d_full)
-            NC.defVar(ensemble_grp, "out_full", out_full, ("out_full",))
-            NC.defDim(ensemble_grp, "out", d)
-            NC.defVar(ensemble_grp, "out", out, ("out",))
             NC.defDim(ensemble_grp, "param", p)
             NC.defVar(ensemble_grp, "param", param, ("param",))
             NC.defDim(ensemble_grp, "iteration", Inf)
@@ -95,18 +99,26 @@ mutable struct NetCDFIO_Diags
             NC.defVar(reference_grp, "config", configuration, ("config",))
             NC.defDim(reference_grp, "config_field", f)
             NC.defVar(reference_grp, "config_field", field, ("config_field",))
-            NC.defDim(reference_grp, "batch_size", batch_size)
+
+            augmented = get_entry(config["process"], "augmented", false)
+            if augmented
+                d = d + p
+            end
 
             # Particle diagnostics
             particle_grp = NC.defGroup(root_grp, "particle_diags")
             NC.defDim(particle_grp, "particle", N_ens)
             NC.defVar(particle_grp, "particle", particle, ("particle",))
-            NC.defDim(particle_grp, "out_full", d_full)
-            NC.defVar(particle_grp, "out_full", out_full, ("out_full",))
-            NC.defDim(particle_grp, "out", d)
-            NC.defVar(particle_grp, "out", out, ("out",))
+            NC.defDim(particle_grp, "out_full_batch", d_full_batch)
+            NC.defVar(particle_grp, "out_full_batch", out_full_batch, ("out_full_batch",))
+            NC.defDim(particle_grp, "out_aug", d)
+            NC.defVar(particle_grp, "out_aug", Array(1:d), ("out_aug",))
             NC.defDim(particle_grp, "param", p)
             NC.defVar(particle_grp, "param", param, ("param",))
+            NC.defDim(particle_grp, "config", C)
+            NC.defVar(particle_grp, "config", configuration, ("config",))
+            NC.defDim(particle_grp, "batch_index", batch_size)
+            NC.defVar(particle_grp, "batch_index", batch_index, ("batch_index",))
             NC.defDim(particle_grp, "iteration", Inf)
             NC.defVar(particle_grp, "iteration", Int16, ("iteration",))
 
@@ -117,16 +129,23 @@ mutable struct NetCDFIO_Diags
                 f_val = length(val_ref_stats.norm_vec[1])
                 batch_size_val = get_entry(config["validation"], "batch_size", length(val_ref_stats.pca_vec))
                 batch_size_val = isnothing(batch_size_val) ? length(val_ref_stats.pca_vec) : batch_size_val
+                d_full_batch_val = Int(d_full_val * batch_size_val / C_val)
 
-                out_val = Array(1:d_val)
                 out_full_val = Array(1:d_full_val)
+                out_val = Array(1:d_val)
                 configuration_val = Array(1:C_val)
                 field_val = Array(1:f_val)
+                batch_index_val = Array(1:batch_size_val)
+                out_full_batch_val = Array(1:d_full_batch_val)
 
-                NC.defDim(particle_grp, "out_full_val", d_full_val)
-                NC.defVar(particle_grp, "out_full_val", out_full_val, ("out_full_val",))
+                NC.defDim(particle_grp, "out_full_batch_val", d_full_val)
+                NC.defVar(particle_grp, "out_full_batch_val", out_full_batch_val, ("out_full_batch_val",))
                 NC.defDim(particle_grp, "out_val", d_val)
                 NC.defVar(particle_grp, "out_val", out_val, ("out_val",))
+                NC.defDim(particle_grp, "batch_index_val", batch_size_val)
+                NC.defVar(particle_grp, "batch_index_val", batch_index_val, ("batch_index_val",))
+                NC.defDim(particle_grp, "config_val", C_val)
+                NC.defVar(particle_grp, "config_val", configuration_val, ("config_val",))
 
                 NC.defDim(reference_grp, "out_full_val", d_full_val)
                 NC.defVar(reference_grp, "out_full_val", out_full_val, ("out_full_val",))
@@ -136,7 +155,7 @@ mutable struct NetCDFIO_Diags
                 NC.defVar(reference_grp, "config_val", configuration_val, ("config_val",))
                 NC.defDim(reference_grp, "config_field_val", f_val)
                 NC.defVar(reference_grp, "config_field_val", field_val, ("config_field_val",))
-                NC.defDim(reference_grp, "batch_size_val", batch_size_val)
+
             end
 
             # Calibration metrics
@@ -200,7 +219,15 @@ function write_current(diags::NetCDFIO_Diags, var_name::String, data; group)
     var = diags.vars[group][var_name]
     last_dim = length(size(var))
     last_dim_end = size(var, last_dim)
-    selectdim(var, last_dim, last_dim_end) .= data
+    try
+        selectdim(var, last_dim, last_dim_end) .= data
+    catch e
+        @error string(
+            "Failed to write array of dimension $(size(data)) as $var_name",
+            " to NetCDF file. Expected array of dimension $(size(var)[1:end-1]).",
+        )
+        e
+    end
 end
 
 """Writes all current fields in a given io_dict to an existing NetCDF Dataset."""
@@ -326,15 +353,15 @@ end
 function io_val_particle_diags(
     diags::NetCDFIO_Diags,
     mse_full::Vector{FT},
-    g::Union{Matrix{FT}, Nothing} = nothing,
-    g_full::Union{Matrix{FT}, Nothing} = nothing,
+    g::Matrix{FT},
+    g_full::Matrix{FT},
+    batch_indices::Union{Vector{Int}, Nothing},
 ) where {FT <: Real}
+    # If not minibatching - training set size
+    batch_indices = isnothing(batch_indices) ? Array(diags.particle_grp["config_val"]) : batch_indices
+
     # Write eval diagnostics to file
-    if !isnothing(g_full)
-        io_dict = io_dictionary_val_particle_eval(g, g_full, mse_full)
-    else
-        io_dict = io_dictionary_val_particle_eval(mse_full)
-    end
+    io_dict = io_dictionary_val_particle_eval(g, g_full, mse_full, batch_indices)
     write_current_dict(diags, io_dict)
 end
 
@@ -342,16 +369,16 @@ function io_particle_diags_eval(
     diags::NetCDFIO_Diags,
     ekp::EnsembleKalmanProcess,
     mse_full::Vector{FT},
-    g_full::Union{Matrix{FT}, Nothing} = nothing,
+    g_full::Matrix{FT},
+    batch_indices::Union{Vector{Int}, Nothing},
 ) where {FT <: Real}
     # Dimension of the outputs - not augmented
-    d = length(diags.ensemble_grp["out"])
+    d = length(diags.particle_grp["out_aug"])
+    # If not minibatching - training set size
+    batch_indices = isnothing(batch_indices) ? Array(diags.particle_grp["config"]) : batch_indices
+
     # Write eval diagnostics to file
-    if !isnothing(g_full)
-        io_dict = io_dictionary_particle_eval(ekp, g_full, mse_full, d)
-    else
-        io_dict = io_dictionary_particle_eval(ekp, mse_full)
-    end
+    io_dict = io_dictionary_particle_eval(ekp, g_full, mse_full, d, batch_indices)
     write_current_dict(diags, io_dict)
 end
 
@@ -369,12 +396,13 @@ function io_diagnostics(
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
     mse_full::Vector{FT},
-    g_full::Union{Matrix{FT}, Nothing} = nothing,
+    g_full::Matrix{FT},
+    batch_indices::Union{Vector{Int}, Nothing},
 ) where {FT <: Real}
     open_files(diags)
     # Eval diagnostics
     io_metrics(diags, ekp, mse_full)
-    io_particle_diags_eval(diags, ekp, mse_full, g_full)
+    io_particle_diags_eval(diags, ekp, mse_full, g_full, batch_indices)
     write_iteration(diags)
     # State diagnostics
     io_particle_diags_state(diags, ekp, priors)
@@ -386,12 +414,13 @@ function io_val_diagnostics(
     diags::NetCDFIO_Diags,
     ekp::EnsembleKalmanProcess,
     mse_full::Vector{FT},
-    g::Union{Matrix{FT}, Nothing} = nothing,
-    g_full::Union{Matrix{FT}, Nothing} = nothing,
+    g::Matrix{FT},
+    g_full::Matrix{FT},
+    batch_indices::Union{Vector{Int}, Nothing},
 ) where {FT <: Real}
     open_files(diags)
     io_val_metrics(diags, ekp, mse_full)
-    io_val_particle_diags(diags, mse_full, g, g_full)
+    io_val_particle_diags(diags, mse_full, g, g_full, batch_indices)
     close_files(diags)
 end
 

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -76,7 +76,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         global_ref_models = deepcopy(ref_model_batch.ref_models)
         # Create input scm stats and namelist file if files don't already exist
         run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
-        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
         # Generate global reference statistics for diagnostics
@@ -89,6 +89,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
         io_ref_stats = ref_stats
         io_ref_models = ref_models
+        batch_indices = nothing
     end
 
     outdir_path = create_output_dir(
@@ -131,7 +132,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
     params = [c[:] for c in eachcol(params_cons_i)]
     mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
-    versions = generate_scm_input(mod_evaluators, outdir_path)
+    versions = generate_scm_input(mod_evaluators, outdir_path, batch_indices)
     # Store version identifiers for this ensemble in a common file
     write_versions(versions, 1, outdir_path = outdir_path)
     # Store ReferenceModelBatch
@@ -153,17 +154,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     )
 
     # Diagnostics IO
-    init_diagnostics(
-        config,
-        outdir_path,
-        io_ref_models,
-        io_ref_stats,
-        ekobj,
-        priors,
-        val_ref_models,
-        val_ref_stats,
-        !isnothing(val_config),
-    )
+    init_diagnostics(config, outdir_path, io_ref_models, io_ref_stats, ekobj, priors, val_ref_models, val_ref_stats)
 
     if mode == "hpc"
         open("$(job_id).txt", "w") do io
@@ -272,19 +263,20 @@ function init_validation(
         @info "Validation using mini-batches."
         ref_model_batch = construct_ref_model_batch(kwargs_ref_model)
         run_reference_SCM.(ref_model_batch.ref_models, overwrite = overwrite, namelist_args = namelist_args)
-        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
         write_val_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
     else
         ref_models = construct_reference_models(kwargs_ref_model)
         run_reference_SCM.(ref_models, overwrite = overwrite, namelist_args = namelist_args)
+        batch_indices = nothing
     end
     ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp))
     params = [c[:] for c in eachcol(params_cons_i)]
     mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
     [
-        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version)
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices)
         for (model_evaluator, version) in zip(mod_evaluators, versions)
     ]
     return ref_models, ref_stats
@@ -327,7 +319,7 @@ function update_validation(
 
     if !isnothing(batch_size)
         ref_model_batch = load(joinpath(outdir_path, "val_ref_model_batch.jld2"))["ref_model_batch"]
-        ref_models = get_minibatch!(ref_model_batch, batch_size)
+        ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
         kwargs_ref_stats = get_ref_stats_kwargs(val_config, reg_config)
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
@@ -337,6 +329,7 @@ function update_validation(
         mod_evaluator = load(scm_val_output_path(outdir_path, versions[1]))["model_evaluator"]
         ref_models = mod_evaluator.ref_models
         ref_stats = mod_evaluator.ref_stats
+        batch_indices = nothing
     end
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp_old))
     params = [c[:] for c in eachcol(params_cons_i)]
@@ -344,7 +337,7 @@ function update_validation(
     # Save new ModelEvaluators using the new versions
     versions = readlines(joinpath(outdir_path, "versions_$(iteration + 1).txt"))
     [
-        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version)
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices)
         for (model_evaluator, version) in zip(mod_evaluators, versions)
     ]
     return
@@ -395,7 +388,9 @@ function ek_update(
 
     val_config = get(config, "validation", nothing)
 
-    mod_evaluator = load(scm_output_path(outdir_path, versions[1]))["model_evaluator"]
+    scm_args = load(scm_output_path(outdir_path, versions[1]))
+    mod_evaluator = scm_args["model_evaluator"]
+    batch_indices = scm_args["batch_indices"]
     ref_stats = mod_evaluator.ref_stats
     ref_models = mod_evaluator.ref_models
 
@@ -422,13 +417,13 @@ function ek_update(
     end
 
     # Diagnostics IO
-    update_diagnostics(outdir_path, ekobj, priors, ref_stats, g_full, batch_size, versions, val_config)
+    update_diagnostics(outdir_path, ekobj, priors, ref_stats, g_full, versions, val_config, batch_indices)
 
     if iteration < N_iter
         # Prepare updated EKP and ReferenceModelBatch if minibatching.
         if !isnothing(batch_size)
             ref_model_batch = load(joinpath(outdir_path, "ref_model_batch.jld2"))["ref_model_batch"]
-            ekp, ref_models, ref_stats, ref_model_batch =
+            ekp, ref_models, ref_stats, ref_model_batch, batch_indices =
                 update_minibatch_inverse_problem(ref_model_batch, ekobj, priors, batch_size, outdir_path, config)
             rm(joinpath(outdir_path, "ref_model_batch.jld2"))
             write_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
@@ -438,7 +433,7 @@ function ek_update(
 
         # Write to file new EKP and ModelEvaluators
         jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
-        write_model_evaluators(ekp, priors, ref_models, ref_stats, outdir_path, iteration)
+        write_model_evaluators(ekp, priors, ref_models, ref_stats, outdir_path, iteration, batch_indices)
 
         # Update validation ModelEvaluators
         if !isnothing(val_config)
@@ -553,11 +548,12 @@ function versioned_model_eval(version::Union{String, Int}, outdir_path::String, 
     # Check consistent failure method for given algorithm
     @assert failure_handler == "sample_succ_gauss" ? config["process"]["algorithm"] != "Sampler" : true
     model_evaluator = scm_args["model_evaluator"]
+    batch_indices = scm_args["batch_indices"]
     # Eval
     sim_dirs, g_scm, g_scm_pca =
         run_SCM(model_evaluator, namelist_args = namelist_args, failure_handler = failure_handler)
     # Store output and delete input
-    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version, batch_indices)
     rm(input_path)
 end
 
@@ -596,7 +592,7 @@ function update_minibatch_inverse_problem(
 )
     # Construct new reference minibatch, new ref_stats, and new ekp
     ref_model_batch = deepcopy(rm_batch)
-    ref_models = get_minibatch!(ref_model_batch, batch_size)
+    ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
     ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
 
     ref_config = config["reference"]
@@ -639,7 +635,7 @@ function update_minibatch_inverse_problem(
     else
         throw(ArgumentError("Process must be an Inversion, Sampler or Unscented Kalman process."))
     end
-    return ekp, ref_models, ref_stats, ref_model_batch
+    return ekp, ref_models, ref_stats, ref_model_batch, batch_indices
 end
 
 """
@@ -669,11 +665,12 @@ function write_model_evaluators(
     ref_stats::ReferenceStatistics,
     outdir_path::String,
     iteration::Int,
+    batch_indices::Union{Vector{Int}, Nothing} = nothing,
 )
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp))
     params = [c[:] for c in eachcol(params_cons_i)]
     mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
-    versions = generate_scm_input(mod_evaluators, outdir_path)
+    versions = generate_scm_input(mod_evaluators, outdir_path, batch_indices)
     # Store version identifiers for this ensemble in a common file
     write_versions(versions, iteration + 1, outdir_path = outdir_path)
     return
@@ -705,9 +702,8 @@ function init_diagnostics(
     ref_stats::ReferenceStatistics,
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
-    val_ref_models::Union{Vector{ReferenceModel}, Nothing},
-    val_ref_stats::Union{ReferenceStatistics, Nothing},
-    validation::Bool = false,
+    val_ref_models::Union{Vector{ReferenceModel}, Nothing} = nothing,
+    val_ref_stats::Union{ReferenceStatistics, Nothing} = nothing,
 )
     write_full_stats = get_entry(config["reference"], "write_full_stats", true)
     N_ens = size(get_u_final(ekp), 2)
@@ -720,7 +716,7 @@ function init_diagnostics(
     init_metrics(diags)
     init_ensemble_diags(diags, ekp, priors)
     init_particle_diags(diags, ekp, priors)
-    if validation
+    if !isnothing(val_ref_models)
         write_full_stats = get_entry(config["validation"], "write_full_stats", true)
         init_val_diagnostics(diags, val_ref_stats, val_ref_models, write_full_stats)
     end
@@ -738,9 +734,9 @@ and the next iteration state (i.e., parameters and parameter metrics) to a diagn
     - priors:: Prior distributions of the parameters.
     - ref_stats :: ReferenceStatistics.
     - g_full :: The forward model evaluation in primitive space.
-    - batch_size :: The number of evaluations per minibatch, if minibatching.
     - versions :: Version identifiers of the forward model evaluations at the current iteration.
     - val_config :: The validation configuration, if given.
+    - batch_indices :: The indices of the ReferenceModels used in the current batch.
 """
 function update_diagnostics(
     outdir_path::String,
@@ -748,41 +744,35 @@ function update_diagnostics(
     priors::ParameterDistribution,
     ref_stats::ReferenceStatistics,
     g_full::Array{FT, 2},
-    batch_size::Union{Int, Nothing},
     versions::Union{Vector{Int}, Vector{String}},
     val_config::Union{Dict{Any, Any}, Nothing} = nothing,
+    batch_indices::Union{Vector{Int}, Nothing} = nothing,
 ) where {FT <: Real}
 
     if !isnothing(val_config)
-        update_val_diagnostics(outdir_path, ekp, versions, val_config)
+        update_val_diagnostics(outdir_path, ekp, versions)
     end
     mse_full = compute_mse(g_full, ref_stats.y_full)
     diags = NetCDFIO_Diags(joinpath(outdir_path, "Diagnostics.nc"))
-    if isnothing(batch_size)
-        io_diagnostics(diags, ekp, priors, mse_full, g_full)
-    else
-        io_diagnostics(diags, ekp, priors, mse_full)
-    end
+
+    io_diagnostics(diags, ekp, priors, mse_full, g_full, batch_indices)
 end
 
 function update_val_diagnostics(
     outdir_path::String,
     ekp::EnsembleKalmanProcess,
     versions::Union{Vector{Int}, Vector{String}},
-    val_config::Dict{Any, Any},
 ) where {FT <: Real}
-    batch_size = get_entry(val_config, "batch_size", nothing)
-    mod_evaluator = load(scm_val_output_path(outdir_path, versions[1]))["model_evaluator"]
+    scm_args = load(scm_val_output_path(outdir_path, versions[1]))
+    mod_evaluator = scm_args["model_evaluator"]
+    val_batch_indices = scm_args["batch_indices"]
     ref_stats = mod_evaluator.ref_stats
     g, g_full = get_ensemble_g_eval(outdir_path, versions, validation = true)
     # Compute diagnostics
     mse_full = compute_mse(g_full, ref_stats.y_full)
     diags = NetCDFIO_Diags(joinpath(outdir_path, "Diagnostics.nc"))
-    if isnothing(batch_size)
-        io_val_diagnostics(diags, ekp, mse_full, g, g_full)
-    else
-        io_val_diagnostics(diags, ekp, mse_full)
-    end
+
+    io_val_diagnostics(diags, ekp, mse_full, g, g_full, val_batch_indices)
 end
 
 end # module

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -271,11 +271,12 @@ Inputs:
  - batch_size      :: The number of `ReferenceModel`s to retrieve.
 Outputs:
  - A vector of `ReferenceModel`s.
+ - The indices of the returned `ReferenceModel`s.
 """
 function get_minibatch!(ref_model_batch::ReferenceModelBatch, batch_size::Int)
     batch = min(batch_size, length(ref_model_batch.eval_order))
     indices = [pop!(ref_model_batch.eval_order) for i in 1:batch]
-    return ref_model_batch.ref_models[indices]
+    return ref_model_batch.ref_models[indices], indices
 end
 
 "Restarts a shuffled evaluation order if the current epoch has finished."

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -373,6 +373,7 @@ assigned numerical version.
 function generate_scm_input(
     model_evaluators::Vector{ModelEvaluator{FT}},
     outdir_path::String = pwd(),
+    batch_indices::Union{Vector{Int}, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     # Generate versions conditioned on being unique within the batch.
     used_versions = Vector{Int}()
@@ -381,7 +382,7 @@ function generate_scm_input(
         while version in used_versions
             version = rand(11111:99999)
         end
-        jldsave(scm_init_path(outdir_path, version); model_evaluator, version)
+        jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
         push!(used_versions, version)
     end
     return used_versions

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -103,6 +103,7 @@ function versioned_model_eval_parallel(
     scm_args = load(input_path)
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
     model_evaluator = scm_args["model_evaluator"]
+    batch_indices = scm_args["batch_indices"]
     # Eval
     failure_handler = get_entry(config["process"], "failure_handler", "high_loss")
 
@@ -110,6 +111,6 @@ function versioned_model_eval_parallel(
         run_SCM_parallel(model_evaluator, namelist_args = namelist_args, failure_handler = failure_handler)
 
     # Store output and delete input
-    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+    jldsave(output_path; sim_dirs, g_scm, g_scm_pca, model_evaluator, version, batch_indices)
     rm(input_path)
 end

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -97,6 +97,7 @@ end
 
     # Run one simulation and perturb results to emulate ensemble
     scm_args = load(scm_init_path(outdir_path, versions[1]))
+    batch_indices = scm_args["batch_indices"]
     priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
     model_evaluator = scm_args["model_evaluator"]
     model_evaluator = precondition(model_evaluator, priors, namelist_args = namelist_args)
@@ -104,7 +105,15 @@ end
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
-        jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+        jldsave(
+            scm_output_path(outdir_path, version);
+            sim_dirs,
+            g_scm,
+            g_scm_pca,
+            model_evaluator,
+            version,
+            batch_indices,
+        )
         @test isfile(joinpath(outdir_path, "scm_output_$version.jld2"))
     end
 
@@ -136,13 +145,30 @@ end
 
     # Run one simulation and perturb results to emulate ensemble
     scm_args = load(scm_init_path(outdir_path, versions[1]))
+    batch_indices = scm_args["batch_indices"]
     model_evaluator = scm_args["model_evaluator"]
     sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator, namelist_args = namelist_args)
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
-        jldsave(scm_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
-        jldsave(scm_val_output_path(outdir_path, version); sim_dirs, g_scm, g_scm_pca, model_evaluator, version)
+        jldsave(
+            scm_output_path(outdir_path, version);
+            sim_dirs,
+            g_scm,
+            g_scm_pca,
+            model_evaluator,
+            version,
+            batch_indices,
+        )
+        jldsave(
+            scm_val_output_path(outdir_path, version);
+            sim_dirs,
+            g_scm,
+            g_scm_pca,
+            model_evaluator,
+            version,
+            batch_indices,
+        )
         @test isfile(joinpath(outdir_path, "scm_output_$version.jld2"))
         @test isfile(joinpath(outdir_path, "scm_val_output_$version.jld2"))
     end

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -41,9 +41,10 @@ end
     @test length(ref_model_batch.eval_order) == 2
 
     # Get a minibatch and check that the eval order shrinks
-    ref_models = get_minibatch!(ref_model_batch, 1)
+    ref_models, model_indices = get_minibatch!(ref_model_batch, 1)
 
     @test isa(ref_models, Vector{ReferenceModel})
+    @test isa(model_indices, Vector{Int})
     @test length(ref_model_batch.ref_models) == 2
     @test length(ref_model_batch.eval_order) == 1
 end


### PR DESCRIPTION
- Adds information about ReferenceModels used per iteration when using batches of data.
- Stores forward model evaluations in Diagnostics even when using batching. These forward model evaluations correspond to the output of ReferenceModels indexed by `batch_indices`.
- Writes to file the diagonal of the full covariance matrix, needed to de-normalize profiles and recover the uncertainty used in the inverse problem. This avoids the need to store the full covariance matrix, which can be extremely large.