### PR TITLE
Add grid stretching to config.jl/get_scm_config

### DIFF
--- a/experiments/scm_pycles_pipeline/config.jl
+++ b/experiments/scm_pycles_pipeline/config.jl
@@ -164,6 +164,8 @@ end
 function get_scm_config()
     config = Dict()
     # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
+    # you must verify that the desired namelist changes correcpond to
+    # the if-else starting at line 368 in src/TurbulenceConvectionUtils.jl
     config["namelist_args"] = nothing
     return config
 end

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -372,6 +372,8 @@ function run_SCM_handler(
             namelist["microphysics"][pName] = pVal
         elseif haskey(namelist["time_stepping"], pName)
             namelist["time_stepping"][pName] = pVal
+        elseif haskey(namelist["grid"]["stretch"], pName)
+            namelist["grid"]["stretch"][pName] = pVal
         else
             throw(ArgumentError("Parameter $pName cannot be calibrated. Consider adding namelist dictionary if needed."))
         end


### PR DESCRIPTION
## Changes
add grid stretch to `get_scm_config` and a warning for future changes to make sure they are possible in `src/TurbulenceConvectionUtils.jl`

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.