### PR TITLE
Add an integration test for the SCT1 benchmark.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,12 +92,23 @@ steps:
       config: cpu
       queue: central
 
-  - label: "Calibrate julia parallel 10 procs"
-    key: "cpu_calibrate_julia_p10"
+  - label: "Bomex julia parallel"
+    key: "cpu_bomex_julia_p10"
     command:
-      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_calibrate.jl"
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config Bomex_integration_test_config.jl"
     artifact_paths:
-      - "integration_tests/output/julia_parallel_calibrate/*"
+      - "integration_tests/output/Bomex_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
+  - label: "SCT1 julia parallel"
+    key: "cpu_sct1_julia_p10"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config SCT1_integration_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/SCT1_julia_parallel/*"
     agents:
       config: cpu
       queue: central

--- a/integration_tests/Bomex_integration_test_config.jl
+++ b/integration_tests/Bomex_integration_test_config.jl
@@ -1,0 +1,140 @@
+#= Custom calibration configuration file. =#
+
+using Distributions
+using StatsBase
+using LinearAlgebra
+using CalibrateEDMF
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.LESUtils
+using CalibrateEDMF.TurbulenceConvectionUtils
+# Import prior constraints
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+# Cases defined as structs for quick access to default configs
+struct Bomex end
+struct ValidateBomex end
+
+function get_config()
+    config = Dict()
+    # Flags for saving output data
+    config["output"] = get_output_config()
+    # Define regularization of inverse problem
+    config["regularization"] = get_regularization_config()
+    # Define reference used in the inverse problem 
+    config["reference"] = get_reference_config(Bomex())
+    # Define reference models to use for validation
+    config["validation"] = get_reference_config(ValidateBomex())
+    # Define the parameter priors
+    config["prior"] = get_prior_config()
+    # Define the kalman process
+    config["process"] = get_process_config()
+    # Define the SCM static configuration
+    config["scm"] = get_scm_config()
+    return config
+end
+
+function get_output_config()
+    config = Dict()
+    config["outdir_root"] = pwd()
+    config["overwrite_scm_file"] = false # Flag for overwritting SCM input file
+    return config
+end
+
+function get_regularization_config()
+    config = Dict()
+    # Regularization of observations: mean and covariance
+    config["perform_PCA"] = true # Performs PCA on data
+    config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
+    config["normalize"] = true  # whether to normalize data by pooled variance
+    config["tikhonov_mode"] = "relative" # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-4 # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean
+    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = nothing
+    return config
+end
+
+function get_process_config()
+    config = Dict()
+    config["N_iter"] = 10
+    config["N_ens"] = 10
+    config["algorithm"] = "Inversion" # "Sampler", "Unscented"
+    config["noisy_obs"] = false
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = true
+    config["failure_handler"] = "sample_succ_gauss"
+    return config
+end
+
+function get_reference_config(::Bomex)
+    config = Dict()
+    config["case_name"] = ["Bomex"]
+    # Flag to indicate source of data (LES or SCM) for reference data and covariance
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    # Fields to learn from during training
+    config["y_names"] = [["thetal_mean", "ql_mean", "qt_mean"]]
+    # LES data can be stored as an Artifact and downloaded lazily
+    config["y_dir"] = [LESUtils.get_path_to_artifact()]
+    # provide list of dirs if different from `y_dir`
+    # config["Σ_dir"] = [...]
+    config["scm_suffix"] = ["000000"]
+    config["scm_parent_dir"] = ["scm_init"]
+    config["t_start"] = [4.0 * 3600]
+    config["t_end"] = [6.0 * 3600]
+    # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
+    # config["Σ_t_start"] = [...]
+    # config["Σ_t_end"] = [...]
+    # If isnothing(config["batch_size"]), use all data per iteration
+    config["batch_size"] = nothing
+    return config
+end
+
+function get_reference_config(::ValidateBomex)
+    config = Dict()
+    config["case_name"] = ["Bomex"]
+    # Flag to indicate source of data (LES or SCM) for reference data and covariance
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    # Validate on different variables for this example
+    config["y_names"] = [["total_flux_h", "total_flux_qt", "u_mean", "v_mean"]]
+    config["y_dir"] = [LESUtils.get_path_to_artifact()]
+    # provide list of dirs if different from `y_dir`
+    # config["Σ_dir"] = [...]
+    config["scm_suffix"] = ["000000"]
+    config["scm_parent_dir"] = ["scm_init"]
+    config["t_start"] = [4.0 * 3600]
+    config["t_end"] = [6.0 * 3600]
+    # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
+    # config["Σ_t_start"] = [...]
+    # config["Σ_t_end"] = [...]
+    # If isnothing(config["batch_size"]), use all data per iteration
+    config["batch_size"] = nothing
+    return config
+end
+
+function get_prior_config()
+    config = Dict()
+    # Define prior bounds on the parameters.
+    config["constraints"] =
+        Dict("entrainment_factor" => [bounded(0.0, 0.5)], "detrainment_factor" => [bounded(0.3, 0.8)])
+    # Define prior mean (must be within bounds).
+    config["prior_mean"] = Dict("entrainment_factor" => [0.02], "detrainment_factor" => [0.4])
+    # Define width of the probability distribution with respect to the bounds. This is equivalent
+    # to the σ of a Gaussian in unconstrained space.
+    config["unconstrained_σ"] = 0.5
+    return config
+end
+
+function get_scm_config()
+    config = Dict()
+    # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
+    config["namelist_args"] = nothing
+    return config
+end

--- a/integration_tests/SCT1_integration_test_config.jl
+++ b/integration_tests/SCT1_integration_test_config.jl
@@ -1,0 +1,165 @@
+#= Custom calibration configuration file. =#
+
+using Distributions
+using StatsBase
+using LinearAlgebra
+using CalibrateEDMF
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.LESUtils
+using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using JLD2
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+
+struct SCT1Train end
+struct SCT1Val end
+
+function get_config()
+    config = Dict()
+    # Flags for saving output data
+    config["output"] = get_output_config()
+    # Define regularization of inverse problem
+    config["regularization"] = get_regularization_config()
+    # Define reference used in the inverse problem 
+    config["reference"] = get_reference_config(SCT1Train())
+    # Define reference used for validation
+    config["validation"] = get_reference_config(SCT1Val())
+    # Define the parameter priors
+    config["prior"] = get_prior_config()
+    # Define the kalman process
+    config["process"] = get_process_config()
+    # Define the SCM static configuration
+    config["scm"] = get_scm_config()
+    return config
+end
+
+function get_output_config()
+    config = Dict()
+    config["outdir_root"] = pwd()
+    config["overwrite_scm_file"] = false # Flag for overwritting SCM input file
+    return config
+end
+
+function get_regularization_config()
+    config = Dict()
+    # Regularization of observations: mean and covariance
+    config["perform_PCA"] = true # Performs PCA on data
+    config["variance_loss"] = 1.0e-1 # Variance truncation level in PCA
+    config["normalize"] = true  # whether to normalize data by pooled variance
+    config["tikhonov_mode"] = "relative" # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean
+    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = 1.0
+    return config
+end
+
+function get_process_config()
+    config = Dict()
+    config["N_iter"] = 2
+    config["N_ens"] = 5 # Must be 2p+1 when algorithm is "Unscented"
+    config["algorithm"] = "Unscented" # "Sampler", "Unscented", "Inversion"
+    config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = true
+    config["failure_handler"] = "sample_succ_gauss" #"high_loss"
+    return config
+end
+
+function get_reference_config(::SCT1Train)
+    config = Dict()
+
+    # AMIP data: October
+    cfsite_numbers = (17, 18, 20, 22, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 10, experiment = "amip")
+    ref_dirs = [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+    suffixes = [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+
+    n_repeat = length(ref_dirs)
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["scm_suffix"] = suffixes
+    config["scm_parent_dir"] = repeat(["scm_init"], n_repeat)
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    config["write_full_stats"] = false
+    return config
+end
+
+function get_reference_config(::SCT1Val)
+    config = Dict()
+
+    # AMIP4K data: July
+    cfsite_numbers = (3, 5, 8, 11, 14)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip4K")
+    ref_dirs = [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+    suffixes = [get_gcm_les_uuid(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+
+    n_repeat = length(ref_dirs)
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "u_mean", "v_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["scm_suffix"] = suffixes
+    config["scm_parent_dir"] = repeat(["scm_init"], n_repeat)
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    config["write_full_stats"] = false
+    return config
+end
+
+function get_prior_config()
+    config = Dict()
+    config["constraints"] = Dict(
+        # entrainment parameters
+        "entrainment_factor" => [bounded(0.0, 1.0)],
+        "detrainment_factor" => [bounded(0.0, 1.0)],
+    )
+
+    # TC.jl prior mean
+    config["prior_mean"] = Dict(
+        # entrainment parameters
+        "entrainment_factor" => [0.13],
+        "detrainment_factor" => [0.51],
+    )
+
+    config["unconstrained_σ"] = 0.25
+    return config
+end
+
+function get_scm_config()
+    config = Dict()
+    config["namelist_args"] = [
+        ("time_stepping", "dt_min", 1.0),
+        ("time_stepping", "dt_max", 2.0),
+        ("stats_io", "frequency", 60.0),
+        ("stats_io", "calibrate_io", false),
+        ("grid", "dz", 50.0),
+        ("grid", "nz", 80),
+    ]
+    return config
+end


### PR DESCRIPTION
- Adds a Julia parallel test for the ReferenceModels used in the SCT1 benchmark.
- The launch script is unified for this and the bomex integration test.
- The config files are now located in the integration tests to decouple them from the experiments.
- Both tests together test most of the diagnostics that we want to have with `calibrate_io`.
- Time to solution will be improved once we can set `calibrate_io` to true. Right now buildkite time is dominated by the SCT1 integration test, which takes <40 min for 2 iterations of UKI.