### PR TITLE
Fix and test issue #285

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,6 +81,17 @@ steps:
       queue: central
       slurm_cpus_per_task: 11
 
+  - label: "Heterogeneous batching"
+    key: "cpu_het_batch"
+    command:
+      - "julia --color=yes -p 7 --project=integration_tests integration_tests/julia_parallel_test.jl --config Het_batch_unscented_test_config.jl"
+    artifact_paths:
+      - "integration_tests/output/Het_batch_unscented_test_config_julia_parallel/*"
+    agents:
+      config: cpu
+      queue: central
+      slurm_cpus_per_task: 8
+
   - label: "helper_funcs"
     key: "cpu_helper_funcs"
     command:
@@ -144,4 +155,7 @@ steps:
     agents:
       config: cpu
       queue: central
+
+
+
 

--- a/integration_tests/Het_batch_unscented_test_config.jl
+++ b/integration_tests/Het_batch_unscented_test_config.jl
@@ -1,0 +1,147 @@
+#= Custom calibration configuration file. =#
+
+using Distributions
+using StatsBase
+using LinearAlgebra
+using CalibrateEDMF
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.LESUtils
+using CalibrateEDMF.TurbulenceConvectionUtils
+# Import prior constraints
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+# Cases defined as structs for quick access to default configs
+struct ObsCampaigns end
+struct ObsCampaignsVal end
+# struct MyAwesomeSetup end
+
+function get_config()
+    config = Dict()
+    # Flags for saving output data
+    config["output"] = get_output_config()
+    # Define regularization of inverse problem
+    config["regularization"] = get_regularization_config()
+    # Define reference used in the inverse problem 
+    config["reference"] = get_reference_config(ObsCampaigns())
+    # Define reference used for validation
+    config["validation"] = get_reference_config(ObsCampaignsVal())
+    # Define the parameter priors
+    config["prior"] = get_prior_config()
+    # Define the kalman process
+    config["process"] = get_process_config()
+    # Define the SCM static configuration
+    config["scm"] = get_scm_config()
+    return config
+end
+
+function get_output_config()
+    config = Dict()
+    config["outdir_root"] = pwd()
+    config["overwrite_scm_file"] = false # Flag for overwritting SCM input file
+    return config
+end
+
+function get_regularization_config()
+    config = Dict()
+    # Regularization of observations: mean and covariance
+    config["perform_PCA"] = true # Performs PCA on data
+    config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
+    config["normalize"] = true  # whether to normalize data by pooled variance
+    config["tikhonov_mode"] = "relative" # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    config["l2_reg"] = 1.0
+    return config
+end
+
+function get_process_config()
+    config = Dict()
+    config["N_iter"] = 6
+    config["N_ens"] = 7
+    config["algorithm"] = "Unscented" # "Sampler", "Unscented", "Inversion"
+    config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
+    # Artificial time stepper of the EKI.
+    config["Δt"] = 1.0
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = true
+    config["failure_handler"] = "sample_succ_gauss"
+    return config
+end
+
+function get_reference_config(::ObsCampaigns)
+    config = Dict()
+    config["case_name"] = ["GABLS", "DYCOMS_RF01"]
+    # Flag to indicate source of data (LES or SCM) for reference data and covariance
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] = [["thetal_mean", "u_mean", "v_mean", "tke_mean"], ["thetal_mean", "ql_mean", "qt_mean"]]
+    config["y_dir"] = ["/groups/esm/ilopezgo/Output.GABLS.iles128wCov", "/groups/esm/ilopezgo/Output.DYCOMS_RF01.may20"]
+    # provide list of dirs if different from `y_dir`
+    # config["Σ_dir"] = [...]
+    config["scm_suffix"] = repeat(["000123"], length(config["case_name"]))
+    config["scm_parent_dir"] = repeat(["scm_init"], length(config["case_name"]))
+    config["t_start"] = [7, 2] * 3600.0
+    config["t_end"] = [9, 4] * 3600.0
+    # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
+    # config["Σ_t_start"] = [...]
+    # config["Σ_t_end"] = [...]
+    config["batch_size"] = 1
+    return config
+end
+
+function get_reference_config(::ObsCampaignsVal)
+    config = Dict()
+    config["case_name"] = ["DYCOMS_RF01"]
+    # Flag to indicate source of data (LES or SCM) for reference data and covariance
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] = [["total_flux_h", "total_flux_qt"]]
+    config["y_dir"] = ["/groups/esm/ilopezgo/Output.DYCOMS_RF01.may20"]
+    # provide list of dirs if different from `y_dir`
+    # config["Σ_dir"] = [...]
+    config["scm_suffix"] = repeat(["000123"], length(config["case_name"]))
+    config["scm_parent_dir"] = repeat(["scm_init"], length(config["case_name"]))
+    config["t_start"] = [2] * 3600.0
+    config["t_end"] = [4] * 3600.0
+    # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
+    # config["Σ_t_start"] = [...]
+    # config["Σ_t_end"] = [...]
+    return config
+end
+
+function get_prior_config()
+    config = Dict()
+    config["constraints"] = Dict(
+        # diffusion parameters
+        "tke_ed_coeff" => [bounded(0.01, 1.0)],
+        "tke_diss_coeff" => [bounded(0.01, 1.0)],
+        "static_stab_coeff" => [bounded(0.1, 1.0)],
+    )
+    # TC.jl prior mean
+    config["prior_mean"] = Dict(
+        # diffusion parameters
+        "tke_ed_coeff" => [0.05],
+        "tke_diss_coeff" => [0.5],
+        "static_stab_coeff" => [0.9],
+    )
+
+    config["unconstrained_σ"] = 0.5
+    return config
+end
+
+function get_scm_config()
+    config = Dict()
+    config["namelist_args"] =
+        [("time_stepping", "dt_min", 1.0), ("time_stepping", "dt_max", 10.0), ("stats_io", "frequency", 60.0)]
+    return config
+end

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -197,9 +197,9 @@ version = "0.1.1"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "IntervalSets", "LinearAlgebra", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
-git-tree-sha1 = "b9645be762ce7e573bcf519c81ed6842704c1087"
+git-tree-sha1 = "7caf4f9d92ba3038c3ec9886920844e4efa7a1de"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.8.0"
+version = "0.9.0"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]
@@ -404,12 +404,6 @@ git-tree-sha1 = "3f3a2501fa7236e9b911e0f7a588c657e822bb6d"
 uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
 version = "2.2.3+0"
 
