### PR TITLE
Print mse vectors, pad left margin plots

### DIFF
--- a/integration_tests/julia_parallel_calibrate.jl
+++ b/integration_tests/julia_parallel_calibrate.jl
@@ -70,11 +70,21 @@ mse_full_var = nt.mse_full_var[1:(end - 1)]
 
 import Plots
 
+# https://github.com/jheinen/GR.jl/issues/278#issuecomment-587090846
+ENV["GKSwstype"] = "nul"
+
 iters = 1:N_iter
+
+@show iters
+@show mse_full_mean
+@show mse_full_nn_mean
+@show mse_full_var
+
 Plots.plot(iters, mse_full_nn_mean; label = "mean")
 Plots.plot!(iters, mse_full_nn_mean .+ sqrt.(mse_full_var); label = "std")
 Plots.xlabel!("Iteration")
 Plots.ylabel!("Train MSE (full)")
+Plots.plot!(; left_margin = 40 * Plots.PlotMeasures.px)
 folder = joinpath(@__DIR__, "output", first(split(basename(@__FILE__), ".")))
 mkpath(folder)
 Plots.savefig(joinpath(folder, "mse.png"))


### PR DESCRIPTION
This PR
 - prints some of the metrics in the integration tests
 - Adjusts the plot margins so that the label is (hopefully) visible when increasing the number of iterations
 - Adds `ENV["GKSwstype"] = "nul"` (see related issue)