### PR TITLE
explicity specify config path for julia_parallel runs

### DIFF
--- a/experiments/scm_pycles_pipeline/README.md
+++ b/experiments/scm_pycles_pipeline/README.md
@@ -16,11 +16,11 @@ Within the `scm_pycles_pipeline` directory (i.e. this example), navigate to `jul
 
 If you are on the Caltech Central Cluster, you can run the project by adding it to the schedule:
 
-  >> sbatch calibrate_script
+  >> sbatch calibrate_script ../config.jl
 
 Otherwise run locally, e.g.:
 
->> sh calibrate_script
+>> sh calibrate_script ../config.jl
 
 # How to run: SLURM HPC pipeline
 

--- a/experiments/scm_pycles_pipeline/julia_parallel/calibrate_script
+++ b/experiments/scm_pycles_pipeline/julia_parallel/calibrate_script
@@ -7,8 +7,10 @@
 #SBATCH --nodes=1   # number of nodes
 #SBATCH -J "ekp_bomex"   # job name
 
+config=${1?Error: no config file given}
+
 module purge
 module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.API.precompile()'
 
-julia --project -p 10 calibrate.jl --config ../config.jl
+julia --project -p 10 calibrate.jl --config $config


### PR DESCRIPTION
This PR makes you specify which config file to use for a calibration run explicitly when using the Julia parallel (pmap) pipeline. e.g.:
```sbatch calibrate_script ../config.jl ```
instead of 
```sbatch calibrate_script ```
which would assume the config file was `../config.jl`. As such, other config file paths can be used.