### PR TITLE
Compile less code

### DIFF
--- a/experiments/SCT1_benchmark/config.jl
+++ b/experiments/SCT1_benchmark/config.jl
@@ -10,9 +10,8 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
-using CalibrateEDMF.ModelTypes
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using JLD2
 using EnsembleKalmanProcesses

--- a/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
@@ -8,7 +8,7 @@
 @everywhere using CalibrateEDMF.TurbulenceConvectionUtils
 
 @everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere include(joinpath(src_dir, "helper_funcs.jl"))
+@everywhere using CalibrateEDMF.HelperFuncs
 @everywhere include(joinpath(src_dir, "parallel.jl"))
 using JLD2
 

--- a/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
@@ -8,7 +8,7 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
+++ b/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
@@ -6,7 +6,7 @@ using CalibrateEDMF
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.Pipeline
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/experiments/les_strats/tc_calibrate.jl
+++ b/experiments/les_strats/tc_calibrate.jl
@@ -8,7 +8,7 @@
 @everywhere using CalibrateEDMF.TurbulenceConvectionUtils
 @everywhere using CalibrateEDMF.Pipeline
 @everywhere const src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere include(joinpath(src_dir, "helper_funcs.jl"))
+@everywhere using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 @everywhere using EnsembleKalmanProcesses
 @everywhere using EnsembleKalmanProcesses.Observations

--- a/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/global_parallel/parallel_scm_eval.jl
@@ -8,7 +8,7 @@
 @everywhere using CalibrateEDMF.TurbulenceConvectionUtils
 
 @everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere include(joinpath(src_dir, "helper_funcs.jl"))
+@everywhere using CalibrateEDMF.HelperFuncs
 @everywhere include(joinpath(src_dir, "parallel.jl"))
 using JLD2
 

--- a/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
@@ -8,7 +8,7 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
@@ -4,7 +4,7 @@ using ArgParse
 using CalibrateEDMF
 using CalibrateEDMF.Pipeline
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 using JLD2
 
 # Read iteration number of ensemble to be recovered

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -6,7 +6,7 @@ using CalibrateEDMF
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.Pipeline
 src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
@@ -16,7 +16,7 @@ using Distributed
 @everywhere using CalibrateEDMF.DistributionUtils
 @everywhere using CalibrateEDMF.Pipeline
 @everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere include(joinpath(src_dir, "helper_funcs.jl"))
+@everywhere using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 @everywhere using EnsembleKalmanProcesses
 @everywhere using EnsembleKalmanProcesses.ParameterDistributions

--- a/src/CalibrateEDMF.jl
+++ b/src/CalibrateEDMF.jl
@@ -1,6 +1,7 @@
 module CalibrateEDMF
 
 # Submodules
+include("HelperFuncs.jl")
 include("ModelTypes.jl")
 include("DistributionUtils.jl")
 include("ReferenceModels.jl")

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -10,7 +10,7 @@ include(joinpath("../ekp_experimental", "failsafe_inversion.jl"))
 
 using ..ReferenceModels
 using ..ReferenceStats
-include("helper_funcs.jl")
+using ..HelperFuncs
 const NC = NCDatasets
 
 export io_dictionary_ensemble, io_dictionary_reference, io_dictionary_metrics

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -1,4 +1,34 @@
-#= Generic utils. =#
+"""
+    HelperFuncs
+
+Generic utils.
+"""
+module HelperFuncs
+
+# We can work on qualifying these later
+export vertical_interpolation,
+    nc_fetch_interpolate,
+    fetch_interpolate_transform,
+    get_height,
+    get_dz,
+    normalize_profile,
+    nc_fetch,
+    is_face_variable,
+    get_stats_path,
+    compute_mse,
+    penalize_nan,
+    serialize_struct,
+    deserialize_struct,
+    jld2_path,
+    scm_init_path,
+    scm_output_path,
+    scm_val_init_path,
+    scm_val_output_path,
+    ekobj_path,
+    write_versions,
+    expand_dict_entry,
+    get_entry,
+    change_entry!
 
 using NCDatasets
 using Statistics
@@ -368,3 +398,5 @@ function change_entry!(dict, keys_and_value)
     last_dict = get_last_nested_dict(dict, keys)
     last_dict[keys[end]] = value
 end
