### PR TITLE
parameter masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Manifest.toml
 
 # editor settings
 .vscode
+LocalPreferences.toml
 
 # simulation setup/results
 *.out
@@ -34,3 +35,5 @@ output
 results_*
 *.in
 *.nc
+CEDMF.so
+output

--- a/docs/src/API/HelperFuncs.md
+++ b/docs/src/API/HelperFuncs.md
@@ -5,6 +5,11 @@ CurrentModule = CalibrateEDMF.HelperFuncs
 ```
 
 ```@docs
+Mask
+identity_mask
+reduce_params
+expand_params
+namelist_subdict_by_key
 vertical_interpolation
 nc_fetch_interpolate
 fetch_interpolate_transform

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -49,15 +49,15 @@ version = "0.2.0"
 
 [[deps.ArrayInterface]]
 deps = ["ArrayInterfaceCore", "Compat", "IfElse", "LinearAlgebra", "Static"]
-git-tree-sha1 = "2be588c1fb8979330766115c6298fdb078c8bbb7"
+git-tree-sha1 = "ec8a5e8528995f2cec48c53eb834ab0d58f8bd99"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.10"
+version = "6.0.14"
 
 [[deps.ArrayInterfaceCore]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "6b4e613363909c847663503a4d6e3e8aec9eacf1"
+git-tree-sha1 = "d0f59ebfe8d3ea2799fb3fb88742d69978e5843e"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.8"
+version = "0.1.10"
 
 [[deps.ArrayInterfaceGPUArrays]]
 deps = ["Adapt", "ArrayInterfaceCore", "GPUArrays", "LinearAlgebra"]
@@ -67,9 +67,9 @@ version = "0.1.0"
 
 [[deps.ArrayInterfaceOffsetArrays]]
 deps = ["ArrayInterface", "OffsetArrays", "Static"]
-git-tree-sha1 = "3cbe45d8cc9cff51f302df1f87df64095423fd96"
+git-tree-sha1 = "7dce0e2846e7496622f5d2742502d7e029693458"
 uuid = "015c0d05-e682-4f19-8f0a-679ce4c54826"
-version = "0.1.2"
+version = "0.1.5"
 
 [[deps.ArrayInterfaceStaticArrays]]
 deps = ["Adapt", "ArrayInterface", "LinearAlgebra", "Static", "StaticArrays"]
@@ -186,9 +186,9 @@ version = "1.0.5"
 
 [[deps.CairoMakie]]
 deps = ["Base64", "Cairo", "Colors", "FFTW", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "SHA"]
-git-tree-sha1 = "5b4842a5c7e49020e25d3abe1028f8feffd636f1"
+git-tree-sha1 = "abd2e8065e110f9397dc3a6a75a2d2ed1fad28a9"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.8.3"
+version = "0.8.4"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -215,9 +215,9 @@ version = "0.3.10"
 
 [[deps.ChainRules]]
 deps = ["ChainRulesCore", "Compat", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics"]
-git-tree-sha1 = "e9023f88b1655ffc6a4aaef2502878e8116151ef"
+git-tree-sha1 = "34e265b1b0049896430625ce1638b2719c783c6b"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.35.1"
+version = "1.35.2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -227,9 +227,9 @@ version = "1.15.0"
 
 [[deps.ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
-git-tree-sha1 = "090c09f509bbfa732c2106a9fa36605ea98dfe50"
+git-tree-sha1 = "24790a9be9c3e736e5539b254ab6eef9027d2538"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.8.0"
+version = "1.8.1"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
@@ -309,9 +309,9 @@ uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "1.0.2"
 
 [[deps.CommonSolve]]
-git-tree-sha1 = "68a0743f578349ada8bc911a5cbd5a2ef6ed6d1f"
+git-tree-sha1 = "332a332c97c7071600984b3c31d9067e1a4e6e25"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.0"
+version = "0.2.1"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
@@ -403,9 +403,9 @@ version = "0.1.0+0"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterfaceCore", "ChainRulesCore", "DataStructures", "Distributions", "DocStringExtensions", "FastBroadcast", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "Logging", "MuladdMacro", "NonlinearSolve", "Parameters", "Printf", "RecursiveArrayTools", "Reexport", "Requires", "SciMLBase", "Setfield", "SparseArrays", "StaticArrays", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "777660556c250ef2e25b346d055bf2f89b7962da"
+git-tree-sha1 = "d1e88ffd2f2be74f59f58437e371ac1d0482695d"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.89.0"
+version = "6.89.3"
 
 [[deps.DiffEqJump]]
 deps = ["ArrayInterfaceCore", "DataStructures", "DiffEqBase", "DocStringExtensions", "FunctionWrappers", "Graphs", "LinearAlgebra", "Markdown", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "StaticArrays", "TreeViews", "UnPack"]
@@ -414,10 +414,10 @@ uuid = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 version = "8.5.0"
 
 [[deps.DiffEqNoiseProcess]]
-deps = ["DiffEqBase", "Distributions", "GPUArrays", "LinearAlgebra", "Optim", "PoissonRandom", "QuadGK", "Random", "Random123", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArrays", "Statistics"]
-git-tree-sha1 = "915286127c88b9306e29229cde687d46196f4060"
+deps = ["DiffEqBase", "Distributions", "GPUArrays", "LinearAlgebra", "Markdown", "Optim", "PoissonRandom", "QuadGK", "Random", "Random123", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArrays", "Statistics"]
+git-tree-sha1 = "7f089e4db1c33b7e2fd1635a721c71bcb7d1ad38"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.11.0"
+version = "5.11.1"
 
 [[deps.DiffResults]]
 deps = ["StaticArrays"]
@@ -488,9 +488,9 @@ version = "2.4.8+0"
 
 [[deps.ExponentialUtilities]]
 deps = ["ArrayInterfaceCore", "GPUArrays", "GenericSchur", "LinearAlgebra", "Printf", "SparseArrays", "libblastrampoline_jll"]
-git-tree-sha1 = "2a0f80d722d7c5d94ab29c76eefbed79ded3a696"
+git-tree-sha1 = "343c0b28b7513bbdd8ea91d8500fd1f357944f22"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
-version = "1.17.0"
+version = "1.17.1"
 
 [[deps.ExprTools]]
 git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
@@ -522,10 +522,10 @@ uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
 version = "3.3.10+0"
 
 [[deps.FastBroadcast]]
-deps = ["LinearAlgebra", "Polyester", "Static", "StrideArraysCore"]
-git-tree-sha1 = "2bef6a96059e40dcf7a69c39506672d551fee983"
+deps = ["ArrayInterface", "ArrayInterfaceCore", "LinearAlgebra", "Polyester", "Static", "StrideArraysCore"]
+git-tree-sha1 = "81765322b2960b7c92f9280b00956cb8d645d3f7"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "0.1.17"
+version = "0.2.0"
 
 [[deps.FastClosures]]
 git-tree-sha1 = "acebe244d53ee1b461970f8910c235b259e772ef"
@@ -552,9 +552,9 @@ version = "0.13.2"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterfaceCore", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "4fc79c0f63ddfdcdc623a8ce36623346a7ce9ae4"
+git-tree-sha1 = "a0700c21266b55bf62c22e75af5668aa7841b500"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.12.0"
+version = "2.12.1"
 
 [[deps.FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
@@ -650,15 +650,15 @@ version = "0.15.2"
 
 [[deps.GR]]
 deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "b316fd18f5bc025fedcb708332aecb3e13b9b453"
+git-tree-sha1 = "c98aea696662d09e215ef7cda5296024a9646c75"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.64.3"
+version = "0.64.4"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "1e5490a51b4e9d07e8b04836f6008f46b48aaa87"
+git-tree-sha1 = "3a233eeeb2ca45842fe100e0413936834215abf5"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.64.3+0"
+version = "0.64.4+0"
 
 [[deps.GaussQuadrature]]
 deps = ["SpecialFunctions"]
@@ -822,9 +822,9 @@ version = "0.6.2"
 
 [[deps.InverseFunctions]]
 deps = ["Test"]
-git-tree-sha1 = "336cc738f03e069ef2cac55a104eb823455dca75"
+git-tree-sha1 = "b3364212fb5d870f724876ffcd34dd8ec6d98918"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.4"
+version = "0.1.7"
 
 [[deps.IrrationalConstants]]
 git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
@@ -933,9 +933,9 @@ version = "3.0.0+1"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "c1cd6561c4eb2176045de2b8016b62732a411f02"
+git-tree-sha1 = "e7e9184b0bf0158ac4e4aa9daf00041b5909bf1a"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.13.1"
+version = "4.14.0"
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
@@ -956,9 +956,9 @@ version = "1.3.0"
 
 [[deps.LabelledArrays]]
 deps = ["ArrayInterface", "ArrayInterfaceStaticArrays", "ChainRulesCore", "LinearAlgebra", "MacroTools", "StaticArrays"]
-git-tree-sha1 = "90d1465b8c4d22b58da9e00414f0123be3267f46"
+git-tree-sha1 = "a63da17ff71f41a1f818e0e1d3c02a32cf4c51f7"
 uuid = "2ee39098-c373-598a-b85f-a56591580800"
-version = "1.10.0"
+version = "1.10.2"
 
 [[deps.LambertW]]
 git-tree-sha1 = "2d9f4009c486ef676646bca06419ac02061c088e"
@@ -972,10 +972,10 @@ uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 version = "0.15.15"
 
 [[deps.LayoutPointers]]
-deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static"]
-git-tree-sha1 = "9e72f9e890c46081dbc0ebeaf6ccaffe16e51626"
+deps = ["ArrayInterface", "ArrayInterfaceOffsetArrays", "ArrayInterfaceStaticArrays", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static"]
+git-tree-sha1 = "a575de5a424a395217930fea6d0934ea853d0158"
 uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
-version = "0.1.8"
+version = "0.1.9"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -1092,9 +1092,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LoopVectorization]]
 deps = ["ArrayInterface", "ArrayInterfaceCore", "ArrayInterfaceOffsetArrays", "ArrayInterfaceStaticArrays", "CPUSummary", "ChainRulesCore", "CloseOpenIntervals", "DocStringExtensions", "ForwardDiff", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "SIMDDualNumbers", "SIMDTypes", "SLEEFPirates", "SpecialFunctions", "Static", "ThreadingUtilities", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "b11116837200f222c00d2b14a594a98ab3c97a0d"
+git-tree-sha1 = "5ea9a0aaf5ded7f0b6e43c96ca1793e60c96af93"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.12.116"
+version = "0.12.118"
 
 [[deps.MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
@@ -1116,15 +1116,15 @@ version = "0.5.9"
 
 [[deps.Makie]]
 deps = ["Animations", "Base64", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Distributions", "DocStringExtensions", "FFMPEG", "FileIO", "FixedPointNumbers", "Formatting", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MakieCore", "Markdown", "Match", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "Printf", "Random", "RelocatableFolders", "Serialization", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "UnicodeFun"]
-git-tree-sha1 = "96e1be5153bd04212e8a9fa19b76f8eff1bb9432"
+git-tree-sha1 = "8e18e964461bf4e9e2ab5374dd9d7edea0ef7a94"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.17.3"
+version = "0.17.4"
 
 [[deps.MakieCore]]
 deps = ["Observables"]
-git-tree-sha1 = "cd999cfcda9ae0dd564a968087005d25359344c9"
+git-tree-sha1 = "76b079514ddae2cb3bf839c499678e1ef6c5df78"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.ManualMemory]]
 git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
@@ -1270,9 +1270,9 @@ version = "0.5.1"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "e7fa2526bf068ad5cbfe9ba7e8a9bbd227b3211b"
+git-tree-sha1 = "b4975062de00106132d0b01b5962c09f7db7d880"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.1"
+version = "1.12.5"
 
 [[deps.Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1355,9 +1355,9 @@ version = "8.44.0+0"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "3411935b2904d5ad3917dee58c03f0d9e6ca5355"
+git-tree-sha1 = "3e32c8dbbbe1159a5057c80b8a463369a78dd8d8"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.11"
+version = "0.11.12"
 
 [[deps.PNGFiles]]
 deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
@@ -1431,21 +1431,21 @@ version = "1.2.0"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "d457f881ea56bbfa18222642de51e0abf67b9027"
+git-tree-sha1 = "9e42de869561d6bdf8602c57ec557d43538a92f0"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.29.0"
+version = "1.29.1"
 
 [[deps.PoissonRandom]]
-deps = ["Random", "Statistics", "Test"]
-git-tree-sha1 = "44d018211a56626288b5d3f8c6497d28c26dc850"
+deps = ["Random"]
+git-tree-sha1 = "9ac1bb7c15c39620685a3a7babc0651f5c64c35b"
 uuid = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
-version = "0.4.0"
+version = "0.4.1"
 
 [[deps.Polyester]]
 deps = ["ArrayInterface", "BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "ManualMemory", "PolyesterWeave", "Requires", "Static", "StrideArraysCore", "ThreadingUtilities"]
-git-tree-sha1 = "b5ef32913639cb417e967da27f98402938408127"
+git-tree-sha1 = "bfd5fb3376bc084d202c717bbba8c94696755d87"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
-version = "0.6.11"
+version = "0.6.12"
 
 [[deps.PolyesterWeave]]
 deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
@@ -1565,9 +1565,9 @@ version = "0.5.2"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArrays", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArrays", "LinearAlgebra", "RecipesBase", "StaticArrays", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "23b198c159dc4fd02204683ed5d4ae105aec5053"
+git-tree-sha1 = "c8bb13a16838ce37f94149c356c5664562b46548"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "2.29.0"
+version = "2.29.2"
 
 [[deps.RecursiveFactorization]]
 deps = ["LinearAlgebra", "LoopVectorization", "Polyester", "StrideArraysCore", "TriangularSolve"]
@@ -1618,9 +1618,9 @@ version = "0.3.0+0"
 
 [[deps.RootSolvers]]
 deps = ["DocStringExtensions", "ForwardDiff"]
-git-tree-sha1 = "3cdfb908df013df404e53d2b7ab1fb893f1cad28"
+git-tree-sha1 = "19c3f7a77c25a6ef75b846129701bc9873ec35a3"
 uuid = "7181ea78-2dcb-4de3-ab41-2b8ab5a31e74"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.Rotations]]
 deps = ["LinearAlgebra", "Quaternions", "Random", "StaticArrays", "Statistics"]
@@ -1679,9 +1679,9 @@ version = "0.3.1"
 
 [[deps.SciMLBase]]
 deps = ["ArrayInterfaceCore", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "RecipesBase", "RecursiveArrayTools", "StaticArrays", "Statistics", "Tables", "TreeViews"]
-git-tree-sha1 = "fe49d53d715bfbb5df78b965f5d2660781ea151c"
+git-tree-sha1 = "b0e2399e5294543a19bf2ad9ea4ba3bed18ad19e"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "1.38.3"
+version = "1.39.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1770,9 +1770,9 @@ version = "0.6.6"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "8e981101b5c246b8325dbb3b294b0c67b9c69a0a"
+git-tree-sha1 = "383a578bdf6e6721f480e749d503ebc8405a0b22"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.4.5"
+version = "1.4.6"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -1780,9 +1780,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c82aaa13b44ea00134f8c9c89819477bd3986ecd"
+git-tree-sha1 = "2c11d7290036fe7aac9038ff312d3b3a2a5bf89e"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
@@ -1824,9 +1824,9 @@ uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
 
 [[deps.SurfaceFluxes]]
 deps = ["CLIMAParameters", "DocStringExtensions", "KernelAbstractions", "RootSolvers", "StaticArrays", "Thermodynamics"]
-git-tree-sha1 = "4a5fc468b124b3d502b06ac4a3f97f7f7416a04c"
+git-tree-sha1 = "94f62d36e6711845297f9dcb04d79e955b747532"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -1895,9 +1895,9 @@ version = "0.5.5"
 
 [[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]
-git-tree-sha1 = "7638550aaea1c9a1e86817a231ef0faa9aca79bd"
+git-tree-sha1 = "464d64b2510a25e6efe410e7edab14fffdc333df"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.19"
+version = "0.5.20"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -298,7 +298,7 @@ Elements:
  - `mse_full_max` :: Ensemble max of MSE(`g_full`, `y_full`).
  - `mse_full_var` :: Variance estimate of MSE(`g_full`, `y_full`), empirical (EKI/EKS) or quadrature (UKI).
  - `mse_full_nn_mean` :: MSE(`g_full`, `y_full`) of particle closest to the mean in parameter space. The mean in parameter space is the solution to the particle-based inversion.
- - `failures` :: Number of particle failures per iteration. If the calibration is run with the "high_loss" failure handler, this diagnostic will not capture the failures due to masking.
+ - `failures` :: Number of particle failures per iteration. If the calibration is run with the "high_loss" failure handler, this diagnostic will not capture the failures due to parameter mapping.
  - `nn_mean_index` :: Particle index of the nearest neighbor to the ensemble mean in parameter space. This index is used to construct `..._nn_mean` metrics.
 """
 function io_dictionary_metrics()

--- a/src/DistributionUtils.jl
+++ b/src/DistributionUtils.jl
@@ -9,6 +9,8 @@ using Distributions
 using JLD2
 using EnsembleKalmanProcesses.ParameterDistributions
 
+import ..HelperFuncs: ParameterMap, do_nothing_param_map
+
 export construct_priors, deserialize_prior
 export logmean_and_logstd, mean_and_std_from_ln
 export flatten_config_dict
@@ -81,7 +83,7 @@ end
     construct_priors(
         params::Dict{String, Vector{Constraint}};
         unconstrained_σ::Float64 = 1.0,
-        prior_mean::Union{Vector{Float64}, Nothing} = nothing,
+        prior_mean::Union{Dict{String, Vector{Float64}}, Nothing} = nothing,
         outdir_path::String = pwd(),
         to_file::Bool = true,
     )

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -28,7 +28,11 @@ export vertical_interpolation,
     write_versions,
     expand_dict_entry,
     get_entry,
-    change_entry!
+    change_entry!,
+    ParameterMap,
+    do_nothing_param_map,
+    expand_params,
+    namelist_subdict_by_key
 
 using NCDatasets
 using Statistics
@@ -37,6 +41,169 @@ using LinearAlgebra
 using Glob
 using JSON
 using Random
+
+"""
+    struct ParameterMap
+
+`ParameterMap` is a struct that defines relations between different parameters.
+
+The dictionary `mapping` specifies a map from any parameter that is not being 
+calibrated to either a calibrated parameter, or a number. 
+If another parameter name is specified, the samples from that parameter's distribution
+is used as the given parameter's value throughout calibration, effectively defining
+an equivalence between the two parameters.
+If a number is specified, the parameter will be assigned that constant value throughout 
+the calibration process.
+
+These mappings are primarily useful for vector parameters, where we can choose to only
+calibrate specific components of a vector parameter, or setting different components of
+a vector equal to other components of the vector (or to other parameters). Note, vector 
+components are specified by `<name>_{<index>}`, e.g. `general_stochastic_ent_params_{3}` 
+for the third component of the vector parameter `general_stochastic_ent_params`.
+
+# Examples
+Suppose we have the parameter vector `param` with five components. We can choose to only
+calibrate the first and third component, fixing the fourth component to 3.0,
+and also specifying that the first and second component should be equal, in the following way:
+```jldoctest
+julia> param_map = ParameterMap(
+    mapping = Dict(
+        "param_{2}" => "param_{1}",
+        "param_{4}" => 3.0,
+    ),
+)
+```
+
+The parameter map should be specified in the function `get_prior_config()` in `config.jl`,
+```jldoctest
+# function get_prior_config()  
+config = Dict()
+
+config["constraints"] = Dict(
+    "param_{1}" => [bounded(1.0, 2.0)],
+    "param_{3} => [bounded(3.0, 4.0)],
+)
+
+config["param_map"] = CalibrateEDMF.HelperFuncs.ParameterMap(
+    mapping = Dict(
+        "param_{2}" => "param_{1}",
+        "param_{4}" => 3.0,
+    ),
+)
+
+# ...
+# end
+```
+Notice that the fifth component was neither specified in the prior, nor the mapping. This will fix
+that component to its default value as specified in the namelist (i.e. in `TurbulenceConvection.jl`).
+
+"""
+Base.@kwdef struct ParameterMap
+    mapping::Dict
+end
+
+""" do-nothing param_map."""
+do_nothing_param_map() = ParameterMap(Dict())
+
+"""
+    expand_params(u_names_calib, u_calib, param_map, namelist)
+
+Expand a list of parameters using a param_map and a namelist.
+
+Expand a list of parameters and its corresponding values using the [`ParameterMap`](@ref). 
+If `u_names_calib` contain vector components, fetch all unspecified components 
+from the `namelist` so that for any vector component in `u_names_calib`, 
+all other components of that vector are also specified.
+
+# Arguments
+- `u_names_calib`: A list of parameter names that are being calibrated
+- `u_calib`: A list of values associated with the parameter names
+- `param_map`: A [`ParameterMap`](@ref) specifying a parameter mapping.
+- `namelist`: A dictionary of default parameter values.
+
+Returns a tuple of two vectors defining parameter names and parameter values,
+possibly expanded relative to the input arguments to define all components of
+vector parameters or from relations specified by the [`ParameterMap`](@ref).
+"""
+function expand_params(u_names_calib::AbstractVector, u_calib::AbstractVector, param_map::ParameterMap, namelist::Dict)
+
+    # Check that `param_map` and `u_names_calib` do not contain any of the same parameters
+    mapping_keys = collect(keys(param_map.mapping))
+    if any(mapping_keys .∈ (u_names_calib,))
+        illegal_params = join(mapping_keys[mapping_keys .∈ (u_names_calib,)], ", ")
+        throw(
+            ArgumentError(
+                "Parameters cannot simultaneously be calibrated and fixed with a param_map. \n Check config for: $illegal_params",
+            ),
+        )
+    end
+
+    # fill `params` using `namelist`
+    base_params = Dict(u_names_calib .=> u_calib)
+    params = fill_param_vectors(namelist, base_params)
+    # update `params` using `param_map` 
+    for (mapping_keys, mapping_values) in param_map.mapping
+        params[mapping_keys] = if isa(mapping_values, Number)
+            mapping_values  # Set numeric value if explicitly provided
+        elseif isa(mapping_values, AbstractString)
+            # if `p1` => `p2`, get value associated with `p2`
+            @assert haskey(base_params, mapping_values) "Parameter `$mapping_values` not among calibrated parameters! Check your config."
+            base_params[mapping_values]
+        else
+            throw(
+                ArgumentError(
+                    "The type of `$mapping_values` for the Pair `$mapping_keys => $mapping_values` is not recognized. " *
+                    "Should be `String` or `Number`, but has type `$(typeof(mapping_values))`.",
+                ),
+            )
+        end
+    end
+
+    return collect.((keys(params), values(params)))
+end
+
+"""
+    fill_param_vectors(namelist, params)
+
+Expand `params` dictionary with defaults from `namelist`.
+
+In practice, `params` is only expanded if it contains vector components,
+in which case default values of unspecified components are fetched from
+the namelist and appended to `params`.
+"""
+function fill_param_vectors(namelist::Dict, params::Dict{<:AbstractString, <:Number})
+    # Fetch default vector parameters from `namelist` that match `params`
+    vec_param_names = unique(getfield.(filter(!isnothing, match.(r".*(?=_{\d+})", keys(params))), :match))
+    namelist_vec_params = Dict(vec_param_names .=> get_namelist_value.(Ref(namelist), vec_param_names))
+    flatten_vector_parameter(p) = "$(p.first)_{" .* string.(1:length(p.second)) .* "}" .=> p.second
+    vec_params = Dict((map(flatten_vector_parameter, collect(namelist_vec_params))...)...)
+    # Update parameter list
+    return merge(vec_params, params)
+end
+
+"""
+    namelist_subdict_by_key(namelist, param_name) -> subdict
+
+Return the subdict of `namelist` that has `param_name` as a key.
+
+The namelist is defined in TurbulenceConvection.jl
+"""
+function namelist_subdict_by_key(namelist::Dict, param_name::AbstractString)::Dict
+    subdict = if haskey(namelist["turbulence"]["EDMF_PrognosticTKE"], param_name)
+        namelist["turbulence"]["EDMF_PrognosticTKE"]
+    elseif haskey(namelist["microphysics"], param_name)
+        namelist["microphysics"]
+    elseif haskey(namelist["time_stepping"], param_name)
+        namelist["time_stepping"]
+    else
+        throw(ArgumentError("Parameter $param_name cannot be calibrated. Consider adding namelist dictionary if needed."))
+    end
+    return subdict
+end
+
+""" Get the namelist value for some parameter name"""
+get_namelist_value(namelist::Dict, param_name::AbstractString) =
+    namelist_subdict_by_key(namelist, param_name)[param_name]
 
 """
     vertical_interpolation(

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -62,6 +62,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     params = config["prior"]["constraints"]
     unc_σ = get_entry(config["prior"], "unconstrained_σ", 1.0)
     prior_μ = get_entry(config["prior"], "prior_mean", nothing)
+    param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
 
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 
@@ -163,7 +164,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
 
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekobj))
     params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), param_map, ref_models, ref_stats) for param in params]
     versions = generate_scm_input(mod_evaluators, outdir_path, batch_indices)
     # Store version identifiers for this ensemble in a common file
     write_versions(versions, 1, outdir_path = outdir_path)
@@ -180,6 +181,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
             reg_config,
             ekobj,
             priors,
+            param_map,
             versions,
             outdir_path,
             overwrite = overwrite_scm_file,
@@ -289,6 +291,7 @@ function init_validation(
     reg_config::Dict{Any, Any},
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
+    param_map::ParameterMap,
     versions::Vector{IT},
     outdir_path::String;
     overwrite::Bool = false,
@@ -312,7 +315,7 @@ function init_validation(
     ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp))
     params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), param_map, ref_models, ref_stats) for param in params]
     [
         jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices) for
         (model_evaluator, version) in zip(mod_evaluators, versions)
@@ -326,10 +329,11 @@ end
         reg_config::Dict{Any, Any},
         ekp_old::EnsembleKalmanProcess,
         priors::ParameterDistribution,
+        param_map::ParameterMap,
         versions::Vector{String},
         outdir_path::String,
         iteration::IT
-        )
+    )
 
 Updates the validation diagnostics and writes to file the validation ModelEvaluators
 for the next calibration step.
@@ -340,6 +344,7 @@ Inputs:
  - reg_config    :: Regularization configuration.
  - ekp_old       :: EnsembleKalmanProcess updated using the past forward model evaluations.
  - priors        :: The priors over parameter space.
+ - param_map     :: A mapping to a reduced parameter set. See [`ParameterMap`](@ref) for details.
  - versions      :: String versions identifying the forward model evaluations.
  - outdir_path   :: Output path directory.
 """
@@ -348,6 +353,7 @@ function update_validation(
     reg_config::Dict{Any, Any},
     ekp_old::EnsembleKalmanProcess,
     priors::ParameterDistribution,
+    param_map::ParameterMap,
     versions::Vector{String},
     outdir_path::String,
     iteration::IT,
@@ -371,7 +377,7 @@ function update_validation(
     end
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp_old))
     params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), param_map, ref_models, ref_stats) for param in params]
     # Save new ModelEvaluators using the new versions
     versions = readlines(joinpath(outdir_path, "versions_$(iteration + 1).txt"))
     [
@@ -425,6 +431,7 @@ function ek_update(
 
     deterministic_forward_map = get_entry(proc_config, "noisy_obs", false)
     augmented = get_entry(proc_config, "augmented", false)
+    param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
 
     ref_config = config["reference"]
     batch_size = get_entry(ref_config, "batch_size", nothing)
@@ -476,12 +483,12 @@ function ek_update(
 
         # Write to file new EKP and ModelEvaluators
         jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
-        write_model_evaluators(ekp, priors, ref_models, ref_stats, outdir_path, iteration, batch_indices)
+        write_model_evaluators(ekp, priors, param_map, ref_models, ref_stats, outdir_path, iteration, batch_indices)
 
         # Update validation ModelEvaluators
         if !isnothing(val_config)
             reg_config = config["regularization"]
-            update_validation(val_config, reg_config, ekobj, priors, versions, outdir_path, iteration)
+            update_validation(val_config, reg_config, ekobj, priors, param_map, versions, outdir_path, iteration)
         end
     end
     # Clean up
@@ -532,6 +539,8 @@ function restart_calibration(
     batch_size = get_entry(ref_config, "batch_size", nothing)
     kwargs_ref_model = get_ref_model_kwargs(ref_config)
 
+    param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
+
     reg_config = config["regularization"]
     kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
 
@@ -559,7 +568,7 @@ function restart_calibration(
 
     # Write to file new EKP and ModelEvaluators
     jldsave(ekobj_path(outdir_path, last_iteration + 1); ekp)
-    write_model_evaluators(ekp, priors, ref_models, ref_stats, outdir_path, last_iteration, batch_indices)
+    write_model_evaluators(ekp, priors, param_map, ref_models, ref_stats, outdir_path, last_iteration, batch_indices)
 
     # Restart validation
     if !isnothing(val_config)
@@ -568,6 +577,7 @@ function restart_calibration(
             reg_config,
             ekobj,
             priors,
+            param_map,
             outdir_path,
             last_iteration,
             overwrite = overwrite_scm_file,
@@ -588,6 +598,7 @@ end
         reg_config::Dict{Any, Any},
         ekp_old::EnsembleKalmanProcess,
         priors::ParameterDistribution,
+        param_map::ParameterMap,
         outdir_path::String,
         last_iteration::IT;
         overwrite::Bool = false,
@@ -604,6 +615,7 @@ Inputs:
  - reg_config    :: Regularization configuration.
  - ekp_old       :: EnsembleKalmanProcess updated using the past forward model evaluations.
  - priors        :: The priors over parameter space.
+ - param_map     :: A mapping to a reduced parameter set. See [`ParameterMap`](@ref) for details.
  - outdir_path   :: Output path directory.
 """
 function restart_validation(
@@ -611,6 +623,7 @@ function restart_validation(
     reg_config::Dict{Any, Any},
     ekp_old::EnsembleKalmanProcess,
     priors::ParameterDistribution,
+    param_map::ParameterMap,
     outdir_path::String,
     last_iteration::IT;
     overwrite::Bool = false,
@@ -635,7 +648,7 @@ function restart_validation(
 
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp_old))
     params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), param_map, ref_models, ref_stats) for param in params]
     # Save new ModelEvaluators using the new versions
     versions = readlines(joinpath(outdir_path, "versions_$(last_iteration + 1).txt"))
     [
@@ -872,6 +885,7 @@ end
     write_model_evaluators(
         ekp::EnsembleKalmanProcess,
         priors::ParameterDistribution,
+        param_map::ParameterMap,
         ref_models::Vector{ReferenceModel},
         ref_stats::ReferenceStatistics,
         outdir_path::String,
@@ -883,6 +897,7 @@ Creates and writes to file the ModelEvaluators for the current particle ensemble
 Inputs:
  - `ekp`         :: The EnsembleKalmanProcess with the current ensemble of parameter values.
  - `priors`      :: The parameter priors.
+ - `param_map`   :: A mapping to a reduced parameter set. See [`ParameterMap`](@ref) for details.
  - `ref_models`  :: The ReferenceModels defining the new model evaluations.
  - `ref_stats`   :: The ReferenceStatistics corresponding to passed `ref_models`.
  - `outdir_path` :: The output directory.
@@ -891,6 +906,7 @@ Inputs:
 function write_model_evaluators(
     ekp::EnsembleKalmanProcess,
     priors::ParameterDistribution,
+    param_map::ParameterMap,
     ref_models::Vector{ReferenceModel},
     ref_stats::ReferenceStatistics,
     outdir_path::String,
@@ -899,7 +915,7 @@ function write_model_evaluators(
 )
     params_cons_i = transform_unconstrained_to_constrained(priors, get_u_final(ekp))
     params = [c[:] for c in eachcol(params_cons_i)]
-    mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
+    mod_evaluators = [ModelEvaluator(param, get_name(priors), param_map, ref_models, ref_stats) for param in params]
     versions = generate_scm_input(mod_evaluators, outdir_path, batch_indices)
     # Store version identifiers for this ensemble in a common file
     write_versions(versions, iteration + 1, outdir_path = outdir_path)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -18,6 +18,7 @@ function run_SCM_parallel(
     return run_SCM_parallel(
         ME.param_cons,
         ME.param_names,
+        ME.param_map,
         ME.ref_models,
         ME.ref_stats,
         error_check = error_check,
@@ -29,6 +30,7 @@ end
 function run_SCM_parallel(
     u::Vector{FT},
     u_names::Vector{String},
+    param_map::ParameterMap,
     RM::Vector{ReferenceModel},
     RS::ReferenceStatistics;
     error_check::Bool = false,
@@ -37,7 +39,7 @@ function run_SCM_parallel(
 ) where {FT <: Real}
 
     mkpath(joinpath(pwd(), "tmp"))
-    result_arr = pmap(x -> eval_single_ref_model(x..., RS, u, u_names, namelist_args), enumerate(RM))
+    result_arr = pmap(x -> eval_single_ref_model(x..., RS, u, u_names, param_map, namelist_args), enumerate(RM))
     # Unpack
     sim_dirs, g_scm, g_scm_pca, sim_errors = (getindex.(result_arr, i) for i in 1:4)
     g_scm = vcat(g_scm...)
@@ -64,13 +66,14 @@ function eval_single_ref_model(
     RS::ReferenceStatistics,
     u::Vector{FT},
     u_names::Vector{String},
+    param_map::ParameterMap,
     namelist_args = nothing,
 ) where {FT <: Real, IT <: Int}
 
     # create temporary directory to store SCM data in
     tmpdir = mktempdir(joinpath(pwd(), "tmp"))
     # run TurbulenceConvection.jl. Get output directory for simulation data
-    sim_dir, model_error = run_SCM_handler(m, tmpdir, u, u_names, namelist_args)
+    sim_dir, model_error = run_SCM_handler(m, tmpdir, u, u_names, param_map, namelist_args)
     filename = get_stats_path(sim_dir)
     z_obs = get_z_obs(m)
     if model_error

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -8,6 +8,7 @@ using CalibrateEDMF.ModelTypes
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.HelperFuncs
 using CalibrateEDMF.TurbulenceConvectionUtils
 using CalibrateEDMF.NetCDFIO
 const CN = CalibrateEDMF.NetCDFIO

--- a/tools/TCRunner.jl
+++ b/tools/TCRunner.jl
@@ -56,6 +56,10 @@ function run_TC_optimal(
     metric::String = "mse_full",
 )
 
+    namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+    val_config = get(config, "validation", nothing)
+    param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
+
     u_names, u = optimal_parameters(joinpath(results_dir, "Diagnostics.nc"); method = method, metric = metric)
 
     for i in 1:length(run_cases["case_name"])
@@ -70,6 +74,7 @@ function run_TC_optimal(
             tc_output_dir;
             u = u,
             u_names = u_names,
+            param_map = param_map,
             namelist_args = namelist_args,
             uuid = run_cases["scm_suffix"][i],
             les = les_path,


### PR DESCRIPTION
# Purpose
This PR is intended to allow for simple functional dependencies between parameters to be calibrated. The primary use cases are the following:
1. Given a parameter vector, this PR allows you to calibrate a subset of its components, keeping the other components to their default values.
2. Define an equality relation between two parameters, either scalar parameters or components of vector parameters.

# Implementation details
In practice, to handle this, the struct `ParameterMap` is introduced:
https://github.com/CliMA/CalibrateEDMF.jl/blob/fa654dd8911895bbe4b08559b635f420270c4261/src/HelperFuncs.jl#L101-L103
The struct contains `mapping`, which is a dictionary that defines how to specify values of parameters that aren't explicitly a part of the calibration process. The dictionary keys are these parameters, while the values can either be 
1. a number. In this case, the parameter is kept fixed at the specified number.
2. a string. The string is assumed to be a parameter that is being calibrated. In this case, the parameter is set to whichever value that parameter takes on for each simulation.

Note that vector parameter components are specified directly by index, i.e., to consider the third component of the vector parameter `param`, write `param_{3}`.

For convenience, the function `do_nothing_param_map ` is also exported, which is a do-nothing `ParameterMap`, defined simply as
```julia
do_nothing_param_map() = ParameterMap(Dict())
```

# Checks:
- [x] Unit tests are added for the new functionality
- [x] Appropriate documentation is added to describe usage, including docstrings.


