### PR TITLE
Add restart option for global_parallel

### DIFF
--- a/experiments/SCT1_benchmark/config.jl
+++ b/experiments/SCT1_benchmark/config.jl
@@ -168,6 +168,7 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
+        ("stats_io", "calibrate_io", false),
         ("grid", "dz", 50.0),
         ("grid", "nz", 80),
     ]

--- a/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
@@ -7,7 +7,6 @@ using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
-src_dir = dirname(pathof(CalibrateEDMF))
 using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses

--- a/experiments/SCT1_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT1_benchmark/global_parallel/restart.jl
@@ -1,0 +1,36 @@
+"""Restarts a calibration process."""
+
+# Import modules to all processes
+using ArgParse
+using Glob
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.Pipeline
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--output_dir"
+    help = "Results output directory"
+    arg_type = String
+    "--job_id"
+    help = "Job identifier"
+    arg_type = String
+    default = "12345"
+end
+parsed_args = parse_args(ARGS, s)
+# Recover inputs for restart
+outdir_path = parsed_args["output_dir"]
+include(joinpath(outdir_path, "config.jl"))
+ekobjs = glob(joinpath(outdir_path, "ekobj_iter_*.jld2"))
+iters = [parse(Int64, split(split(split(ekobj, "/")[2], "_")[3], ".")[1]) for ekobj in ekobjs]
+last_iteration = maximum(iters)
+
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, last_iteration))["ekp"]
+config = get_config()
+restart_calibration(ekobj, priors, last_iteration, config, outdir_path, job_id = parsed_args["job_id"])

--- a/experiments/SCT1_benchmark/global_parallel/restart.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/restart.sbatch
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "restart"   # job name
+
+module purge
+module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1
+
+output_dir=${1?Error: no output directory given}
+job_id=${2?Error: no job ID given}
+
+julia --project restart.jl --output_dir $output_dir --job_id $job_id
+echo "Calibration process at ${output_dir} restarted."

--- a/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#SBATCH --time=0:20:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH -J "restart_call"   # job name
+
+output_dir=${1?Error: no output directory given}
+config=${output_dir}/"config.jl"
+
+# Job identifier
+job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+# Get size of the ensemble from config, trim comments and whitespace
+n=$(grep N_ens ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Total umber of calibration iterations (previous+new), trim comments and whitespace
+n_it=$(grep N_iter ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Get last iteration
+last_ekobj=$(ls -v ${output_dir}/ekobj_iter_* | tail -1)
+last_iter=${last_ekobj%.*} # Remove trailing file format
+last_iter=${last_iter##*_} # Remove leading filename
+first_new_iter=$(($last_iter + 1))
+
+# Number of parallel processes for SCM evaluation, split evenly between train and validation
+n_proc_scm=10
+echo "Restarting calibration with ${n} ensemble members and ${n_it} iterations (grand total)."
+
+module purge
+module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
+export JULIA_MPI_BINARY=system
+export JULIA_CUDA_USE_BINARYBUILDER=false
+
+# run instantiate/precompile serial
+julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -e 'using Pkg; Pkg.precompile()'
+
+# First call to calibrate.jl will create the ensemble files from the priors
+id_restart_ens=$(sbatch --parsable -A esm restart.sbatch $output_dir $job_id)
+for it in $(seq $first_new_iter 1 $n_it)
+do
+# Parallel runs of forward model
+if [ "$it" = "$first_new_iter" ]; then
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_restart_ens --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+else
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+fi
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
+done
+

--- a/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
+++ b/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
@@ -5,7 +5,6 @@ using ArgParse
 using CalibrateEDMF
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.Pipeline
-src_dir = dirname(pathof(CalibrateEDMF))
 using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -78,7 +78,7 @@ run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = nameli
     end
 end
 
-@testset "Pipeline" begin
+@testset "Pipeline with restart" begin
 
     ###  Test HPC pipeline
     outdir_path = init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"))
@@ -127,6 +127,15 @@ end
     for i in 1:config["process"]["N_ens"]
         @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
+
+    restart_calibration(ekobj, priors, 2, config, outdir_path, mode = "hpc")
+    @test isfile(joinpath(outdir_path, "ekobj_iter_3.jld2"))
+    @test isfile(joinpath(outdir_path, "versions_3.txt"))
+    versions = readlines(joinpath(outdir_path, "versions_3.txt"))
+    for i in 1:config["process"]["N_ens"]
+        @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
+    end
+
     rm(outdir_path, recursive = true)
 end
 
@@ -190,6 +199,14 @@ end
     @test isfile(joinpath(outdir_path, "ekobj_iter_2.jld2"))
     @test isfile(joinpath(outdir_path, "versions_2.txt"))
     versions = readlines(joinpath(outdir_path, "versions_2.txt"))
+    for i in 1:config["process"]["N_ens"]
+        @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
+    end
+
+    restart_calibration(ekobj, priors, 2, config, outdir_path, mode = "hpc")
+    @test isfile(joinpath(outdir_path, "ekobj_iter_3.jld2"))
+    @test isfile(joinpath(outdir_path, "versions_3.txt"))
+    versions = readlines(joinpath(outdir_path, "versions_3.txt"))
     for i in 1:config["process"]["N_ens"]
         @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end


### PR DESCRIPTION
- Adds Pipeline functions that allow restarting a calibration process, `restart_calibration` and `restart_validation`.
- Adds a global_parallel restart pipeline. To run the pipeline, do

```
sbatch restart_ekp_par_calibration.sbatch <results_dir_of_process_to_be_restarted>
```

This commands restarts the calibration process stored in `<results_dir_of_process_to_be_restarted>`, using the configuration stored in said directory.

The restarted simulation will continue to a grand total of `process_config["N_iter"]`, starting from the number of calibration steps that already occurred. This means that if the process had run for 50 iterations and we set process_config["N_iter"]=75, the restarted calibration will run for an additional 25 iterations. So, in order to continue a calibration that had run to completion, just modify the `process_config["N_iter"]` entry in `<results_dir_of_process_to_be_restarted>/config.jl`
