### PR TITLE
Return control even if preconditioner fails.

### DIFF
--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -488,7 +488,8 @@ function precondition(
             max_counter = max_counter,
         )
     elseif model_error
-        throw(OverflowError("Number of recursive calls to preconditioner exceeded $(max_counter). Terminating."))
+        @error "Number of recursive calls to preconditioner exceeded $(max_counter). Returning last failed parameter."
+        return param
     else
         @info "Preconditioning finished."
         return param


### PR DESCRIPTION
Prior behavior:

- Calibration process fails during the preconditioning step if preconditioning does not result in a successful ensemble after `max_counter` samples of the prior.

New behavior:

- Preconditioner is run until `max_counter` is encountered or preconditioning is successful. Control is then returned without throwing an error, only logging an error message if `max_counter` is reached.