### PR TITLE
Qualify ModelTypes

### DIFF
--- a/experiments/SCT1_benchmark/config.jl
+++ b/experiments/SCT1_benchmark/config.jl
@@ -4,7 +4,7 @@ using Distributions
 using StatsBase
 using LinearAlgebra
 using CalibrateEDMF
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
@@ -89,8 +89,8 @@ function get_reference_config(::SCT1Train)
     n_repeat = length(ref_dirs)
     config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] =
         repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
     config["y_dir"] = ref_dirs
@@ -117,8 +117,8 @@ function get_reference_config(::SCT1Val)
     n_repeat = length(ref_dirs)
     config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] =
         repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
     config["y_dir"] = ref_dirs

--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -4,7 +4,7 @@ using Distributions
 using StatsBase
 using LinearAlgebra
 using CalibrateEDMF
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
 # Import prior constraints
@@ -78,8 +78,8 @@ function get_reference_config(::ObsCampaigns)
     config = Dict()
     config["case_name"] = ["DYCOMS_RF01", "GABLS", "Bomex"]
     # Flag to indicate source of data (LES or SCM) for reference data and covariance
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] = [
         ["thetal_mean", "ql_mean", "qt_mean", "total_flux_h", "total_flux_qt"],
         ["thetal_mean", "u_mean", "v_mean", "tke_mean"],
@@ -129,8 +129,8 @@ function get_reference_config(::LesDrivenScm)
     n_repeat = length(ref_dirs)
     config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] =
         repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
     config["y_dir"] = ref_dirs
@@ -156,8 +156,8 @@ function get_reference_config(::LesDrivenScmVal)
     n_repeat = length(ref_dirs)
     config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] =
         repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
     config["y_dir"] = ref_dirs

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -21,7 +21,7 @@ using Distributions
 using StatsBase
 using LinearAlgebra
 using CalibrateEDMF
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
 # Import prior constraints
@@ -92,8 +92,8 @@ function get_reference_config(::Bomex)
     config = Dict()
     config["case_name"] = ["Bomex"]
     # Flag to indicate source of data (LES or SCM) for reference data and covariance
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     # "total_flux_qt" will be available in TC.jl version 0.5.0
     config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean", "total_flux_h"]]
     config["y_dir"] = [get_les_data_path()]
@@ -115,8 +115,8 @@ function get_reference_config(::LesDrivenScm)
     config = Dict()
     config["case_name"] = ["LES_driven_SCM"]
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = LES()
-    config["Σ_reference_type"] = LES()
+    config["y_reference_type"] = ModelTypes.LES()
+    config["Σ_reference_type"] = ModelTypes.LES()
     config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean"]]
     cfsite_number = 17
     les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip")

--- a/src/ModelTypes.jl
+++ b/src/ModelTypes.jl
@@ -1,5 +1,4 @@
 module ModelTypes
-export ModelType, LES, SCM
 
 abstract type ModelType end
 struct LES <: ModelType end

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -10,7 +10,7 @@ using EnsembleKalmanProcesses
 import EnsembleKalmanProcesses: Process, Unscented, Inversion, Sampler
 using EnsembleKalmanProcesses.ParameterDistributions
 using ..ReferenceModels
-using ..ModelTypes
+import ..ModelTypes
 using ..LESUtils
 using ..HelperFuncs
 
@@ -22,7 +22,7 @@ export generate_ekp, generate_tekp
 
 """
     struct ReferenceStatistics{FT <: Real}
-    
+
 A structure containing statistics from the reference model used to
 define a well-posed inverse problem.
 """
@@ -49,8 +49,8 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
             tikhonov_noise::FT = 0.0,
             tikhonov_mode::String = "absolute",
             dim_scaling::Bool = false,
-            y_type::ModelType = LES(),
-            Σ_type::ModelType = LES(),
+            y_type::ModelTypes.ModelType = ModelTypes.LES(),
+            Σ_type::ModelTypes.ModelType = ModelTypes.LES(),
             Δt::FT = 6 * 3600.0,
         ) where {FT <: Real}
 
@@ -67,8 +67,8 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         the inverse of the desired condition number. This value is enforced to be
         larger than the sqrt of the machine precision for stability.
      - dim_scaling      :: Whether to scale covariance blocks by their size.
-     - y_type           :: Type of reference mean data. Either LES() or SCM().
-     - Σ_type           :: Type of reference covariance data. Either LES() or SCM().
+     - y_type           :: Type of reference mean data. Either ModelTypes.LES() or ModelTypes.SCM().
+     - Σ_type           :: Type of reference covariance data. Either ModelTypes.LES() or ModelTypes.SCM().
      - Δt               :: [LES last time - SCM start time (LES timeframe)] for
        LES_driven_SCM cases.
     Outputs:
