### PR TITLE
Augment system for nonzero regularizations only, improve error messages.

### DIFF
--- a/experiments/SCT1_benchmark/config.jl
+++ b/experiments/SCT1_benchmark/config.jl
@@ -56,8 +56,13 @@ function get_regularization_config()
     config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
     config["dim_scaling"] = true # Dimensional scaling of the loss
 
-    # Parameter regularization: L2 regularization with respect to prior mean
-    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
     # To turn off regularization, set config["process"]["augmented"] to false.
     config["l2_reg"] = 1.0
     return config

--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -53,8 +53,13 @@ function get_regularization_config()
     config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
     config["dim_scaling"] = true # Dimensional scaling of the loss
 
-    # Parameter regularization: L2 regularization with respect to prior mean
-    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
     # To turn off regularization, set config["process"]["augmented"] to false.
     config["l2_reg"] = nothing
     return config

--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -53,8 +53,13 @@ function get_regularization_config()
     config["tikhonov_noise"] = 1.0e-4 # Tikhonov regularization
     config["dim_scaling"] = true # Dimensional scaling of the loss
 
-    # Parameter regularization: L2 regularization with respect to prior mean
-    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
     # To turn off regularization, set config["process"]["augmented"] to false.
     config["l2_reg"] = nothing
     return config

--- a/integration_tests/Bomex_integration_test_config.jl
+++ b/integration_tests/Bomex_integration_test_config.jl
@@ -51,8 +51,13 @@ function get_regularization_config()
     config["tikhonov_noise"] = 1.0e-4 # Tikhonov regularization
     config["dim_scaling"] = true # Dimensional scaling of the loss
 
-    # Parameter regularization: L2 regularization with respect to prior mean
-    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
     # To turn off regularization, set config["process"]["augmented"] to false.
     config["l2_reg"] = nothing
     return config

--- a/integration_tests/SCT1_integration_test_config.jl
+++ b/integration_tests/SCT1_integration_test_config.jl
@@ -55,8 +55,13 @@ function get_regularization_config()
     config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
     config["dim_scaling"] = true # Dimensional scaling of the loss
 
-    # Parameter regularization: L2 regularization with respect to prior mean
-    # Set to `nothing` or `0.0` to use prior covariance as regularizer.
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
     # To turn off regularization, set config["process"]["augmented"] to false.
     config["l2_reg"] = 1.0
     return config

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -40,17 +40,18 @@ run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = nameli
     prior_means = [
         Dict("entrainment_factor" => [0.15], "detrainment_factor" => [0.4]),
         nothing,
+        nothing,
         Dict("entrainment_factor" => [0.1], "detrainment_factor" => [0.2]),
     ]
-    batch_sizes = [nothing, 1, nothing]
-    augments = [true, true, false]
-    l2_regs = [1.0, Dict("entrainment_factor" => [0.0], "detrainment_factor" => [0.1]), nothing]
-    norms = [true, false, true]
-    dim_scalings = [true, false, false]
-    tikhonov_modes = ["relative", "absolute", "relative"]
-    modes = ["pmap", "hpc", "pmap"]
-    validations = [config["reference"], config["reference"], nothing]
-    algos = ["Sampler", "Unscented", "Inversion"]
+    batch_sizes = [nothing, 1, 1, nothing]
+    augments = [true, true, true, false]
+    l2_regs = [1.0, Dict("entrainment_factor" => [0.0], "detrainment_factor" => [0.1]), nothing, nothing]
+    norms = [true, false, true, true]
+    dim_scalings = [true, false, true, false]
+    tikhonov_modes = ["relative", "absolute", "relative", "relative"]
+    modes = ["pmap", "hpc", "hpc", "pmap"]
+    validations = [config["reference"], config["reference"], config["reference"], nothing]
+    algos = ["Sampler", "Unscented", "Unscented", "Inversion"]
 
     for (prior_mean, batch_size, augment, norm, dim_scaling, tikhonov_mode, mode, validation, algo, l2_reg) in
         zip(prior_means, batch_sizes, augments, norms, dim_scalings, tikhonov_modes, modes, validations, algos, l2_regs)

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -98,6 +98,12 @@ using CalibrateEDMF.HelperFuncs
         Σ_type = SCM(),
     )
 
+    l2_reg = Dict("foo" => [0.1], "bar" => [0.3, 0.0, 0.4])
+    reg_indices = regularized_param_indices(l2_reg)
+    @test length(reg_indices) == 3
+    # Dict is not ordered
+    @test reg_indices == [1, 3, 4]
+
     @testset "PCA" begin
         dofs = [5, 10, 25, 100, 250]
         ts = [30, 300, 200, 50, 40]


### PR DESCRIPTION
- Augments system for nonzero regularized dimensions only. The previous implementation augmented the system with all dimensions and returned variances of 1/eps(FT) for dimensions with 0 regularization. This change should greatly improve stability for partial regularization.
- Enforces more explicitly that the passed regularization dictionary is complete. Allow passing partial dicts is a bit more involved, so we will avoid this for now. The way we choose unregularized dimensions is by setting them to 0.