### PR TITLE
Perform unit tests on buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,78 @@ steps:
 
   - wait
 
+  - label: "helper_funcs"
+    key: "cpu_helper_funcs"
+    command:
+      - "julia --color=yes --project test/helper_funcs/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "DistributionUtils"
+    key: "cpu_distributionutils"
+    command:
+      - "julia --color=yes --project test/DistributionUtils/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "LESUtils"
+    key: "cpu_lesutils"
+    command:
+      - "julia --color=yes --project test/LESUtils/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "TurbulenceConvectionUtils"
+    key: "cpu_turbulenceconvectionutils"
+    command:
+      - "julia --color=yes --project test/TurbulenceConvectionUtils/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "ReferenceModels"
+    key: "cpu_referencemodels"
+    command:
+      - "julia --color=yes --project test/ReferenceModels/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "ReferenceStats"
+    key: "cpu_referencestats"
+    command:
+      - "julia --color=yes --project test/ReferenceStats/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "Pipeline"
+    key: "cpu_pipeline"
+    command:
+      - "julia --color=yes --project test/Pipeline/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "NetCDFIO"
+    key: "cpu_netcdfio"
+    command:
+      - "julia --color=yes --project test/NetCDFIO/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
   - label: "Calibrate julia parallel"
     key: "cpu_calibrate_julia"
     command:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,5 @@
+using Test
 
-include(joinpath("helper_funcs", "runtests.jl"))
-include(joinpath("DistributionUtils", "runtests.jl"))
-include(joinpath("LESUtils", "runtests.jl"))
-include(joinpath("TurbulenceConvectionUtils", "runtests.jl"))
-include(joinpath("ReferenceModels", "runtests.jl"))
-include(joinpath("ReferenceStats", "runtests.jl"))
-include(joinpath("Pipeline", "runtests.jl"))
-include(joinpath("NetCDFIO", "runtests.jl"))
+@testset "Unit tests" begin
+    @test 1 == 1
+end


### PR DESCRIPTION
This PR moves all of our unit tests to buildkite to parallelize them. This technically limits our test coverage on other operating systems (and will effectively kill our code coverage reports), but it will make CI quite faster.

lol, and MacOS agents are taking just as long to test `@test 1 == 1` on GHA, so maybe we can next remove our bors check on GHA CI (we can still run it). Actually, maybe in a follow-up PR I'll add the GHA CI tests back in but just not depend on it with bors.