### PR TITLE
Add integration test for calibration restart, speed up Bomex.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,6 +103,18 @@ steps:
       queue: central
       slurm_cpus_per_task: 11
 
+  - label: "Bomex continue"
+    key: "cpu_bomex_continue"
+    depends_on: "cpu_bomex_julia_p10"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/continue_julia_parallel_test.jl --config Bomex_integration_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/Bomex_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
   - label: "SCT1 julia parallel"
     key: "cpu_sct1_julia_p10"
     command:

--- a/integration_tests/Bomex_integration_test_config.jl
+++ b/integration_tests/Bomex_integration_test_config.jl
@@ -135,6 +135,6 @@ end
 function get_scm_config()
     config = Dict()
     # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
-    config["namelist_args"] = nothing
+    config["namelist_args"] = [("stats_io", "calibrate_io", true)]
     return config
 end


### PR DESCRIPTION
- Adds an integration test for a restart calibration that is run for an additional 5 steps.
- Speeds up the Bomex integration test by setting `calibrate_io` to true. This works for the outputs we are using in the Bomex-config, but not others (e.g, entropy).