### PR TITLE
Add system image precompilation to global_parallel pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,11 @@ env:
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/cpu"
 
 steps:
+
+  # Report to Codecov
+  # - plugins:
+  #     - joscha/codecov#v2.1.6: ~
+
   - label: "init environment :computer:"
     key: "init_cpu_env"
     command:
@@ -31,7 +36,54 @@ steps:
 
   - wait
 
+  - label: "Bomex Inv julia_par"
+    key: "cpu_bomex_julia_p10"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config Bomex_inversion_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/Bomex_inversion_test_config_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
+  - label: "Bomex Inv continue"
+    key: "cpu_bomex_continue"
+    depends_on: "cpu_bomex_julia_p10"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/continue_julia_parallel_test.jl --config Bomex_inversion_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/Bomex_inversion_test_config_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
+  - label: "Bomex SparseInv julia_par"
+    key: "cpu_bomex_sparse"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config Bomex_sparseinversion_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/Bomex_sparseinversion_test_config_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
+  - label: "SCT1 julia parallel"
+    key: "cpu_sct1_julia_p10"
+    command:
+      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config SCT1_integration_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/SCT1_integration_test_config_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 11
+
   # Unit tests through CI: buildkite tends to produce irreproducible errors
+  #
+  #
   # - label: "helper_funcs"
   #   key: "cpu_helper_funcs"
   #   command:
@@ -95,49 +147,4 @@ steps:
   #   agents:
   #     config: cpu
   #     queue: central
-
-  - label: "Bomex Inv julia_par"
-    key: "cpu_bomex_julia_p10"
-    command:
-      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config Bomex_inversion_test_config.jl"
-    artifact_paths:
-      - "integration_tests/output/Bomex_julia_parallel/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_cpus_per_task: 11
-
-  - label: "Bomex Inv continue"
-    key: "cpu_bomex_continue"
-    depends_on: "cpu_bomex_julia_p10"
-    command:
-      - "julia --color=yes -p 10 --project=integration_tests integration_tests/continue_julia_parallel_test.jl --config Bomex_inversion_test_config.jl"
-    artifact_paths:
-      - "integration_tests/output/Bomex_julia_parallel/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_cpus_per_task: 11
-
-  - label: "Bomex SparseInv julia_par"
-    key: "cpu_bomex_sparse"
-    command:
-      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config Bomex_sparseinversion_test_config.jl"
-    artifact_paths:
-      - "integration_tests/output/Bomex_sparse_julia_parallel/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_cpus_per_task: 11
-
-  - label: "SCT1 julia parallel"
-    key: "cpu_sct1_julia_p10"
-    command:
-      - "julia --color=yes -p 10 --project=integration_tests integration_tests/julia_parallel_test.jl --config SCT1_integration_test_config.jl"
-    artifact_paths:
-      - "integration_tests/output/SCT1_julia_parallel/*"
-    agents:
-      config: cpu
-      queue: central
-      slurm_cpus_per_task: 11
 

--- a/experiments/SCT1_benchmark/README.md
+++ b/experiments/SCT1_benchmark/README.md
@@ -20,6 +20,8 @@ If you are on the Caltech Central Cluster, you can run the project by adding it 
 
   >> sbatch ekp_par_calibration.sbatch ../config.jl
 
+The HPC pipeline parallelizes jobs using different Julia sessions per ensemble member and iteration. Due to the just-in-time compilation nature of Julia, this requires compiling the source code again for every new HPC node requested. In order to reduce the compilation overhead, this pipeline builds a system image of `EnsembleKalmanProcesses.jl`, `TurbulenceConvection.jl`, `CalibrateEDMF.jl` and all the functions called in the `CalibrateEDMF.jl` test suite. **This system image uses a *frozen* version of the source code, so it must be re-generated every time any of the precompiled packages is updated or modified by the user**.
+
 # Output
 
 While the simulations run, the results are dumped to a directory named *results_...* after every iteration of the calibration algorithm. The diagnostics are stored in NetCDF4 format in `Diagnostics.nc`, within the results folder. NetCDF files may be processed using python or julia. You may also access a human-readable version of the netCDF file in linux using `ncdump`:

--- a/experiments/SCT1_benchmark/global_parallel/create_tc_so.jl
+++ b/experiments/SCT1_benchmark/global_parallel/create_tc_so.jl
@@ -1,0 +1,28 @@
+using Glob
+
+if isempty(Glob.glob("CEDMF.so"))
+
+    using Pkg
+    using PackageCompiler
+    using CalibrateEDMF
+
+    cedmf = pkgdir(CalibrateEDMF)
+    pkgs = [:CalibrateEDMF]
+    append!(pkgs, [Symbol(v.name) for v in values(Pkg.dependencies()) if v.is_direct_dep])
+
+    create_sysimage(
+        pkgs;
+        sysimage_path = "CEDMF.so",
+        # Caltech Central CPU architecture, `native` leads to issues as well.
+        # This one works most of the time, but needs a failsafe mechanism.
+        cpu_target = "skylake-avx512",
+        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
+    )
+
+    # Other cpu_target options
+    #cpu_target = "native", # Default 
+    #cpu_target = PackageCompiler.default_app_cpu_target(),
+    #cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)", # Same as Julia Base
+    #cpu_target = "generic",
+
+end