@@ -82,8 +82,8 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         tikhonov_noise::FT = 0.0,
         tikhonov_mode::String = "absolute",
         dim_scaling::Bool = false,
-        y_type::ModelType = LES(),
-        Σ_type::ModelType = LES(),
+        y_type::ModelTypes.ModelType = ModelTypes.LES(),
+        Σ_type::ModelTypes.ModelType = ModelTypes.LES(),
         Δt::FT = 6 * 3600.0,
     ) where {FT <: Real}
         # Init arrays
@@ -148,7 +148,7 @@ full_length(RS::ReferenceStatistics) = length(RS.y_full)
         Σ_names::Vector{String},
         normalize::Bool;
         z_scm::Union{Vector{FT}, Nothing} = nothing,
-    )   
+    )
 
 Get observations for variables y_names, interpolated to
 z_scm (if given), and possibly normalized with respect to the pooled variance.
@@ -182,13 +182,13 @@ end
 
 function get_obs(
     m::ReferenceModel,
-    y_type::Union{LES, SCM},
-    Σ_type::Union{LES, SCM},
+    y_type::ModelTypes.ModelType,
+    Σ_type::ModelTypes.ModelType,
     normalize::Bool;
     z_scm::Union{Vector{FT}, Nothing},
 ) where {FT <: Real}
-    y_names = isa(y_type, LES) ? get_les_names(m, m.y_dir) : m.y_names
-    Σ_names = isa(Σ_type, LES) ? get_les_names(m, m.Σ_dir) : m.y_names
+    y_names = isa(y_type, ModelTypes.LES) ? get_les_names(m, m.y_dir) : m.y_names
+    Σ_names = isa(Σ_type, ModelTypes.LES) ? get_les_names(m, m.Σ_dir) : m.y_names
     get_obs(m, y_names, Σ_names, normalize, z_scm = z_scm)
 end
 
@@ -242,7 +242,7 @@ Inputs:
  - z_scm :: If given, interpolate LES observations to given levels.
 Outputs:
  - y :: Output vector used in the inverse problem, which concatenates the
-   requested profiles. 
+   requested profiles.
 """
 function get_profile(
     sim_dir::String,

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -4,7 +4,7 @@ using NCDatasets
 using Random
 const NC = NCDatasets
 using CalibrateEDMF
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.DistributionUtils
@@ -38,7 +38,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
     # Generate ref_stats
     ref_models = construct_reference_models(kwargs_ref_model)
     run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
-    ref_stats = ReferenceStatistics(ref_models, y_type = SCM(), Σ_type = SCM())
+    ref_stats = ReferenceStatistics(ref_models, y_type = ModelTypes.SCM(), Σ_type = ModelTypes.SCM())
     # Generate config
     config = Dict()
     config["process"] = Dict()

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -4,7 +4,7 @@ using Distributions
 using StatsBase
 using LinearAlgebra
 using CalibrateEDMF
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
@@ -67,8 +67,8 @@ function get_reference_config(::Bomex)
     config = Dict()
     config["case_name"] = ["Bomex"]
     # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
-    config["y_reference_type"] = SCM()
-    config["Σ_reference_type"] = SCM()
+    config["y_reference_type"] = ModelTypes.SCM()
+    config["Σ_reference_type"] = ModelTypes.SCM()
     config["y_names"] = [["thetal_mean", "qt_mean"]]
     ref_root_dir = mktempdir()
     config["y_dir"] = [joinpath(ref_root_dir, "Output.Bomex.ref")]

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using LinearAlgebra
-using CalibrateEDMF.ModelTypes
+import CalibrateEDMF.ModelTypes
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
@@ -65,8 +65,8 @@ using CalibrateEDMF.TurbulenceConvectionUtils
             tikhonov_noise = 0.1,
             tikhonov_mode = tikhonov_mode,
             dim_scaling = dim_scaling,
-            y_type = SCM(),
-            Σ_type = SCM(),
+            y_type = ModelTypes.SCM(),
+            Σ_type = ModelTypes.SCM(),
         )
 
         @test pca_length(ref_stats) == size(ref_stats.Γ, 1)
@@ -89,7 +89,7 @@ using CalibrateEDMF.TurbulenceConvectionUtils
         perform_PCA = false,
         normalize = false,
         tikhonov_mode = "relative",
-        y_type = SCM(),
-        Σ_type = SCM(),
+        y_type = ModelTypes.SCM(),
+        Σ_type = ModelTypes.SCM(),
     )
 end


### PR DESCRIPTION
This PR removes the `ModelTypes` module exports and qualifies the model types. 