### PR TITLE
Move constructors docs to struct docstring for Documenter 

### DIFF
--- a/docs/src/API/ReferenceStats.md
+++ b/docs/src/API/ReferenceStats.md
@@ -9,6 +9,8 @@ ReferenceStatistics
 get_obs
 obs_PCA
 pca
+pca_length
+full_length
 get_profile
 get_time_covariance
 ```

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -710,9 +710,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.Interpolations]]
 deps = ["AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
-git-tree-sha1 = "b15fc0a95c564ca2e0a7ae12c1f095ca848ceb31"
+git-tree-sha1 = "b7bc05649af456efc75d178846f47006c2c4c3c7"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.13.5"
+version = "0.13.6"
 
 [[deps.IntervalSets]]
 deps = ["Dates", "Statistics"]
@@ -1163,9 +1163,9 @@ version = "1.4.1"
 
 [[deps.OrdinaryDiffEq]]
 deps = ["Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DocStringExtensions", "ExponentialUtilities", "FastClosures", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "LinearSolve", "Logging", "LoopVectorization", "MacroTools", "MuladdMacro", "NLsolve", "NonlinearSolve", "Polyester", "PreallocationTools", "RecursiveArrayTools", "Reexport", "SciMLBase", "SparseArrays", "SparseDiffTools", "StaticArrays", "UnPack"]
-git-tree-sha1 = "c5568ed45ee56cb4a5e3cebff3b91541ae016a83"
+git-tree-sha1 = "8031a288c9b418664a3dfbac36e464a3f61ace73"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-version = "6.9.0"
+version = "6.10.0"
 
 [[deps.PCRE_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -24,6 +24,38 @@ reference models.
 # Fields
 
 $(TYPEDFIELDS)
+
+# Constructors
+
+    ReferenceModel(
+        y_names::Vector{String},
+        y_dir::String,
+        scm_dir::String,
+        case_name::String,
+        t_start::Real,
+        t_end::Real;
+        Σ_dir::Union{String, Nothing} = nothing,
+        Σ_t_start::Union{Real, Nothing} = nothing,
+        Σ_t_end::Union{Real, Nothing} = nothing,
+    )
+
+`ReferenceModel` constructor allowing for any or all of `Σ_dir`, `Σ_t_start`, `Σ_t_end` to be
+unspecified, in which case they take their values from `y_dir`, `t_start` and `t_end`, respectively.
+
+    ReferenceModel(
+        y_names::Vector{String},
+        y_dir::String,
+        scm_parent_dir::String,
+        scm_suffix::String,
+        case_name::String,
+        t_start::Real,
+        t_end::Real;
+        Σ_dir::Union{String, Nothing} = nothing,
+        Σ_t_start::Union{Real, Nothing} = nothing,
+        Σ_t_end::Union{Real, Nothing} = nothing,
+    )
+
+`ReferenceModel` constructor using `scm_parent_dir`, `case_name`, `scm_suffix`, to define `scm_dir`.
 """
 Base.@kwdef struct ReferenceModel
     "Vector of reference variable names"
@@ -49,22 +81,6 @@ Base.@kwdef struct ReferenceModel
     n_obs::Union{Integer, Nothing}
 end  # ReferenceModel struct
 
-"""
-    ReferenceModel(
-        y_names::Vector{String},
-        y_dir::String,
-        scm_dir::String,
-        case_name::String,
-        t_start::Real,
-        t_end::Real;
-        Σ_dir::Union{String, Nothing} = nothing,
-        Σ_t_start::Union{Real, Nothing} = nothing,
-        Σ_t_end::Union{Real, Nothing} = nothing,
-    )
-
-Construct `ReferenceModel` allowing for any or all of `Σ_dir`, `Σ_t_start`, `Σ_t_end` to be
-unspecified, in which case they take their values from `y_dir`, `t_start` and `t_end`, respectively.
-"""
 function ReferenceModel(
     y_names::Vector{String},
     y_dir::String,
@@ -84,23 +100,6 @@ function ReferenceModel(
     ReferenceModel(y_names, y_dir, Σ_dir, scm_dir, case_name, t_start, t_end, Σ_t_start, Σ_t_end, n_obs)
 end
 
-"""
-    ReferenceModel(
-        y_names::Vector{String},
-        y_dir::String,
-        scm_parent_dir::String,
-        scm_suffix::String,
-        case_name::String,
-        t_start::Real,
-        t_end::Real;
-        Σ_dir::Union{String, Nothing} = nothing,
-        Σ_t_start::Union{Real, Nothing} = nothing,
-        Σ_t_end::Union{Real, Nothing} = nothing,
-    )
-
-`ReferenceModel` constructor using `scm_parent_dir`, `case_name`, `scm_suffix`, to define `scm_dir`.
-
-"""
 function ReferenceModel(
     y_names::Vector{String},
     y_dir::String,
@@ -245,6 +244,22 @@ order for ReferenceModels within the current epoch.
 # Fields
 
 $(TYPEDFIELDS)
+
+# Constructors
+    
+    ReferenceModelBatch(ref_models::Vector{ReferenceModel}, shuffling::Bool = true)
+
+`ReferenceModelBatch` constructor given a vector of `ReferenceModel`s.
+
+
+    ReferenceModelBatch(kwarg_ld::Dict{Symbol, Vector{T} where T}, shuffling::Bool = true)
+
+`ReferenceModelBatch` constructor given a dictionary of keyword argument lists.
+
+Inputs:
+
+ - `kwarg_ld`     :: Dictionary of keyword argument lists
+ - `shuffling`    :: Whether to shuffle the order of ReferenceModels.
 """
 Base.@kwdef struct ReferenceModelBatch
     "Vector containing all reference models"
@@ -253,30 +268,12 @@ Base.@kwdef struct ReferenceModelBatch
     eval_order::Vector{Int}
 end
 
-"""
-    ReferenceModelBatch(kwarg_ld::Dict{Symbol, Vector{T} where T}, shuffling::Bool = true)
-
-::ReferenceModelBatch constructor given a dictionary of keyword argument lists.
-
-Inputs:
-
- - `kwarg_ld`     :: Dictionary of keyword argument lists
- - `shuffling`    :: Whether to shuffle the order of ReferenceModels.
-
-Outputs:
-
- - A ReferenceModelBatch.
-"""
 function ReferenceModelBatch(kwarg_ld::Dict{Symbol, Vector{T} where T}, shuffling::Bool = true)
     ref_models = construct_reference_models(kwarg_ld)
     eval_order = shuffling ? shuffle(1:length(ref_models)) : 1:length(ref_models)
     return ReferenceModelBatch(ref_models, eval_order)
 end
-"""
-    ReferenceModelBatch(ref_models::Vector{ReferenceModel}, shuffling::Bool = true)
 
-::ReferenceModelBatch constructor given a vector of `ReferenceModel`s.
-"""
 function ReferenceModelBatch(ref_models::Vector{ReferenceModel}, shuffling::Bool = true)
     eval_order = shuffling ? shuffle(1:length(ref_models)) : 1:length(ref_models)
     return ReferenceModelBatch(ref_models, eval_order)


### PR DESCRIPTION
## Changes

Documenter does not show `docstrings` of inner or outer constructors explicitly. In order to show constructors in docs, we move here the constructor documentation to the `docstring` of the struct.
 
## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.