### PR TITLE
Make log a bit more compact

### DIFF
--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -101,8 +101,7 @@ function run_SCM(
         g_scm_pca .= 1e5
     end
 
-    @info "Length of g_scm (full): $(length(g_scm))"
-    @info "Length of g_scm (pca) : $(length(g_scm_pca))"
+    @info "Length of g_scm (full, pca): ($(length(g_scm)), $(length(g_scm_pca)))"
     if error_check
         return sim_dirs, g_scm, g_scm_pca, model_error
     else

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -50,8 +50,7 @@ function run_SCM_parallel(
         g_scm_pca .= 1e5
     end
 
-    @info "Length of g_scm (full): $(length(g_scm))"
-    @info "Length of g_scm (pca) : $(length(g_scm_pca))"
+    @info "Length of g_scm (full, pca): ($(length(g_scm)), $(length(g_scm_pca)))"
     if error_check
         return sim_dirs, g_scm, g_scm_pca, model_error
     else


### PR DESCRIPTION
This PR combines the `@info` statements from
```julia
[ Info: Length of g_scm (full): 180
[ Info: Length of g_scm (pca) : 13
```
to
```julia
[ Info: Length of g_scm (full, pca): (180, 13)
```
to help compactify the logging a bit (multi-processor runs still log quite a bit of info).