--- a/experiments/SCT1_benchmark/global_parallel/ekp_par_calibration.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/ekp_par_calibration.sbatch
@@ -25,20 +25,25 @@ export JULIA_MPI_BINARY=system
 export JULIA_CUDA_USE_BINARYBUILDER=false
 
 # run instantiate/precompile serial
-julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
-julia --project -e 'using Pkg; Pkg.precompile()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.precompile()'
 
-# First call to calibrate.jl will create the ensemble files from the priors
-id_init_ens=$(sbatch --parsable -A esm init.sbatch $config $job_id)
 for it in $(seq 1 1 $n_it)
 do
 # Parallel runs of forward model
 if [ "$it" = "1" ]; then
+    # Generate system image
+    id_so=$(sbatch --parsable -A esm sysimage.sbatch)
+    # Initialize calibration
+    id_init_ens=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_so init.sbatch $config $job_id)
+    # Precondition parameters
     id_precond=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_init_ens --array=1-$n precondition_prior.sbatch $it $job_id)
+    # Run ensemble of forward models
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_precond --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
 else
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
 fi
+# Update ensemble
 id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
 done
 

--- a/experiments/SCT1_benchmark/global_parallel/init.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/init.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=3:00:00   # walltime
+#SBATCH --time=2:00:00   # walltime
 #SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
 #SBATCH --nodes=1         # number of nodes
 #SBATCH --mem-per-cpu=20G   # memory per CPU core
@@ -8,10 +8,14 @@
 
 #julia package management
 module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1
-julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.API.precompile()'
 
 config=${1?Error: no config file given}
 job_id=${2?Error: no job ID given}
 
-julia --project init.jl --config $config --job_id $job_id
+julia --project -C skylake-avx512 -JCEDMF.so init.jl --config $config --job_id $job_id && (
+  echo sysimage loaded successfully
+) || (
+  julia --project init.jl --config $config --job_id $job_id
+)
+
 echo 'Ensemble initialized for calibration.'

--- a/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=2:00:00   # walltime
+#SBATCH --time=1:00:00   # walltime
 #SBATCH --nodes=1         # number of nodes
 #SBATCH --mem-per-cpu=6G   # memory per CPU core
 #SBATCH -J "sct_run"   # job name
@@ -14,9 +14,17 @@ run_num=${SLURM_ARRAY_TASK_ID}
 job_dir=$(head $job_id".txt" | tail -1)
 version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
 
-julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train" &
+julia --project -C skylake-avx512 -JCEDMF.so -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train" && (
+  echo sysimage loaded successfully
+) || (
+  julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train"
+) &
 P1=$!
-julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation" &
+julia --project -C skylake-avx512 -JCEDMF.so -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation" && (
+  echo sysimage loaded successfully
+) || (
+  julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation"
+) &
 P2=$!
 wait $P1 $P2
 echo "SCM simulation for ${version} in iteration ${iteration_} finished"

--- a/experiments/SCT1_benchmark/global_parallel/precondition_prior.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/precondition_prior.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=3:00:00   # walltime
+#SBATCH --time=2:00:00   # walltime
 #SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
 #SBATCH --nodes=1         # number of nodes
 #SBATCH --mem-per-cpu=6G   # memory per CPU core
@@ -14,6 +14,11 @@ run_num=${SLURM_ARRAY_TASK_ID}
 job_dir=$(head $job_id".txt" | tail -1)
 version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
 
-julia --project  precondition_prior.jl --version $version --job_dir $job_dir
+julia --project -C skylake-avx512 -JCEDMF.so precondition_prior.jl --version $version --job_dir $job_dir && (
+  echo sysimage loaded successfully
+) || (
+  julia --project precondition_prior.jl --version $version --job_dir $job_dir
+)
+
 echo "Preconditioning for ${version} finished."
 

--- a/experiments/SCT1_benchmark/global_parallel/restart.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/restart.sbatch
@@ -6,11 +6,15 @@
 #SBATCH --mem-per-cpu=6G   # memory per CPU core
 #SBATCH -J "restart"   # job name
 
-module purge
 module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1
 
 output_dir=${1?Error: no output directory given}
 job_id=${2?Error: no job ID given}
 
