### PR TITLE
Log use of get_entry defaults to info.

### DIFF
--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -371,13 +371,13 @@ end
 """
     get_entry(dict, key, default)
 
-Calls `get` but throws a warning if the default is used.
+Calls `get` but logs whether the default is used.
 """
 function get_entry(dict, key, default)
     if haskey(dict, key)
         return dict[key]
     else
-        @warn "Key $key not found in dictionary. Returning default value."
+        @info "Key $key not found in dictionary. Returning default value $default."
         return default
     end
 end


### PR DESCRIPTION
Logs whether the default was used in `get_entry` at the info level. From recent experience using a warning has been distracting users while debugging. This warning was typically ok to ignore since some configurations will resort to defaults in operational use.