### PR TITLE
Use artifacts (enable local run) improve paths

### DIFF
--- a/experiments/scm_pycles_pipeline/Artifacts.toml
+++ b/experiments/scm_pycles_pipeline/Artifacts.toml
@@ -1,0 +1,2 @@
+[PyCLES_output]
+git-tree-sha1 = "895519bbfa0c4f864cbf3f522a1d40d6bf98054b"

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -1,5 +1,22 @@
 #= Custom calibration configuration file. =#
 
+import ArtifactWrappers
+const AW = ArtifactWrappers
+
+function get_les_data_path()
+    #! format: off
+    PyCLES_output_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        isempty(get(ENV, "CI", "")),
+        "PyCLES_output",
+        AW.ArtifactFile[
+        AW.ArtifactFile(url = "https://caltech.box.com/shared/static/d6oo7th33839qmp4z99n8z4ryk3iepoq.nc", filename = "Bomex.nc",),
+        ],
+    )
+    PyCLES_output_dataset_path = AW.get_data_folder(PyCLES_output_dataset)
+    return PyCLES_output_dataset_path
+end
+
 using Distributions
 using StatsBase
 using LinearAlgebra
@@ -79,7 +96,7 @@ function get_reference_config(::Bomex)
     config["Σ_reference_type"] = LES()
     # "total_flux_qt" will be available in TC.jl version 0.5.0
     config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean", "total_flux_h"]]
-    config["y_dir"] = ["/groups/esm/zhaoyi/pycles_clima/Output.Bomex.aug09"]
+    config["y_dir"] = [get_les_data_path()]
     # provide list of dirs if different from `y_dir`
     # config["Σ_dir"] = [...]
     config["scm_suffix"] = ["000000"]

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl
@@ -10,7 +10,7 @@
 # Import modules to all processes
 using Distributed
 @everywhere using Pkg
-@everywhere Pkg.activate("../../..")
+@everywhere Pkg.activate(dirname(dirname(dirname(@__DIR__))))
 @everywhere using ArgParse
 @everywhere using CalibrateEDMF
 @everywhere using CalibrateEDMF.DistributionUtils
@@ -33,7 +33,12 @@ s = ArgParseSettings()
     arg_type = String
 end
 parsed_args = parse_args(ARGS, s)
-include(parsed_args["config"])
+if parsed_args["config"] == nothing
+    include(joinpath(dirname(@__DIR__), "config.jl"))
+    @warn "Using default config file."
+else
+    include(parsed_args["config"])
+end
 config = get_config()
 
 # Initialize calibration process

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -239,6 +239,11 @@ Given directory to standard LES or SCM output, fetch path to stats file.
 """
 function get_stats_path(dir)
     stats = joinpath(dir, "stats")
+    if !ispath(stats)
+        stat_files = glob(relpath(abspath(joinpath(dir, "*.nc"))))
+        @assert length(stat_files) == 1
+        return stat_files[1]
+    end
     try
         stat_files = glob(relpath(abspath(joinpath(stats, "*.nc"))))
         @assert length(stat_files) == 1


### PR DESCRIPTION
I've uploaded the data from `"/groups/esm/zhaoyi/pycles_clima/Output.Bomex.aug09"` to Caltech Box, and it's now lazily downloaded using Artifacts.

This PR allows us to run locally:

```julia
julia --project
using Distributed # maybe needed?
include("experiments/scm_pycles_pipeline/julia_parallel/calibrate.jl")
```

cc @yairchn 

I'm hoping that this can also be run in a distributed fashion using

```julia
julia -p 4 --project
using Revise; include(joinpath("experiments", "scm_pycles_pipeline", "julia_parallel", "calibrate.jl"))
```
(hopefully fixing #201).