### PR TITLE
Add a multi-processor job to buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,13 +95,13 @@ steps:
       queue: central
       slurm_ntasks: 1
 
-  - label: "Calibrate julia parallel"
-    key: "cpu_calibrate_julia"
+  - label: "Calibrate julia parallel 10 procs"
+    key: "cpu_calibrate_julia_p10"
     command:
       - cd experiments/scm_pycles_pipeline/julia_parallel
-      - "julia --color=yes --project calibrate.jl --config ../config.jl"
+      - "julia --color=yes -p 10 --project calibrate.jl --config ../config.jl"
     agents:
       config: cpu
       queue: central
-      slurm_ntasks: 1
+      slurm_ntasks: 11
 


### PR DESCRIPTION
This PR adds a julia parallel job to buildkite that runs with 10 processors, just so that a multi-processor job is tested.

Note that `julia -p 10` specifies 10 workers, and `slurm_ntasks: 11` specifies the total number of tasks.