+
+end # module

--- a/src/LESUtils.jl
+++ b/src/LESUtils.jl
@@ -1,10 +1,11 @@
 module LESUtils
 
+import NCDatasets
 import CalibrateEDMF.ReferenceModels: ReferenceModel
 using TurbulenceConvection
 tc = dirname(pathof(TurbulenceConvection))
 include(joinpath(tc, "name_aliases.jl"))
-include("helper_funcs.jl")
+using ..HelperFuncs
 
 export get_les_names, get_cfsite_les_dir, find_alias
 
@@ -56,7 +57,7 @@ end
 Finds the alias present in an NCDataset from a list of possible aliases.
 """
 function find_alias(aliases::Tuple{Vararg{String}}, les_dir::String)
-    NCDataset(get_stats_path(les_dir)) do ds
+    NCDatasets.NCDataset(get_stats_path(les_dir)) do ds
         for alias in aliases
             if haskey(ds, alias)
                 return alias

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -1,6 +1,8 @@
 module NetCDFIO
 
 using NCDatasets
+const NC = NCDatasets
+
 using Statistics
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
@@ -8,8 +10,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 using ..ReferenceModels
 using ..ReferenceStats
 using ..Diagnostics
-include("helper_funcs.jl")
-const NC = NCDatasets
+using ..HelperFuncs
 
 export NetCDFIO_Diags
 export open_files, close_files, write_iteration

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -11,7 +11,7 @@ using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
 using CalibrateEDMF.NetCDFIO
 cedmf = pkgdir(CalibrateEDMF)
-include(joinpath(cedmf, "src", "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -1,7 +1,8 @@
 module ReferenceModels
 
 using JLD2
-include("helper_funcs.jl")
+using ..HelperFuncs
+using Random
 
 export ReferenceModel, ReferenceModelBatch
 export get_t_start, get_t_end, get_t_start_Σ, get_t_end_Σ, get_z_obs

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -12,7 +12,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 using ..ReferenceModels
 using ..ModelTypes
 using ..LESUtils
-include("helper_funcs.jl")
+using ..HelperFuncs
 
 export ReferenceStatistics
 export pca_length, full_length

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -13,7 +13,7 @@ tc = pkgdir(TurbulenceConvection)
 include(joinpath(tc, "driver", "main.jl"))
 include(joinpath(tc, "driver", "generate_namelist.jl"))
 
-include(joinpath(@__DIR__, "helper_funcs.jl"))
+using ..HelperFuncs
 
 export ModelEvaluator
 export run_SCM, run_SCM_handler, get_scm_namelist, run_reference_SCM

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -5,7 +5,7 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
 using TurbulenceConvection
-include(joinpath(@__DIR__, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 
 export run_SCM_parallel, eval_single_ref_model, versioned_model_eval_parallel
 

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -11,7 +11,7 @@ using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
 const src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -13,7 +13,8 @@ using EnsembleKalmanProcesses.ParameterDistributions
 import TurbulenceConvection
 cedmf = pkgdir(CalibrateEDMF)
 test_dir = joinpath(cedmf, "test", "Pipeline")
-include(joinpath(cedmf, "src", "helper_funcs.jl"))
+using CalibrateEDMF.HelperFuncs
+using Random
 include(joinpath(test_dir, "config.jl"))
 
 # Shared simulations

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.TurbulenceConvectionUtils
+using Random
 
 @testset "ReferenceModel" begin
     les_dir_test = "/foo/bar/les"

--- a/test/helper_funcs/runtests.jl
+++ b/test/helper_funcs/runtests.jl
@@ -2,8 +2,8 @@ using Test
 using Distributions
 using Random
 using CalibrateEDMF
+using CalibrateEDMF.HelperFuncs
 const src_dir = dirname(pathof(CalibrateEDMF))
-include(joinpath(src_dir, "helper_funcs.jl"))
 
 @testset "error_utils" begin
     # Vector of vectors vs vector


### PR DESCRIPTION
This PR makes `helper_funcs.jl` a module inside CalibrateEDMF.jl and utilizes the module in various places. This should help compiling fewer versions of the same code.

I think what I've done should work, but we should probably still try testing other parallel schemes with this PR since this changes how code is loaded.

We should do this (and possibly merge?) with `src/parallel.jl`.