-julia --project restart.jl --output_dir $output_dir --job_id $job_id
+julia --project -C skylake-avx512 -JCEDMF.so restart.jl --output_dir $output_dir --job_id $job_id && (
+  echo sysimage loaded successfully
+) || (
+  julia --project restart.jl --output_dir $output_dir --job_id $job_id
+)
+
 echo "Calibration process at ${output_dir} restarted."

--- a/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
@@ -32,19 +32,23 @@ export JULIA_MPI_BINARY=system
 export JULIA_CUDA_USE_BINARYBUILDER=false
 
 # run instantiate/precompile serial
-julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
-julia --project -e 'using Pkg; Pkg.precompile()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.precompile()'
 
-# First call to calibrate.jl will create the ensemble files from the priors
-id_restart_ens=$(sbatch --parsable -A esm restart.sbatch $output_dir $job_id)
 for it in $(seq $first_new_iter 1 $n_it)
 do
 # Parallel runs of forward model
 if [ "$it" = "$first_new_iter" ]; then
+    # Generate system image
+    id_so=$(sbatch --parsable -A esm sysimage.sbatch)
+    # Restart calibration
+    id_restart_ens=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_so restart.sbatch $output_dir $job_id)
+    # Run ensemble of forward models
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_restart_ens --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
 else
     id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
 fi
+# Update ensemble
 id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
 done
 

--- a/experiments/SCT1_benchmark/global_parallel/step_ekp.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/step_ekp.sbatch
@@ -11,5 +11,10 @@ iteration_=${1?Error: no iteration given}
 job_id=${2?Error: no job ID given}
 job_dir=$(head $job_id".txt" | tail -1)
 
-julia --project step_ekp.jl --iteration $iteration_ --job_dir $job_dir
+julia --project -C skylake-avx512 -JCEDMF.so step_ekp.jl --iteration $iteration_ --job_dir $job_dir && (
+  echo sysimage loaded successfully
+) || (
+  julia --project step_ekp.jl --iteration $iteration_ --job_dir $job_dir
+)
+
 echo "Ensemble at iteration ${iteration_} stepped forward."

--- a/experiments/SCT1_benchmark/global_parallel/sysimage.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/sysimage.sbatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#SBATCH --time=3:00:00   # walltime
+#SBATCH --ntasks=1  # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1   # number of nodes
+#SBATCH --mem-per-cpu=20G   # memory per CPU core
+#SBATCH -J "sys_im"   # job name
+
+module load julia/1.7.0 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+julia --project -C skylake-avx512 create_tc_so.jl
+
+echo "System image creation/check finished."

--- a/integration_tests/Bomex_sparseinversion_test_config.jl
+++ b/integration_tests/Bomex_sparseinversion_test_config.jl
@@ -92,7 +92,7 @@ function get_reference_config(::Bomex)
     config["y_dir"] = [LESUtils.get_path_to_artifact()]
     # provide list of dirs if different from `y_dir`
     # config["Σ_dir"] = [...]
-    config["scm_suffix"] = ["000000"]
+    config["scm_suffix"] = ["000001"]
     config["scm_parent_dir"] = ["scm_init"]
     config["t_start"] = [4.0 * 3600]
     config["t_end"] = [6.0 * 3600]
@@ -115,7 +115,7 @@ function get_reference_config(::ValidateBomex)
     config["y_dir"] = [LESUtils.get_path_to_artifact()]
     # provide list of dirs if different from `y_dir`
     # config["Σ_dir"] = [...]
