### PR TITLE
Add GHA tests back in, make bors not depend on GHA

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,9 +2,6 @@ status = [
   "buildkite/calibrateedmf-ci",
   "format",
   "docbuild",
-  "ci 1.7.0 - ubuntu-latest",
-  # "ci 1.7.0 - windows-latest",
-  "ci 1.7.0 - macOS-latest",
 ]
 delete_merged_branches = true
 timeout_sec = 10800

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
-using Test
 
-@testset "Unit tests" begin
-    @test 1 == 1
-end
+include(joinpath("helper_funcs", "runtests.jl"))
+include(joinpath("DistributionUtils", "runtests.jl"))
+include(joinpath("LESUtils", "runtests.jl"))
+include(joinpath("TurbulenceConvectionUtils", "runtests.jl"))
+include(joinpath("ReferenceModels", "runtests.jl"))
+include(joinpath("ReferenceStats", "runtests.jl"))
+include(joinpath("Pipeline", "runtests.jl"))
+include(joinpath("NetCDFIO", "runtests.jl"))


### PR DESCRIPTION
This PR reverts a part of #195. This will fix our coverage, which dropped. Now, we'll still run GHA CI, but bors will only depend on codecov, in order to keep CI time down.

cc @ilopezgp 