-[[deps.EllipsisNotation]]
-deps = ["ArrayInterface"]
-git-tree-sha1 = "d064b0340db45d48893e7604ec95e7a2dc9da904"
-uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.5.0"
-
 [[deps.Elliptic]]
 git-tree-sha1 = "71c79e77221ab3a29918aaf6db4f217b89138608"
 uuid = "b305315f-e792-5b7a-8f41-49f472929428"
@@ -510,10 +504,10 @@ uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
 [[deps.Flux]]
-deps = ["AbstractTrees", "Adapt", "CUDA", "CodecZlib", "Colors", "DelimitedFiles", "Functors", "Juno", "LinearAlgebra", "MacroTools", "NNlib", "NNlibCUDA", "Pkg", "Printf", "Random", "Reexport", "SHA", "Statistics", "StatsBase", "Test", "ZipFile", "Zygote"]
-git-tree-sha1 = "0b3c6d0ce57d3b793eabd346ccc8f605035ef079"
+deps = ["AbstractTrees", "Adapt", "ArrayInterface", "CUDA", "CodecZlib", "Colors", "DelimitedFiles", "Functors", "Juno", "LinearAlgebra", "MacroTools", "NNlib", "NNlibCUDA", "Pkg", "Printf", "Random", "Reexport", "SHA", "SparseArrays", "Statistics", "StatsBase", "Test", "ZipFile", "Zygote"]
+git-tree-sha1 = "511b7c48eebb602a8f63e7d6c63e25633468dc16"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.4"
+version = "0.12.10"
 
 [[deps.Fontconfig_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
@@ -715,10 +709,10 @@ uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 version = "0.13.5"
 
 [[deps.IntervalSets]]
-deps = ["Dates", "EllipsisNotation", "Statistics"]
-git-tree-sha1 = "bcf640979ee55b652f3b01650444eb7bbe3ea837"
+deps = ["Dates", "Statistics"]
+git-tree-sha1 = "be25da7314bea50ad8303325ba08d9257bf19f9c"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.5.4"
+version = "0.6.0"
 
 [[deps.InverseFunctions]]
 deps = ["Test"]
@@ -791,9 +785,9 @@ version = "0.7.2"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
-git-tree-sha1 = "a024280a69c49f51ba29d2deb66f07508f0b9b49"
+git-tree-sha1 = "82f5afb342a5624dc4651981584a841f6088166b"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.7.13"
+version = "0.8.0"
 
 [[deps.KrylovKit]]
 deps = ["LinearAlgebra", "Printf"]
@@ -960,9 +954,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "DocStringExtensions", "IterativeSolvers", "KLU", "Krylov", "KrylovKit", "LinearAlgebra", "RecursiveFactorization", "Reexport", "Requires", "SciMLBase", "Setfield", "SparseArrays", "SuiteSparse", "UnPack"]
-git-tree-sha1 = "8f6456f4abf9e6bb3330751ffea3626e08c273a7"
+git-tree-sha1 = "6eb8e10ed29b85673495c29bd77ee0dfa8929977"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "1.14.0"
+version = "1.15.0"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
@@ -975,9 +969,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.LoopVectorization]]
 deps = ["ArrayInterface", "CPUSummary", "ChainRulesCore", "CloseOpenIntervals", "DocStringExtensions", "ForwardDiff", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "SIMDDualNumbers", "SLEEFPirates", "SpecialFunctions", "Static", "ThreadingUtilities", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "0ad02fdd8009e42eb52fcef08a4130465e055ebc"
+git-tree-sha1 = "aa73a4f9379db5b4d573bce890289fb34239403d"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.12.104"
+version = "0.12.105"
 
 [[deps.MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
@@ -1070,15 +1064,15 @@ version = "4.5.1"
 
 [[deps.NNlib]]
 deps = ["Adapt", "ChainRulesCore", "Compat", "LinearAlgebra", "Pkg", "Requires", "Statistics"]
-git-tree-sha1 = "3a8dfd0cfb5bb3b82d09949e14423409b9334acb"
+git-tree-sha1 = "a59a614b8b4ea6dc1dcec8c6514e251f13ccbe10"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.7.34"
+version = "0.8.4"
 
 [[deps.NNlibCUDA]]
 deps = ["CUDA", "LinearAlgebra", "NNlib", "Random", "Statistics"]
-git-tree-sha1 = "a2dc748c9f6615197b6b97c10bcce829830574c9"
+git-tree-sha1 = "0d18b4c80a92a00d3d96e8f9677511a7422a946e"
 uuid = "a00861dc-f156-4864-bf3c-e6376f28a68d"
-version = "0.1.11"
+version = "0.2.2"
 
 [[deps.NPZ]]
 deps = ["Compat", "ZipFile"]
@@ -1543,9 +1537,9 @@ version = "6.46.0"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "Requires", "SIMDTypes", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "1bed84857cff4ffa43c6bab6210739cc1d49b377"
+git-tree-sha1 = "c7e0392560f15771003cce388fe8471d17941374"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-version = "0.2.18"
+version = "0.2.19"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
@@ -1652,9 +1646,9 @@ version = "0.3.3"
 
 [[deps.TurbulenceConvection]]
 deps = ["CLIMAParameters", "ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "StaticArrays", "StatsBase", "StochasticDiffEq", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "1cf47e0e262b7f710f99897c8c3210347f28f3b0"
+git-tree-sha1 = "e8c4eb1c9d29ad01cd6fa1ddf65ec28c3dbaa6ed"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "0.17.2"
+version = "0.17.4"
 
 [[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
@@ -1686,9 +1680,9 @@ version = "0.1.2"
 
 [[deps.VectorizationBase]]
 deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "Hwloc", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "83dde373d2695470a6e8abd1380ec4b5e0dd935e"
+git-tree-sha1 = "460aacceb20a12ec187eb8ca183c5944dc6c99c4"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.27"
+version = "0.21.28"
 
 [[deps.VertexSafeGraphs]]
 deps = ["Graphs"]

--- a/integration_tests/julia_parallel_test.jl
+++ b/integration_tests/julia_parallel_test.jl
@@ -122,7 +122,7 @@ Plots.ylabel!("Validation MSE (full)")
 Plots.plot!(; left_margin = 40 * Plots.PlotMeasures.px)
 
 Plots.plot(p1, p2; layout = (1, 2))
-case_name = first(split(config_rel_filepath, "_"))
+
 folder = joinpath(@__DIR__, "output", string(config_basename, "_julia_parallel"))
 mkpath(folder)
 Plots.savefig(joinpath(folder, string(config_basename, "_mse.png")))
@@ -132,7 +132,20 @@ end
 
 using Test
 @testset "Julia Parallel Calibrate" begin
-    # TODO: add better regression test (random seed)
-    @test mse_full_mean[end] < mse_full_mean[1]
-    @test mse_full_var[end] < mse_full_var[1]
+    batch_size = get_entry(config["reference"], "batch_size", nothing)
+    if isnothing(batch_size)
+        # Test convergence
+        @test mse_full_mean[end] < mse_full_mean[1]
+        # Test collapse
+        if algorithm != "Unscented"
+            @test mse_full_var[end] < mse_full_var[1]
+        end
+    else
+        # Test convergence
+        @test val_mse_full_mean[end] < val_mse_full_mean[1]
+        # Test collapse
+        if algorithm != "Unscented"
+            @test val_mse_full_var[end] < val_mse_full_var[1]
+        end
+    end
 end


### PR DESCRIPTION
This PR enables training with heterogeneous (i.e., different size) minibatches, fixing #285.

This was previously not possible because we assumed homogeneity in the dimension of `g_full` for any batch, which is only true when training on ReferenceModels with the same number of fields and same number of vertical levels. We fix this by:

- Changing the allocated dimension of `g_full` and `g_full_val` in the diagnostics netCDF to the maximum possible dimension of the problem, regardless of the batching strategy. These arrays are then filled starting from the leading element, so when batching there is a trailing set of zeroes that are not filled.
- The same approach is taken for the number of fields per configuration. This dimension of the netCDF array is now taken to be the maximum number of fields of any configuration, and when we evaluate configurations with fewer fields, the trailing elements are filled as zeros. 

Additionally, we add an integration test to verify that calibration with heterogeneous batching does not break, using batch size of 1 and a total of 2 configurations.