-    config["scm_suffix"] = ["000000"]
+    config["scm_suffix"] = ["000001"]
     config["scm_parent_dir"] = ["scm_init"]
     config["t_start"] = [4.0 * 3600]
     config["t_end"] = [6.0 * 3600]

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -43,9 +43,9 @@ version = "0.2.0"
 
 [[deps.ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "6e8fada11bb015ecf9263f64b156f98b546918c7"
+git-tree-sha1 = "8d4a07999261b4461daae67b2d1e12ae1a097741"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "5.0.5"
+version = "5.0.6"
 
 [[deps.ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]
@@ -960,9 +960,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "DocStringExtensions", "IterativeSolvers", "KLU", "Krylov", "KrylovKit", "LinearAlgebra", "RecursiveFactorization", "Reexport", "Requires", "SciMLBase", "Setfield", "SparseArrays", "SuiteSparse", "UnPack"]
-git-tree-sha1 = "a25bc80647e44d0e1e1694b47000603497700b18"
+git-tree-sha1 = "8f6456f4abf9e6bb3330751ffea3626e08c273a7"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "1.13.0"
+version = "1.14.0"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
@@ -975,9 +975,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LoopVectorization]]
 deps = ["ArrayInterface", "CPUSummary", "ChainRulesCore", "CloseOpenIntervals", "DocStringExtensions", "ForwardDiff", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "SIMDDualNumbers", "SLEEFPirates", "SpecialFunctions", "Static", "ThreadingUtilities", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "077c7c9d746cbe30ac5f001ea4c1277f64cc5dad"
+git-tree-sha1 = "0ad02fdd8009e42eb52fcef08a4130465e055ebc"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.12.103"
+version = "0.12.104"
 
 [[deps.MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
@@ -1163,9 +1163,9 @@ version = "1.4.1"
 
 [[deps.OrdinaryDiffEq]]
 deps = ["Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DocStringExtensions", "ExponentialUtilities", "FastClosures", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "LinearSolve", "Logging", "LoopVectorization", "MacroTools", "MuladdMacro", "NLsolve", "NonlinearSolve", "Polyester", "PreallocationTools", "RecursiveArrayTools", "Reexport", "SciMLBase", "SparseArrays", "SparseDiffTools", "StaticArrays", "UnPack"]
-git-tree-sha1 = "509aa6d3b2773e5109d4a4dd9a300259ac727961"
+git-tree-sha1 = "adb3b4eec5bd0234dc55b7459d61276a870436c2"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-version = "6.7.1"
+version = "6.8.0"
 
 [[deps.PCRE_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1543,9 +1543,9 @@ version = "6.46.0"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "Requires", "SIMDTypes", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "28debdcb4371020f89ffce06af4f7f68905a5fec"
+git-tree-sha1 = "6685213e80d3173f23947224a2fa71886def0119"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-version = "0.2.15"
+version = "0.2.17"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]

--- a/integration_tests/continue_julia_parallel_test.jl
+++ b/integration_tests/continue_julia_parallel_test.jl
@@ -30,11 +30,11 @@ s = ArgParseSettings()
 end
 parsed_args = parse_args(ARGS, s)
 config_rel_filepath = parsed_args["config"]
-case_name = first(split(config_rel_filepath, "_"))
+config_basename = first(split(config_rel_filepath, "."))
 
-folder = joinpath(@__DIR__, "output", string(case_name, "_julia_parallel"))
+folder = joinpath(@__DIR__, "output", string(config_basename, "_julia_parallel"))
 @assert isdir(folder)
-outdir_path = open(f -> read(f, String), string(folder, case_name, ".txt"))
+outdir_path = open(f -> read(f, String), string(folder, config_basename, ".txt"))
 
 include(joinpath(outdir_path, "config.jl"))
 ekobjs = glob(joinpath(relpath(outdir_path), "ekobj_iter_*.jld2"))
@@ -121,9 +121,9 @@ Plots.ylabel!("Validation MSE (full)")
 Plots.plot!(; left_margin = 40 * Plots.PlotMeasures.px)
 
 Plots.plot(p1, p2; layout = (1, 2))
-folder = joinpath(@__DIR__, "output", string(first(split(config_rel_filepath, "_")), "_julia_parallel"))
+folder = joinpath(@__DIR__, "output", string(config_basename, "_julia_parallel"))
 mkpath(folder)
-Plots.savefig(joinpath(folder, "mse.png"))
+Plots.savefig(joinpath(folder, string(config_basename, "_mse_continued.png")))
 
 using Test
 @testset "Julia Parallel Calibrate" begin

--- a/integration_tests/julia_parallel_test.jl
+++ b/integration_tests/julia_parallel_test.jl
@@ -38,6 +38,7 @@ s = ArgParseSettings()
 end
 parsed_args = parse_args(ARGS, s)
 config_rel_filepath = parsed_args["config"]
+config_basename = first(split(config_rel_filepath, "."))
 
 config_filename = joinpath(@__DIR__, config_rel_filepath)
 include(config_filename)
@@ -122,12 +123,12 @@ Plots.plot!(; left_margin = 40 * Plots.PlotMeasures.px)
 
 Plots.plot(p1, p2; layout = (1, 2))
 case_name = first(split(config_rel_filepath, "_"))
-folder = joinpath(@__DIR__, "output", string(case_name, "_julia_parallel"))
+folder = joinpath(@__DIR__, "output", string(config_basename, "_julia_parallel"))
 mkpath(folder)
-Plots.savefig(joinpath(folder, string(algorithm, "_mse.png")))
-open(string(folder, case_name, ".txt"), "w") do io
+Plots.savefig(joinpath(folder, string(config_basename, "_mse.png")))
+open(string(folder, config_basename, ".txt"), "w") do io
     write(io, outdir_path)
-end;
+end
 
 using Test
 @testset "Julia Parallel Calibrate" begin


### PR DESCRIPTION
Adds a system image precompilation to the global_parallel calibration pipeline. The cpu_target of precompiled code seems to be somewhat randomly unstable, so we implement a fallback mechanism such that if the system image is detected as _not compatible with the target_, we can continue calibration without the system image for that particular process.

We also enforce the cpu_target of Julia calls within the pipeline to `skylake-avx512`, the microarchitecture in the Caltech central cluster.