### PR TITLE
Expensive calibration using pmap

### DIFF
--- a/experiments/les_strats/config_nn_uki20.jl
+++ b/experiments/les_strats/config_nn_uki20.jl
@@ -1,0 +1,224 @@
+#= Custom calibration configuration file. =#
+
+using Distributions
+using StatsBase
+using LinearAlgebra
+using Random
+using CalibrateEDMF
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.LESUtils
+using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using JLD2
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+
+# Cases defined as structs for quick access to default configs
+struct LesDrivenScm end
+struct LesDrivenScmVal end
+
+function get_config()
+    config = Dict()
+    # Flags for saving output data
+    config["output"] = get_output_config()
+    # Define regularization of inverse problem
+    config["regularization"] = get_regularization_config()
+    # Define reference used in the inverse problem 
+    config["reference"] = get_reference_config(LesDrivenScm())
+    # Define reference used for validation
+    config["validation"] = get_reference_config(LesDrivenScmVal())
+    # Define the parameter priors
+    config["prior"] = get_prior_config()
+    # Define the kalman process
+    config["process"] = get_process_config()
+    # Define the SCM static configuration
+    config["scm"] = get_scm_config()
+    return config
+end
+
+function get_output_config()
+    config = Dict()
+    config["outdir_root"] = pwd()
+    config["overwrite_scm_file"] = false # Flag for overwritting SCM input file
+    return config
+end
+
+function get_regularization_config()
+    config = Dict()
+    # Regularization of observations: mean and covariance
+    config["perform_PCA"] = true # Performs PCA on data
+    config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
+    config["normalize"] = true  # whether to normalize data by pooled variance
+    config["tikhonov_mode"] = "relative" # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean
+    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = 20.0 / 60.0 # 1.0
+    return config
+end
+
+function get_process_config()
+    config = Dict()
+    config["N_iter"] = 60
+    config["N_ens"] = 159 # Must be 2p+1 when algorithm is "Unscented"
+    config["algorithm"] = "Unscented" # "Sampler", "Unscented", "Inversion"
+    config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 60.0 / 20.0 # 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = true
+    config["failure_handler"] = "sample_succ_gauss" #"high_loss" #"sample_succ_gauss"
+    return config
+end
+
+function get_reference_config(::LesDrivenScm)
+    config = Dict()
+
+    # AMIP data: July
+    cfsite_numbers = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip")
+    ref_dirs = [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+    suffixes = [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+    # AMIP data: October
+    cfsite_numbers = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 10, experiment = "amip")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    append!(suffixes, [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    # AMIP data: January
+    cfsite_numbers = (2, 3, 5, 7, 9, 11, 13, 21, 22, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 1, experiment = "amip")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    append!(suffixes, [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    # AMIP data: April
+    cfsite_numbers = (2, 3, 5, 7, 9, 11, 13, 19, 21, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 4, experiment = "amip")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    append!(suffixes, [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+
+    n_repeat = length(ref_dirs)
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["scm_suffix"] = suffixes
+    config["scm_parent_dir"] = repeat(["scm_init"], n_repeat)
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    # config["n_obs"] = repeat([40], n_repeat)
+    config["batch_size"] = 20
+    config["write_full_stats"] = false
+    return config
+end
+
+function get_reference_config(::LesDrivenScmVal)
+    config = Dict()
+
+    # AMIP4K data: July
+    cfsite_numbers = (3, 5, 8, 11, 14)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip4K")
+    ref_dirs = [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+    suffixes = [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+
+    # AMIP4K data: January
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 1, experiment = "amip4K")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+    append!(suffixes, [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+
+    n_repeat = length(ref_dirs)
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["scm_suffix"] = suffixes
+    config["scm_parent_dir"] = repeat(["scm_init"], n_repeat)
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    config["write_full_stats"] = false
+    return config
+end
+
+function get_prior_config()
+    config = Dict()
+    config["constraints"] = Dict(
+        # entrainment parameters
+        "general_ent_params" => [repeat([no_constraint()], 69)...,],
+        "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
+
+        # diffusion parameters
+        "tke_ed_coeff" => [bounded(0.01, 1.0)],
+        "tke_diss_coeff" => [bounded(0.01, 1.0)],
+        "static_stab_coeff" => [bounded(0.01, 1.0)],
+        "tke_surf_scale" => [bounded(1.0, 16.0)],
+        "Prandtl_number_0" => [bounded(0.5, 1.5)],
+
+        # momentum exchange parameters
+        "pressure_normalmode_adv_coeff" => [bounded(0.0, 100.0)],
+        "pressure_normalmode_buoy_coeff1" => [bounded(0.0, 10.0)],
+        "pressure_normalmode_drag_coeff" => [bounded(0.0, 50.0)],
+
+        # surface
+        "surface_area" => [bounded(0.01, 0.5)],
+    )
+
+    # TC.jl prior mean
+    config["prior_mean"] = Dict(
+        # entrainment parameters
+        "general_ent_params" => 0.1.*(rand(69).-0.5),
+        "turbulent_entrainment_factor" => [0.075],
+
+        # diffusion parameters
+        "tke_ed_coeff" => [0.14],
+        "tke_diss_coeff" => [0.22],
+        "static_stab_coeff" => [0.4],
+        "tke_surf_scale" => [3.75],
+        "Prandtl_number_0" => [0.74],
+
+        # momentum exchange parameters
+        "pressure_normalmode_adv_coeff" => [0.001],
+        "pressure_normalmode_buoy_coeff1" => [0.12],
+        "pressure_normalmode_drag_coeff" => [10.0],
+
+        # surface
+        "surface_area" => [0.1],
+    )
+
+    # config["unconstrained_σ"] = 1.0
+    # Tight initial prior for Unscented
+    config["unconstrained_σ"] = 0.25
+    return config
+end
+
+function get_scm_config()
+    config = Dict()
+    config["namelist_args"] = [
+        ("time_stepping", "dt_min", 1.0),
+        ("time_stepping", "dt_max", 2.0),
+        ("stats_io", "frequency", 60.0),
+        ("grid", "dz", 50.0),
+        ("grid", "nz", 80),
+        ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"), 
+        ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
+        ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
+    ]
+    return config
+end

--- a/experiments/les_strats/julia_parallel/calibrate.jl
+++ b/experiments/les_strats/julia_parallel/calibrate.jl
@@ -1,0 +1,61 @@
+# This is an example on training the TurbulenceConvection.jl implementation
+# of the EDMF scheme with data generated using PyCLES (an LES solver) or
+# TurbulenceConvection.jl (perfect model setting).
+#
+# This example parallelizes forward model evaluations using Julia's pmap() function.
+# This parallelization strategy is efficient for small ensembles (N_ens < 20). For
+# calibration processes involving a larger number of ensemble members, parallelization
+# using HPC resources directly is advantageous.
+
+# Import modules to all processes
+using Distributed
+@everywhere using Pkg
+@everywhere Pkg.activate(dirname(dirname(dirname(@__DIR__))))
+@everywhere using ArgParse
+@everywhere using CalibrateEDMF
+@everywhere using CalibrateEDMF.DistributionUtils
+@everywhere using CalibrateEDMF.Pipeline
+@everywhere src_dir = dirname(pathof(CalibrateEDMF))
+@everywhere using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+@everywhere using EnsembleKalmanProcesses
+@everywhere using EnsembleKalmanProcesses.ParameterDistributions
+# include(joinpath(@__DIR__, "../../../src/viz/ekp_plots.jl"))
+using JLD2
+
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--config"
+    help = "Inverse problem config file path"
+    arg_type = String
+end
+parsed_args = parse_args(ARGS, s)
+if parsed_args["config"] == nothing
+    include(joinpath(dirname(@__DIR__), "config.jl"))
+    @warn "Using default config file."
+else
+    include(parsed_args["config"])
+end
+config = get_config()
+
+# Initialize calibration process
+outdir_path = init_calibration(config; config_path = parsed_args["config"], mode = "pmap")
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+
+# Dispatch SCM eval functions to workers
+@everywhere scm_eval_train(version) = versioned_model_eval(version, $outdir_path, "train", $config)
+@everywhere scm_eval_validation(version) = versioned_model_eval(version, $outdir_path, "validation", $config)
+
+# Calibration process
+N_iter = config["process"]["N_iter"]
+@info "Running EK updates for $N_iter iterations"
+for iteration in 1:N_iter
+    @time begin
+        @info "   iter = $iteration"
+        versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+        ekp = load(ekobj_path(outdir_path, iteration))["ekp"]
+        pmap(scm_eval_train, versions)
+        pmap(scm_eval_validation, versions)
+        ek_update(ekp, priors, iteration, config, versions, outdir_path)
+    end
+end

--- a/experiments/les_strats/julia_parallel/calibrate_script
+++ b/experiments/les_strats/julia_parallel/calibrate_script
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#Submit this script with: sbatch calibrate_script
+
+#SBATCH --time=24:00:00   # walltime
+#SBATCH --ntasks=159  # number of processor cores (i.e. tasks)
+#SBATCH -J "j_pmap"   # job name
+
+module purge
+module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.API.precompile()'
+
+julia --project -p 159 calibrate.jl --config ../config_nn_uki20.jl

--- a/experiments/les_strats/julia_parallel/slurm-21602769.out
+++ b/experiments/les_strats/julia_parallel/slurm-21602769.out
@@ -1,0 +1,184 @@
+Worker 57 terminated.
+UNHANDLED TASK ERROR: EOFError: read end of file
+Stacktrace:
+ [1] (::Base.var"#wait_locked#645")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:892
+ [2] unsafe_read(s::Sockets.TCPSocket, p::Ptr{UInt8}, nb::UInt64)
+   @ Base ./stream.jl:900
+ [3] unsafe_read
+   @ ./io.jl:724 [inlined]
+ [4] unsafe_read(s::Sockets.TCPSocket, p::Base.RefValue{NTuple{4, Int64}}, n::Int64)
+   @ Base ./io.jl:723
+ [5] read!
+   @ ./io.jl:725 [inlined]
+ [6] deserialize_hdr_raw
+   @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/messages.jl:167 [inlined]
+ [7] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:165
+ [8] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [9] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 6 terminated.
+UNHANDLED TASK ERROR: EOFError: read end of file
+Stacktrace:
+ [1] (::Base.var"#wait_locked#645")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:892
+ [2] unsafe_read(s::Sockets.TCPSocket, p::Ptr{UInt8}, nb::UInt64)
+   @ Base ./stream.jl:900
+ [3] unsafe_read
+   @ ./io.jl:724 [inlined]
+ [4] unsafe_read(s::Sockets.TCPSocket, p::Base.RefValue{NTuple{4, Int64}}, n::Int64)
+   @ Base ./io.jl:723
+ [5] read!
+   @ ./io.jl:725 [inlined]
+ [6] deserialize_hdr_raw
+   @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/messages.jl:167 [inlined]
+ [7] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:165
+ [8] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [9] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 81 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 95 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 87 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+ERROR: TaskFailedException
+
+    nested task error: worker did not connect within 60.0 seconds
+    Stacktrace:
+     [1] error(s::String)
+       @ Base ./error.jl:33
+     [2] create_worker(manager::Distributed.LocalManager, wconfig::WorkerConfig)
+       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:687
+     [3] setup_launched_worker(manager::Distributed.LocalManager, wconfig::WorkerConfig, launched_q::Vector{Int64})
+       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:541
+     [4] (::Distributed.var"#41#44"{Distributed.LocalManager, Vector{Int64}, WorkerConfig})()
+       @ Distributed ./task.jl:423
+
+...and 4 more exceptions.
+
+Stacktrace:
+  [1] sync_end(c::Channel{Any})
+    @ Base ./task.jl:381
+  [2] macro expansion
+    @ ./task.jl:400 [inlined]
+  [3] addprocs_locked(manager::Distributed.LocalManager; kwargs::Base.Pairs{Symbol, Cmd, Tuple{Symbol}, NamedTuple{(:exeflags,), Tuple{Cmd}}})
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:487
+  [4] addprocs(manager::Distributed.LocalManager; kwargs::Base.Pairs{Symbol, Cmd, Tuple{Symbol}, NamedTuple{(:exeflags,), Tuple{Cmd}}})
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:447
+  [5] #addprocs#257
+    @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/managers.jl:436 [inlined]
+  [6] process_opts(opts::Base.JLOptions)
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1334
+  [7] #invokelatest#2
+    @ ./essentials.jl:716 [inlined]
+  [8] invokelatest
+    @ ./essentials.jl:714 [inlined]
+  [9] exec_options(opts::Base.JLOptions)
+    @ Base ./client.jl:252
+ [10] _start()
+    @ Base ./client.jl:495
+┌ Warning: Forcibly interrupting busy workers
+│   exception = IOError: stream is closed or unusable
+└ @ Distributed /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1249
+┌ Error: Unable to terminate all workers
+│   exception =
+│    IOError: stream is closed or unusable
+│    Stacktrace:
+│      [1] check_open
+│        @ ./stream.jl:386 [inlined]
+│      [2] uv_write_async(s::Sockets.TCPSocket, p::Ptr{UInt8}, n::UInt64)
+│        @ Base ./stream.jl:1018
+│      [3] uv_write(s::Sockets.TCPSocket, p::Ptr{UInt8}, n::UInt64)
+│        @ Base ./stream.jl:981
+│      [4] uv_write
+│        @ ./stream.jl:977 [inlined]
+│      [5] flush(s::Sockets.TCPSocket)
+│        @ Base ./stream.jl:1073
+│      [6] send_msg_(w::Distributed.Worker, header::Distributed.MsgHeader, msg::Distributed.RemoteDoMsg, now::Bool)
+│        @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/messages.jl:187
+│      [7] send_msg
+│        @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/messages.jl:122 [inlined]
+│      [8] #remote_do#165
+│        @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:519 [inlined]
+│      [9] remote_do
+│        @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:519 [inlined]
+│     [10] #remote_do#166
+│        @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:544 [inlined]
+│     [11] remote_do
+│        @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:544 [inlined]
+│     [12] kill(manager::Distributed.LocalManager, pid::Int64, config::WorkerConfig)
+│        @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/managers.jl:668
+│     [13] _rmprocs(pids::Vector{Int64}, waitfor::Float64)
+│        @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1050
+│     [14] rmprocs(pids::Vector{Int64}; waitfor::Float64)
+│        @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1033
+│     [15] terminate_all_workers()
+│        @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1253
+│     [16] _atexit()
+│        @ Base ./initdefs.jl:350
+│     [17] exit
+│        @ ./initdefs.jl:28 [inlined]
+│     [18] _start()
+│        @ Base ./client.jl:498
+└ @ Distributed /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1255
+      From worker 47:	Master process (id 1) could not connect within 60.0 seconds.
+      From worker 47:	exiting.
+      From worker 48:	Master process (id 1) could not connect within 60.0 seconds.
+      From worker 48:	exiting.
+slurmstepd: error: Detected 313 oom-kill event(s) in step 21602769.batch cgroup. Some of your processes may have been killed by the cgroup out-of-memory handler.

--- a/experiments/les_strats/julia_parallel/slurm-21602794.out
+++ b/experiments/les_strats/julia_parallel/slurm-21602794.out
@@ -1,0 +1,1503 @@
+      From worker 42:	Master process (id 1) could not connect within 60.0 seconds.
+      From worker 42:	exiting.
+      From worker 52:	fatal: error thrown and no exception handler available.
+      From worker 52:	InterruptException()
+      From worker 52:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 52:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 50:	fatal: error thrown and no exception handler available.
+      From worker 50:	InterruptException()
+      From worker 50:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 50:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 46:	fatal: error thrown and no exception handler available.
+      From worker 46:	InterruptException()
+      From worker 46:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 46:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 44:	fatal: error thrown and no exception handler available.
+      From worker 44:	InterruptException()
+      From worker 44:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 44:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 47:	fatal: error thrown and no exception handler available.
+      From worker 47:	InterruptException()
+      From worker 47:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 47:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 51:	fatal: error thrown and no exception handler available.
+      From worker 51:	InterruptException()
+      From worker 51:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 51:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 48:	fatal: error thrown and no exception handler available.
+      From worker 48:	InterruptException()
+      From worker 48:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 48:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 54:	fatal: error thrown and no exception handler available.
+      From worker 54:	InterruptException()
+      From worker 54:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 54:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 45:	fatal: error thrown and no exception handler available.
+      From worker 45:	InterruptException()
+      From worker 45:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 45:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 43:	fatal: error thrown and no exception handler available.
+      From worker 43:	InterruptException()
+      From worker 43:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 43:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 49:	fatal: error thrown and no exception handler available.
+      From worker 49:	InterruptException()
+      From worker 49:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 49:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 55:	fatal: error thrown and no exception handler available.
+      From worker 55:	InterruptException()
+      From worker 55:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 55:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 56:	fatal: error thrown and no exception handler available.
+      From worker 56:	InterruptException()
+      From worker 56:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 56:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 57:	fatal: error thrown and no exception handler available.
+      From worker 57:	InterruptException()
+      From worker 57:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 57:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 63:	fatal: error thrown and no exception handler available.
+      From worker 63:	InterruptException()
+      From worker 63:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 63:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 59:	fatal: error thrown and no exception handler available.
+      From worker 59:	InterruptException()
+      From worker 59:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 59:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 60:	fatal: error thrown and no exception handler available.
+      From worker 60:	InterruptException()
+      From worker 60:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 60:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 61:	fatal: error thrown and no exception handler available.
+      From worker 61:	InterruptException()
+      From worker 61:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 61:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 62:	fatal: error thrown and no exception handler available.
+      From worker 62:	InterruptException()
+      From worker 62:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 62:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 58:	fatal: error thrown and no exception handler available.
+      From worker 58:	InterruptException()
+      From worker 58:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 58:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 65:	fatal: error thrown and no exception handler available.
+      From worker 65:	InterruptException()
+      From worker 65:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 65:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 64:	fatal: error thrown and no exception handler available.
+      From worker 64:	InterruptException()
+      From worker 64:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 64:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 66:	fatal: error thrown and no exception handler available.
+      From worker 66:	InterruptException()
+      From worker 66:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 66:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 67:	fatal: error thrown and no exception handler available.
+      From worker 67:	InterruptException()
+      From worker 67:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 67:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 68:	fatal: error thrown and no exception handler available.
+      From worker 68:	InterruptException()
+      From worker 68:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 68:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 71:	fatal: error thrown and no exception handler available.
+      From worker 71:	InterruptException()
+      From worker 71:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 71:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 69:	fatal: error thrown and no exception handler available.
+      From worker 69:	InterruptException()
+      From worker 69:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 69:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 70:	fatal: error thrown and no exception handler available.
+      From worker 70:	InterruptException()
+      From worker 70:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 70:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 72:	fatal: error thrown and no exception handler available.
+      From worker 72:	InterruptException()
+      From worker 72:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 72:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 77:	fatal: error thrown and no exception handler available.
+      From worker 77:	InterruptException()
+      From worker 77:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 77:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 74:	fatal: error thrown and no exception handler available.
+      From worker 74:	InterruptException()
+      From worker 74:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 74:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 75:	fatal: error thrown and no exception handler available.
+      From worker 75:	InterruptException()
+      From worker 75:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 75:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 73:	fatal: error thrown and no exception handler available.
+      From worker 73:	InterruptException()
+      From worker 73:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 73:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 76:	fatal: error thrown and no exception handler available.
+      From worker 76:	InterruptException()
+      From worker 76:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 76:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 82:	fatal: error thrown and no exception handler available.
+      From worker 82:	InterruptException()
+      From worker 82:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 82:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 78:	fatal: error thrown and no exception handler available.
+      From worker 78:	InterruptException()
+      From worker 78:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 78:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 80:	fatal: error thrown and no exception handler available.
+      From worker 80:	InterruptException()
+      From worker 80:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 80:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 79:	fatal: error thrown and no exception handler available.
+      From worker 79:	InterruptException()
+      From worker 79:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 79:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 84:	fatal: error thrown and no exception handler available.
+      From worker 84:	InterruptException()
+      From worker 84:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 84:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 83:	fatal: error thrown and no exception handler available.
+      From worker 83:	InterruptException()
+      From worker 83:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 83:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 94:	fatal: error thrown and no exception handler available.
+      From worker 94:	InterruptException()
+      From worker 94:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 94:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 86:	fatal: error thrown and no exception handler available.
+      From worker 86:	InterruptException()
+      From worker 85:	fatal: error thrown and no exception handler available.
+      From worker 85:	InterruptException()
+      From worker 85:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 85:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 92:	fatal: error thrown and no exception handler available.
+      From worker 92:	InterruptException()
+      From worker 92:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 92:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 96:	fatal: error thrown and no exception handler available.
+      From worker 96:	InterruptException()
+      From worker 96:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 96:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 89:	fatal: error thrown and no exception handler available.
+      From worker 89:	InterruptException()
+      From worker 87:	fatal: error thrown and no exception handler available.
+      From worker 87:	InterruptException()
+      From worker 93:	fatal: error thrown and no exception handler available.
+      From worker 93:	InterruptException()
+      From worker 90:	fatal: error thrown and no exception handler available.
+      From worker 90:	InterruptException()
+      From worker 90:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 90:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 91:	fatal: error thrown and no exception handler available.
+      From worker 91:	InterruptException()
+      From worker 95:	fatal: error thrown and no exception handler available.
+      From worker 95:	InterruptException()
+      From worker 101:	fatal: error thrown and no exception handler available.
+      From worker 101:	InterruptException()
+      From worker 97:	fatal: error thrown and no exception handler available.
+      From worker 97:	InterruptException()
+      From worker 102:	fatal: error thrown and no exception handler available.
+      From worker 102:	InterruptException()
+      From worker 104:	fatal: error thrown and no exception handler available.
+      From worker 104:	InterruptException()
+      From worker 107:	fatal: error thrown and no exception handler available.
+      From worker 107:	InterruptException()
+      From worker 103:	fatal: error thrown and no exception handler available.
+      From worker 103:	InterruptException()
+      From worker 105:	fatal: error thrown and no exception handler available.
+      From worker 105:	InterruptException()
+      From worker 108:	fatal: error thrown and no exception handler available.
+      From worker 108:	InterruptException()
+      From worker 98:	fatal: error thrown and no exception handler available.
+      From worker 98:	InterruptException()
+      From worker 99:	fatal: error thrown and no exception handler available.
+      From worker 99:	InterruptException()
+      From worker 106:	fatal: error thrown and no exception handler available.
+      From worker 106:	InterruptException()
+      From worker 106:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 106:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 109:	fatal: error thrown and no exception handler available.
+      From worker 109:	InterruptException()
+      From worker 111:	fatal: error thrown and no exception handler available.
+      From worker 111:	InterruptException()
+      From worker 113:	fatal: error thrown and no exception handler available.
+      From worker 113:	InterruptException()
+      From worker 116:	fatal: error thrown and no exception handler available.
+      From worker 116:	InterruptException()
+      From worker 117:	fatal: error thrown and no exception handler available.
+      From worker 117:	InterruptException()
+      From worker 120:	fatal: error thrown and no exception handler available.
+      From worker 120:	InterruptException()
+      From worker 118:	fatal: error thrown and no exception handler available.
+      From worker 118:	InterruptException()
+      From worker 121:	fatal: error thrown and no exception handler available.
+      From worker 121:	InterruptException()
+      From worker 115:	fatal: error thrown and no exception handler available.
+      From worker 115:	InterruptException()
+      From worker 122:	fatal: error thrown and no exception handler available.
+      From worker 122:	InterruptException()
+      From worker 122:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 122:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 119:	fatal: error thrown and no exception handler available.
+      From worker 119:	InterruptException()
+      From worker 126:	fatal: error thrown and no exception handler available.
+      From worker 126:	InterruptException()
+      From worker 126:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 126:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 123:	fatal: error thrown and no exception handler available.
+      From worker 123:	InterruptException()
+      From worker 127:	fatal: error thrown and no exception handler available.
+      From worker 127:	InterruptException()
+      From worker 124:	fatal: error thrown and no exception handler available.
+      From worker 124:	InterruptException()
+      From worker 128:	fatal: error thrown and no exception handler available.
+      From worker 128:	InterruptException()
+      From worker 125:	fatal: error thrown and no exception handler available.
+      From worker 125:	InterruptException()
+      From worker 129:	fatal: error thrown and no exception handler available.
+      From worker 129:	InterruptException()
+      From worker 133:	fatal: error thrown and no exception handler available.
+      From worker 133:	InterruptException()
+      From worker 130:	fatal: error thrown and no exception handler available.
+      From worker 130:	InterruptException()
+      From worker 134:	fatal: error thrown and no exception handler available.
+      From worker 134:	InterruptException()
+      From worker 131:	fatal: error thrown and no exception handler available.
+      From worker 131:	InterruptException()
+      From worker 136:	fatal: error thrown and no exception handler available.
+      From worker 136:	InterruptException()
+      From worker 114:	fatal: error thrown and no exception handler available.
+      From worker 114:	InterruptException()
+      From worker 132:	fatal: error thrown and no exception handler available.
+      From worker 132:	InterruptException()
+      From worker 138:	fatal: error thrown and no exception handler available.
+      From worker 138:	InterruptException()
+      From worker 110:	fatal: error thrown and no exception handler available.
+      From worker 110:	InterruptException()
+      From worker 139:	fatal: error thrown and no exception handler available.
+      From worker 139:	InterruptException()
+      From worker 112:	fatal: error thrown and no exception handler available.
+      From worker 112:	InterruptException()
+      From worker 142:	fatal: error thrown and no exception handler available.
+      From worker 142:	InterruptException()
+      From worker 137:	fatal: error thrown and no exception handler available.
+      From worker 137:	InterruptException()
+      From worker 140:	fatal: error thrown and no exception handler available.
+      From worker 140:	InterruptException()
+      From worker 141:	fatal: error thrown and no exception handler available.
+      From worker 141:	InterruptException()
+      From worker 145:	fatal: error thrown and no exception handler available.
+      From worker 145:	InterruptException()
+      From worker 143:	fatal: error thrown and no exception handler available.
+      From worker 143:	InterruptException()
+      From worker 146:	fatal: error thrown and no exception handler available.
+      From worker 146:	InterruptException()
+      From worker 144:	fatal: error thrown and no exception handler available.
+      From worker 144:	InterruptException()
+      From worker 147:	fatal: error thrown and no exception handler available.
+      From worker 147:	InterruptException()
+      From worker 135:	fatal: error thrown and no exception handler available.
+      From worker 135:	InterruptException()
+      From worker 149:	fatal: error thrown and no exception handler available.
+      From worker 149:	InterruptException()
+      From worker 148:	fatal: error thrown and no exception handler available.
+      From worker 148:	InterruptException()
+      From worker 155:	fatal: error thrown and no exception handler available.
+      From worker 155:	InterruptException()
+      From worker 151:	fatal: error thrown and no exception handler available.
+      From worker 151:	InterruptException()
+      From worker 151:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 151:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 157:	fatal: error thrown and no exception handler available.
+      From worker 157:	InterruptException()
+      From worker 157:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 157:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 156:	fatal: error thrown and no exception handler available.
+      From worker 156:	InterruptException()
+      From worker 158:	fatal: error thrown and no exception handler available.
+      From worker 158:	InterruptException()
+      From worker 154:	fatal: error thrown and no exception handler available.
+      From worker 154:	InterruptException()
+      From worker 160:	fatal: error thrown and no exception handler available.
+      From worker 160:	InterruptException()
+      From worker 159:	fatal: error thrown and no exception handler available.
+      From worker 159:	InterruptException()
+      From worker 150:	fatal: error thrown and no exception handler available.
+      From worker 150:	InterruptException()
+      From worker 152:	fatal: error thrown and no exception handler available.
+      From worker 152:	InterruptException()
+      From worker 153:	fatal: error thrown and no exception handler available.
+      From worker 153:	InterruptException()
+      From worker 117:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 117:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 146:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 146:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 155:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 155:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 120:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 120:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 154:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 154:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 158:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 158:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 127:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 127:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 134:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 134:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 107:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 107:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 128:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 128:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 121:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 121:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 133:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 133:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 139:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 139:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 142:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 142:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 138:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 138:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 129:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 129:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 136:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 136:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 145:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 145:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 116:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 116:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 147:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 147:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 91:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 91:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 113:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 113:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 97:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 97:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 109:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 109:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 141:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 141:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 89:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 89:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 156:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 156:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 132:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 132:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 108:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 108:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 125:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 125:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 104:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 104:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 102:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 102:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 101:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 101:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 131:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 131:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 98:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 98:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 135:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 135:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 153:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 153:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 111:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 111:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 152:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 152:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 112:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 112:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 123:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 123:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 150:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 150:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 140:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 140:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 149:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 149:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 137:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 137:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 143:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 143:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 119:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 119:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 148:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 148:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 99:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 99:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 93:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 93:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 114:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 114:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 159:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 159:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 130:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 130:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 160:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 160:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 87:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 87:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 95:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 95:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 124:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 124:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 110:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 110:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 115:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 115:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 103:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 103:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 118:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 118:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 86:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 86:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 105:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 105:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 144:	jl_mutex_unlock at /buildworker/worker/package_linux64/build/src/julia_locks.h:129 [inlined]
+      From worker 144:	jl_task_get_next at /buildworker/worker/package_linux64/build/src/partr.c:484
+      From worker 84:	poptask at ./task.jl:827
+      From worker 67:	poptask at ./task.jl:827
+      From worker 72:	poptask at ./task.jl:827
+      From worker 46:	poptask at ./task.jl:827
+      From worker 56:	poptask at ./task.jl:827
+      From worker 52:	poptask at ./task.jl:827
+      From worker 55:	poptask at ./task.jl:827
+      From worker 76:	poptask at ./task.jl:827
+      From worker 75:	poptask at ./task.jl:827
+      From worker 77:	poptask at ./task.jl:827
+      From worker 74:	poptask at ./task.jl:827
+      From worker 83:	poptask at ./task.jl:827
+      From worker 49:	poptask at ./task.jl:827
+      From worker 66:	poptask at ./task.jl:827
+      From worker 65:	poptask at ./task.jl:827
+      From worker 44:	poptask at ./task.jl:827
+      From worker 48:	poptask at ./task.jl:827
+      From worker 84:	wait at ./task.jl:836
+      From worker 43:	poptask at ./task.jl:827
+      From worker 76:	wait at ./task.jl:836
+      From worker 55:	wait at ./task.jl:836
+      From worker 47:	poptask at ./task.jl:827
+      From worker 74:	wait at ./task.jl:836
+      From worker 62:	poptask at ./task.jl:827
+      From worker 67:	wait at ./task.jl:836
+      From worker 45:	poptask at ./task.jl:827
+      From worker 83:	wait at ./task.jl:836
+      From worker 77:	wait at ./task.jl:836
+      From worker 68:	poptask at ./task.jl:827
+      From worker 72:	wait at ./task.jl:836
+      From worker 75:	wait at ./task.jl:836
+      From worker 66:	wait at ./task.jl:836
+      From worker 56:	wait at ./task.jl:836
+      From worker 78:	poptask at ./task.jl:827
+      From worker 52:	wait at ./task.jl:836
+      From worker 65:	wait at ./task.jl:836
+      From worker 46:	wait at ./task.jl:836
+      From worker 49:	wait at ./task.jl:836
+      From worker 82:	poptask at ./task.jl:827
+      From worker 85:	poptask at ./task.jl:827
+      From worker 157:	poptask at ./task.jl:827
+      From worker 70:	poptask at ./task.jl:827
+      From worker 84:	task_done_hook at ./task.jl:544
+      From worker 76:	task_done_hook at ./task.jl:544
+      From worker 76:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 76:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 61:	poptask at ./task.jl:827
+      From worker 55:	task_done_hook at ./task.jl:544
+      From worker 55:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 55:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 74:	task_done_hook at ./task.jl:544
+      From worker 120:	poptask at ./task.jl:827
+      From worker 48:	wait at ./task.jl:836
+      From worker 74:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 74:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 67:	task_done_hook at ./task.jl:544
+      From worker 44:	wait at ./task.jl:836
+      From worker 94:	poptask at ./task.jl:827
+      From worker 67:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 67:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 83:	task_done_hook at ./task.jl:544
+      From worker 63:	poptask at ./task.jl:827
+      From worker 83:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 83:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 77:	task_done_hook at ./task.jl:544
+      From worker 45:	wait at ./task.jl:836
+      From worker 77:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 77:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 59:	poptask at ./task.jl:827
+      From worker 72:	task_done_hook at ./task.jl:544
+      From worker 72:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 72:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 155:	poptask at ./task.jl:827
+      From worker 75:	task_done_hook at ./task.jl:544
+      From worker 75:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 75:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 66:	task_done_hook at ./task.jl:544
+      From worker 66:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 66:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 56:	task_done_hook at ./task.jl:544
+      From worker 126:	poptask at ./task.jl:827
+      From worker 56:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 56:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 52:	task_done_hook at ./task.jl:544
+      From worker 96:	poptask at ./task.jl:827
+      From worker 52:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 52:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 65:	task_done_hook at ./task.jl:544
+      From worker 60:	poptask at ./task.jl:827
+      From worker 65:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 65:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 46:	task_done_hook at ./task.jl:544
+      From worker 68:	wait at ./task.jl:836
+      From worker 64:	poptask at ./task.jl:827
+      From worker 46:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 46:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 46:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 46:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 49:	task_done_hook at ./task.jl:544
+      From worker 84:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 84:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 84:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 84:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 84:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 49:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 49:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 49:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 49:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 49:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 76:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 76:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 76:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 55:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 55:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 57:	poptask at ./task.jl:827
+      From worker 55:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 74:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 74:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 74:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 62:	wait at ./task.jl:836
+      From worker 47:	wait at ./task.jl:836
+      From worker 67:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 67:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 67:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 92:	poptask at ./task.jl:827
+      From worker 83:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 83:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 83:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 78:	wait at ./task.jl:836
+      From worker 43:	wait at ./task.jl:836
+      From worker 77:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 77:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 77:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 72:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 72:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 72:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 82:	wait at ./task.jl:836
+      From worker 75:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 75:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 75:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 66:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 66:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 66:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 56:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 56:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 56:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 52:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 52:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 52:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 85:	wait at ./task.jl:836
+      From worker 65:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 65:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 65:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 46:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 157:	wait at ./task.jl:836
+      From worker 57:	wait at ./task.jl:836
+      From worker 44:	task_done_hook at ./task.jl:544
+      From worker 44:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 44:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 44:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 44:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 48:	task_done_hook at ./task.jl:544
+      From worker 45:	task_done_hook at ./task.jl:544
+      From worker 61:	wait at ./task.jl:836
+      From worker 48:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 48:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 94:	wait at ./task.jl:836
+      From worker 59:	wait at ./task.jl:836
+      From worker 78:	task_done_hook at ./task.jl:544
+      From worker 45:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 45:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 96:	wait at ./task.jl:836
+      From worker 155:	wait at ./task.jl:836
+      From worker 82:	task_done_hook at ./task.jl:544
+      From worker 82:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 63:	wait at ./task.jl:836
+      From worker 82:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 45:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 45:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 60:	wait at ./task.jl:836
+      From worker 85:	task_done_hook at ./task.jl:544
+      From worker 126:	wait at ./task.jl:836
+      From worker 48:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 48:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 48:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 62:	task_done_hook at ./task.jl:544
+      From worker 62:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 62:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 44:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 70:	wait at ./task.jl:836
+      From worker 68:	task_done_hook at ./task.jl:544
+      From worker 64:	wait at ./task.jl:836
+      From worker 68:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 68:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 45:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 92:	wait at ./task.jl:836
+      From worker 47:	task_done_hook at ./task.jl:544
+      From worker 78:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 78:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 47:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 47:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 78:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 78:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 47:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 47:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 47:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 43:	task_done_hook at ./task.jl:544
+      From worker 62:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 62:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 62:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 43:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 43:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 43:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 43:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 43:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 157:	task_done_hook at ./task.jl:544
+      From worker 120:	wait at ./task.jl:836
+      From worker 68:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 68:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 68:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 82:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 82:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 82:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 157:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 157:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 157:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 157:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 157:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 85:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 85:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 85:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 85:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 78:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 85:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 70:	task_done_hook at ./task.jl:544
+      From worker 64:	task_done_hook at ./task.jl:544
+      From worker 120:	task_done_hook at ./task.jl:544
+      From worker 61:	task_done_hook at ./task.jl:544
+      From worker 61:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 61:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 59:	task_done_hook at ./task.jl:544
+      From worker 94:	task_done_hook at ./task.jl:544
+      From worker 155:	task_done_hook at ./task.jl:544
+      From worker 155:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 155:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 96:	task_done_hook at ./task.jl:544
+      From worker 96:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 96:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 60:	task_done_hook at ./task.jl:544
+      From worker 60:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 60:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 60:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 60:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 63:	task_done_hook at ./task.jl:544
+      From worker 63:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 63:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 63:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 63:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 63:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 126:	task_done_hook at ./task.jl:544
+      From worker 126:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 126:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 126:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 126:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 59:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 59:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 59:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 59:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 57:	task_done_hook at ./task.jl:544
+      From worker 57:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 57:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 57:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 57:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 70:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 70:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 70:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 70:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 92:	task_done_hook at ./task.jl:544
+      From worker 92:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 92:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 92:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 92:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 64:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 64:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 64:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 64:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 64:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 120:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 120:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 120:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 120:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 120:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 94:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 94:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 94:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 94:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 94:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 155:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 155:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 155:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 61:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 61:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 61:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 70:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 60:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 59:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 96:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 96:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 96:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 126:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 57:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 92:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 54:	poptask at ./task.jl:827
+      From worker 50:	poptask at ./task.jl:827
+      From worker 54:	wait at ./task.jl:836
+      From worker 50:	wait at ./task.jl:836
+      From worker 54:	task_done_hook at ./task.jl:544
+      From worker 54:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 54:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 54:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 54:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 54:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 50:	task_done_hook at ./task.jl:544
+      From worker 50:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 50:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 50:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 50:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 50:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 73:	poptask at ./task.jl:827
+      From worker 73:	wait at ./task.jl:836
+      From worker 73:	task_done_hook at ./task.jl:544
+      From worker 73:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 73:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 73:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 73:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 73:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 90:	poptask at ./task.jl:827
+      From worker 90:	wait at ./task.jl:836
+      From worker 90:	task_done_hook at ./task.jl:544
+      From worker 90:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 90:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 90:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 90:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 90:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 58:	poptask at ./task.jl:827
+      From worker 58:	wait at ./task.jl:836
+      From worker 58:	task_done_hook at ./task.jl:544
+      From worker 58:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 58:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 58:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 58:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 58:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 151:	poptask at ./task.jl:827
+      From worker 151:	wait at ./task.jl:836
+      From worker 151:	task_done_hook at ./task.jl:544
+      From worker 151:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 151:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 151:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 151:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 151:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 122:	poptask at ./task.jl:827
+      From worker 122:	wait at ./task.jl:836
+      From worker 122:	task_done_hook at ./task.jl:544
+      From worker 122:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 122:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 122:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 122:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 122:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 110:	poptask at ./task.jl:827
+      From worker 69:	poptask at ./task.jl:827
+      From worker 93:	poptask at ./task.jl:827
+      From worker 142:	poptask at ./task.jl:827
+      From worker 51:	poptask at ./task.jl:827
+      From worker 107:	poptask at ./task.jl:827
+      From worker 110:	wait at ./task.jl:836
+      From worker 144:	poptask at ./task.jl:827
+      From worker 99:	poptask at ./task.jl:827
+      From worker 138:	poptask at ./task.jl:827
+      From worker 105:	poptask at ./task.jl:827
+      From worker 111:	poptask at ./task.jl:827
+      From worker 152:	poptask at ./task.jl:827
+      From worker 105:	wait at ./task.jl:836
+      From worker 99:	wait at ./task.jl:836
+      From worker 69:	wait at ./task.jl:836
+      From worker 104:	poptask at ./task.jl:827
+      From worker 91:	poptask at ./task.jl:827
+      From worker 125:	poptask at ./task.jl:827
+      From worker 156:	poptask at ./task.jl:827
+      From worker 97:	poptask at ./task.jl:827
+      From worker 117:	poptask at ./task.jl:827
+      From worker 136:	poptask at ./task.jl:827
+      From worker 143:	poptask at ./task.jl:827
+      From worker 106:	poptask at ./task.jl:827
+      From worker 116:	poptask at ./task.jl:827
+      From worker 95:	poptask at ./task.jl:827
+      From worker 71:	poptask at ./task.jl:827
+      From worker 115:	poptask at ./task.jl:827
+      From worker 121:	poptask at ./task.jl:827
+      From worker 128:	poptask at ./task.jl:827
+      From worker 86:	poptask at ./task.jl:827
+      From worker 144:	wait at ./task.jl:836
+      From worker 125:	wait at ./task.jl:836
+      From worker 156:	wait at ./task.jl:836
+      From worker 146:	poptask at ./task.jl:827
+      From worker 99:	task_done_hook at ./task.jl:544
+      From worker 99:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 99:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 143:	wait at ./task.jl:836
+      From worker 91:	wait at ./task.jl:836
+      From worker 119:	poptask at ./task.jl:827
+      From worker 97:	wait at ./task.jl:836
+      From worker 106:	wait at ./task.jl:836
+      From worker 159:	poptask at ./task.jl:827
+      From worker 93:	wait at ./task.jl:836
+      From worker 144:	task_done_hook at ./task.jl:544
+      From worker 140:	poptask at ./task.jl:827
+      From worker 139:	poptask at ./task.jl:827
+      From worker 117:	wait at ./task.jl:836
+      From worker 113:	poptask at ./task.jl:827
+      From worker 152:	wait at ./task.jl:836
+      From worker 99:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 99:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 99:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 86:	wait at ./task.jl:836
+      From worker 115:	wait at ./task.jl:836
+      From worker 121:	wait at ./task.jl:836
+      From worker 156:	task_done_hook at ./task.jl:544
+      From worker 112:	poptask at ./task.jl:827
+      From worker 128:	wait at ./task.jl:836
+      From worker 154:	poptask at ./task.jl:827
+      From worker 138:	wait at ./task.jl:836
+      From worker 108:	poptask at ./task.jl:827
+      From worker 104:	wait at ./task.jl:836
+      From worker 144:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 144:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 144:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 144:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 144:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 125:	task_done_hook at ./task.jl:544
+      From worker 125:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 125:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 125:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 125:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 125:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 111:	wait at ./task.jl:836
+      From worker 51:	wait at ./task.jl:836
+      From worker 106:	task_done_hook at ./task.jl:544
+      From worker 109:	poptask at ./task.jl:827
+      From worker 153:	poptask at ./task.jl:827
+      From worker 148:	poptask at ./task.jl:827
+      From worker 102:	poptask at ./task.jl:827
+      From worker 143:	task_done_hook at ./task.jl:544
+      From worker 143:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 143:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 143:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 143:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 143:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 97:	task_done_hook at ./task.jl:544
+      From worker 117:	task_done_hook at ./task.jl:544
+      From worker 117:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 117:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 117:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 103:	poptask at ./task.jl:827
+      From worker 156:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 156:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 156:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 156:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 156:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 146:	wait at ./task.jl:836
+      From worker 130:	poptask at ./task.jl:827
+      From worker 136:	wait at ./task.jl:836
+      From worker 128:	task_done_hook at ./task.jl:544
+      From worker 128:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 79:	poptask at ./task.jl:827
+      From worker 97:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 97:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 101:	poptask at ./task.jl:827
+      From worker 97:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 97:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 97:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 142:	wait at ./task.jl:836
+      From worker 106:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 106:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 106:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 106:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 106:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 91:	task_done_hook at ./task.jl:544
+      From worker 91:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 91:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 91:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 91:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 86:	task_done_hook at ./task.jl:544
+      From worker 86:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 86:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 86:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 86:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 86:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 121:	task_done_hook at ./task.jl:544
+      From worker 117:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 112:	wait at ./task.jl:836
+      From worker 117:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 71:	wait at ./task.jl:836
+      From worker 154:	wait at ./task.jl:836
+      From worker 115:	task_done_hook at ./task.jl:544
+      From worker 115:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 115:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 115:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 115:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 89:	poptask at ./task.jl:827
+      From worker 115:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 103:	wait at ./task.jl:836
+      From worker 140:	wait at ./task.jl:836
+      From worker 139:	wait at ./task.jl:836
+      From worker 107:	wait at ./task.jl:836
+      From worker 135:	poptask at ./task.jl:827
+      From worker 87:	poptask at ./task.jl:827
+      From worker 128:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 128:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 128:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 128:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 80:	poptask at ./task.jl:827
+      From worker 110:	task_done_hook at ./task.jl:544
+      From worker 91:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 153:	wait at ./task.jl:836
+      From worker 146:	task_done_hook at ./task.jl:544
+      From worker 105:	task_done_hook at ./task.jl:544
+      From worker 146:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 146:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 102:	wait at ./task.jl:836
+      From worker 146:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 121:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 121:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 121:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 121:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 121:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 118:	poptask at ./task.jl:827
+      From worker 116:	wait at ./task.jl:836
+      From worker 69:	task_done_hook at ./task.jl:544
+      From worker 69:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 69:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 69:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 69:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 134:	poptask at ./task.jl:827
+      From worker 95:	wait at ./task.jl:836
+      From worker 131:	poptask at ./task.jl:827
+      From worker 146:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 146:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 154:	task_done_hook at ./task.jl:544
+      From worker 154:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 154:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 154:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 154:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 119:	wait at ./task.jl:836
+      From worker 140:	task_done_hook at ./task.jl:544
+      From worker 140:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 140:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 139:	task_done_hook at ./task.jl:544
+      From worker 139:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 139:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 133:	poptask at ./task.jl:827
+      From worker 93:	task_done_hook at ./task.jl:544
+      From worker 105:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 105:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 105:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 105:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 153:	task_done_hook at ./task.jl:544
+      From worker 102:	task_done_hook at ./task.jl:544
+      From worker 110:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 110:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 102:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 102:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 110:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 110:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 110:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 112:	task_done_hook at ./task.jl:544
+      From worker 150:	poptask at ./task.jl:827
+      From worker 112:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 112:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 112:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 112:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 103:	task_done_hook at ./task.jl:544
+      From worker 129:	poptask at ./task.jl:827
+      From worker 140:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 140:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 140:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 113:	wait at ./task.jl:836
+      From worker 159:	wait at ./task.jl:836
+      From worker 139:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 139:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 139:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 69:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 154:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 79:	wait at ./task.jl:836
+      From worker 108:	wait at ./task.jl:836
+      From worker 98:	poptask at ./task.jl:827
+      From worker 138:	task_done_hook at ./task.jl:544
+      From worker 153:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 153:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 153:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 153:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 153:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 102:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 102:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 102:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 51:	task_done_hook at ./task.jl:544
+      From worker 51:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 51:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 112:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 152:	task_done_hook at ./task.jl:544
+      From worker 152:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 152:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 103:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 103:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 103:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 103:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 103:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 136:	task_done_hook at ./task.jl:544
+      From worker 136:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 136:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 132:	poptask at ./task.jl:827
+      From worker 160:	poptask at ./task.jl:827
+      From worker 109:	wait at ./task.jl:836
+      From worker 107:	task_done_hook at ./task.jl:544
+      From worker 104:	task_done_hook at ./task.jl:544
+      From worker 104:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 104:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 104:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 104:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 123:	poptask at ./task.jl:827
+      From worker 93:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 93:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 93:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 93:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 111:	task_done_hook at ./task.jl:544
+      From worker 111:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 111:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 148:	wait at ./task.jl:836
+      From worker 124:	poptask at ./task.jl:827
+      From worker 80:	wait at ./task.jl:836
+      From worker 105:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 142:	task_done_hook at ./task.jl:544
+      From worker 142:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 142:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 131:	wait at ./task.jl:836
+      From worker 135:	wait at ./task.jl:836
+      From worker 134:	wait at ./task.jl:836
+      From worker 87:	wait at ./task.jl:836
+      From worker 138:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 138:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 138:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 138:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 71:	task_done_hook at ./task.jl:544
+      From worker 51:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 51:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 51:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 152:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 152:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 89:	wait at ./task.jl:836
+      From worker 152:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 136:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 136:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 107:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 107:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 136:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 107:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 107:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 101:	wait at ./task.jl:836
+      From worker 130:	wait at ./task.jl:836
+      From worker 93:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 137:	poptask at ./task.jl:827
+      From worker 119:	task_done_hook at ./task.jl:544
+      From worker 116:	task_done_hook at ./task.jl:544
+      From worker 142:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 142:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 142:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 141:	poptask at ./task.jl:827
+      From worker 111:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 111:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 111:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 159:	task_done_hook at ./task.jl:544
+      From worker 127:	poptask at ./task.jl:827
+      From worker 114:	poptask at ./task.jl:827
+      From worker 104:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 108:	task_done_hook at ./task.jl:544
+      From worker 138:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 71:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 71:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 145:	poptask at ./task.jl:827
+      From worker 71:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 71:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 71:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 147:	poptask at ./task.jl:827
+      From worker 95:	task_done_hook at ./task.jl:544
+      From worker 95:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 95:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 116:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 116:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 150:	wait at ./task.jl:836
+      From worker 116:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 116:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 113:	task_done_hook at ./task.jl:544
+      From worker 118:	wait at ./task.jl:836
+      From worker 119:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 119:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 119:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 119:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 148:	task_done_hook at ./task.jl:544
+      From worker 133:	wait at ./task.jl:836
+      From worker 98:	wait at ./task.jl:836
+      From worker 107:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 123:	wait at ./task.jl:836
+      From worker 149:	poptask at ./task.jl:827
+      From worker 129:	wait at ./task.jl:836
+      From worker 108:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 108:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 108:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 108:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 109:	task_done_hook at ./task.jl:544
+      From worker 132:	wait at ./task.jl:836
+      From worker 124:	wait at ./task.jl:836
+      From worker 89:	task_done_hook at ./task.jl:544
+      From worker 158:	poptask at ./task.jl:827
+      From worker 159:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 159:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 159:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 159:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 116:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 87:	task_done_hook at ./task.jl:544
+      From worker 87:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 87:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 148:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 148:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 160:	wait at ./task.jl:836
+      From worker 148:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 148:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 148:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 135:	task_done_hook at ./task.jl:544
+      From worker 95:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 95:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 95:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 79:	task_done_hook at ./task.jl:544
+      From worker 79:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 79:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 79:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 79:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 134:	task_done_hook at ./task.jl:544
+      From worker 134:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 134:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 113:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 113:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 113:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 113:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 113:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 119:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 101:	task_done_hook at ./task.jl:544
+      From worker 131:	task_done_hook at ./task.jl:544
+      From worker 131:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 131:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 108:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 131:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 80:	task_done_hook at ./task.jl:544
+      From worker 114:	wait at ./task.jl:836
+Worker 53 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 81 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 88 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+Worker 100 terminated.
+UNHANDLED TASK ERROR: IOError: read: connection reset by peer (ECONNRESET)
+Stacktrace:
+ [1] wait_readnb(x::Sockets.TCPSocket, nb::Int64)
+   @ Base ./stream.jl:408
+ [2] (::Base.var"#wait_locked#644")(s::Sockets.TCPSocket, buf::IOBuffer, nb::Int64)
+   @ Base ./stream.jl:848
+ [3] readbytes!(s::Sockets.TCPSocket, a::Vector{UInt8}, nb::Int64)
+   @ Base ./stream.jl:854
+ [4] read(s::Sockets.TCPSocket, nb::Int64)
+   @ Base ./io.jl:965
+ [5] process_hdr(s::Sockets.TCPSocket, validate_cookie::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:265
+ [6] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:151
+ [7] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
+   @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:126
+ [8] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
+   @ Distributed ./task.jl:423
+ERROR: TaskFailedException
+
+    nested task error: worker did not connect within 60.0 seconds
+    Stacktrace:
+     [1] error(s::String)
+       @ Base ./error.jl:33
+     [2] create_worker(manager::Distributed.LocalManager, wconfig::WorkerConfig)
+       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:687
+     [3] setup_launched_worker(manager::Distributed.LocalManager, wconfig::WorkerConfig, launched_q::Vector{Int64})
+       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:541
+     [4] (::Distributed.var"#41#44"{Distributed.LocalManager, Vector{Int64}, WorkerConfig})()
+       @ Distributed ./task.jl:423
+
+...and 5 more exceptions.
+
+Stacktrace:
+  [1] sync_end(c::Channel{Any})
+    @ Base ./task.jl:381
+  [2] macro expansion
+    @ ./task.jl:400 [inlined]
+  [3] addprocs_locked(manager::Distributed.LocalManager; kwargs::Base.Pairs{Symbol, Cmd, Tuple{Symbol}, NamedTuple{(:exeflags,), Tuple{Cmd}}})
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:487
+  [4] addprocs(manager::Distributed.LocalManager; kwargs::Base.Pairs{Symbol, Cmd, Tuple{Symbol}, NamedTuple{(:exeflags,), Tuple{Cmd}}})
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:447
+  [5] #addprocs#257
+    @ /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/managers.jl:436 [inlined]
+  [6] process_opts(opts::Base.JLOptions)
+    @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1334
+  [7] #invokelatest#2
+    @ ./essentials.jl:716 [inlined]
+  [8] invokelatest
+    @ ./essentials.jl:714 [inlined]
+  [9] exec_options(opts::Base.JLOptions)
+    @ Base ./client.jl:252
+ [10] _start()
+    @ Base ./client.jl:495
+┌ Warning: Forcibly interrupting busy workers
+│   exception = IOError: stream is closed or unusable
+└ @ Distributed /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1249
+┌ Error: Unable to terminate all workers
+│   exception =
+│    rmprocs: pids [43, 44, 45, 46, 47, 48, 49, 50, 51, 54, 57, 58, 59, 60, 61, 62, 63, 65, 66, 68, 69, 70, 71, 73, 75, 77, 79, 80, 82, 83, 84, 85, 86, 87, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 152, 153, 154, 156, 157, 158, 159, 160] not terminated after 5.0 seconds.
+│    Stacktrace:
+│     [1] _rmprocs(pids::Vector{Int64}, waitfor::Float64)
+│       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1065
+│     [2] rmprocs(pids::Vector{Int64}; waitfor::Float64)
+│       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1033
+│     [3] terminate_all_workers()
+│       @ Distributed /central/software/julia/1.7.0/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1253
+│     [4] _atexit()
+│       @ Base ./initdefs.jl:350
+│     [5] exit
+│       @ ./initdefs.jl:28 [inlined]
+│     [6] _start()
+│       @ Base ./client.jl:498
+└ @ Distributed /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Distributed/src/cluster.jl:1255
+      From worker 131:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 109:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 109:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 109:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 109:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 109:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 89:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 89:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 135:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 135:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 159:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 147:	wait at ./task.jl:836
+      From worker 130:	task_done_hook at ./task.jl:544
+      From worker 130:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 130:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 137:	wait at ./task.jl:836
+      From worker 87:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 87:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 87:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 141:	wait at ./task.jl:836
+      From worker 134:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 134:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 134:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 79:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 127:	wait at ./task.jl:836
+      From worker 101:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 101:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 101:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 101:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 129:	task_done_hook at ./task.jl:544
+      From worker 80:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 80:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 80:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 80:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 80:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 89:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 89:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 89:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 131:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 118:	task_done_hook at ./task.jl:544
+      From worker 133:	task_done_hook at ./task.jl:544
+      From worker 118:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 118:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 133:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 133:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 98:	task_done_hook at ./task.jl:544
+      From worker 130:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 130:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 130:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 135:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 135:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 135:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 158:	wait at ./task.jl:836
+      From worker 145:	wait at ./task.jl:836
+      From worker 160:	task_done_hook at ./task.jl:544
+      From worker 150:	task_done_hook at ./task.jl:544
+      From worker 150:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 150:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 150:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 150:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 149:	wait at ./task.jl:836
+      From worker 101:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 123:	task_done_hook at ./task.jl:544
+      From worker 123:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 123:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 129:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 129:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 129:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 129:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 118:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 118:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 118:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 133:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 133:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 133:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 132:	task_done_hook at ./task.jl:544
+      From worker 132:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 132:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 124:	task_done_hook at ./task.jl:544
+      From worker 124:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 124:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 127:	task_done_hook at ./task.jl:544
+      From worker 98:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 98:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 98:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 98:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 98:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 160:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 160:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 160:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 160:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 129:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 150:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 123:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 123:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 123:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 141:	task_done_hook at ./task.jl:544
+      From worker 114:	task_done_hook at ./task.jl:544
+      From worker 114:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 114:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 124:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 124:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 124:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 127:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 127:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 132:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 132:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 132:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 147:	task_done_hook at ./task.jl:544
+      From worker 147:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 147:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 127:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 127:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 137:	task_done_hook at ./task.jl:544
+      From worker 160:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 149:	task_done_hook at ./task.jl:544
+      From worker 141:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 141:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 141:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 141:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 141:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 145:	task_done_hook at ./task.jl:544
+      From worker 127:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 114:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 114:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 114:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 137:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 137:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 147:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 147:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 147:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 158:	task_done_hook at ./task.jl:544
+      From worker 149:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 149:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 149:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 149:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 137:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 137:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 145:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 145:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 145:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 145:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 137:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 158:	_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2247 [inlined]
+      From worker 158:	jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2429
+      From worker 158:	jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1788 [inlined]
+      From worker 158:	jl_finish_task at /buildworker/worker/package_linux64/build/src/task.c:218
+      From worker 158:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 149:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+      From worker 145:	start_task at /buildworker/worker/package_linux64/build/src/task.c:888
+slurmstepd: error: Detected 2778 oom-kill event(s) in step 21602794.batch cgroup. Some of your processes may have been killed by the cgroup out-of-memory handler.

--- a/experiments/les_strats/julia_parallel/slurm-21602887.out
+++ b/experiments/les_strats/julia_parallel/slurm-21602887.out
@@ -1,0 +1,5 @@
+
+signal (11): Segmentation fault
+in expression starting at /central/groups/esm/ilopezgo/CalibrateEDMF.jl/experiments/les_strats/julia_parallel/calibrate.jl:15
+/var/spool/slurmd/job21602887/slurm_script: line 13:  6094 Bus error               (core dumped) julia --project -p 159 calibrate.jl --config ../config_nn_uki20.jl
+slurmstepd: error: Detected 776319 oom-kill event(s) in step 21602887.batch cgroup. Some of your processes may have been killed by the cgroup out-of-memory handler.


### PR DESCRIPTION
Here is an example of an expensive calibration process that fails using Julia_pmap. I think the main issue comes from the memory requirements when building the ReferenceStatistics object from numerous pycles netcdf files.