### PR TITLE
Add learning rate schedulers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,6 +124,14 @@ steps:
       config: cpu
       queue: central
 
+  - label: "KalmanProcessUtils"
+    key: "cpu_kalmanutils"
+    command:
+      - "julia --color=yes --project test/KalmanProcessUtils/runtests.jl"
+    agents:
+      config: cpu
+      queue: central
+
   - label: "TurbulenceConvectionUtils"
     key: "cpu_turbulenceconvectionutils"
     command:

--- a/docs/src/API/KalmanProcessUtils.md
+++ b/docs/src/API/KalmanProcessUtils.md
@@ -5,6 +5,9 @@ CurrentModule = CalibrateEDMF.KalmanProcessUtils
 ```
 
 ```@docs
+PiecewiseConstantDecay
+PiecewiseConstantGrowth
+get_Δt
 generate_ekp
 generate_tekp
 get_sparse_indices

--- a/integration_tests/Bomex_inversion_test_config.jl
+++ b/integration_tests/Bomex_inversion_test_config.jl
@@ -7,6 +7,7 @@ using CalibrateEDMF
 using CalibrateEDMF.ModelTypes
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.KalmanProcessUtils
 # Import prior constraints
 using EnsembleKalmanProcesses.ParameterDistributions
 using JLD2
@@ -70,7 +71,7 @@ function get_process_config()
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     config["noisy_obs"] = false
     # Artificial time stepper of the EKI.
-    config["Δt"] = 1.0
+    config["Δt"] = PiecewiseConstantDecay(1.0, 5)
     # Whether to augment the outputs with the parameters for regularization
     config["augmented"] = true
     config["failure_handler"] = "sample_succ_gauss"

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -120,9 +120,9 @@ version = "0.4.1"
 
 [[deps.CFTime]]
 deps = ["Dates", "Printf"]
-git-tree-sha1 = "bca6cb6ee746e6485ca4535f6cc29cf3579a0f20"
+git-tree-sha1 = "ed2e76c1c3c43fd9d0cb9248674620b29d71f2d1"
 uuid = "179af706-886a-5703-950a-314cd64e0468"
-version = "0.1.1"
+version = "0.1.2"
 
 [[deps.CLIMAParameters]]
 deps = ["Test"]

--- a/test/KalmanProcessUtils/runtests.jl
+++ b/test/KalmanProcessUtils/runtests.jl
@@ -1,0 +1,22 @@
+using Test
+using NCDatasets
+using CalibrateEDMF.KalmanProcessUtils
+import CalibrateEDMF.KalmanProcessUtils: LearningRateScheduler
+
+@testset "KalmanProcessUtils" begin
+
+    @testset "LearningRateScheduler" begin
+        Δt_init = 1.0
+        τ = 5
+
+        Δt_decay = PiecewiseConstantDecay(Δt_init, τ)
+        Δt_growth = PiecewiseConstantGrowth(Δt_init, τ)
+        @test isa(Δt_decay, LearningRateScheduler)
+        @test isa(Δt_growth, LearningRateScheduler)
+
+        t_future = 10
+        @test get_Δt(Δt_decay, t_future) < Δt_init
+        @test get_Δt(Δt_growth, t_future) > Δt_init
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 include(joinpath("helper_funcs", "runtests.jl"))
 include(joinpath("DistributionUtils", "runtests.jl"))
 include(joinpath("LESUtils", "runtests.jl"))
+include(joinpath("KalmanProcessUtils", "runtests.jl"))
 include(joinpath("TurbulenceConvectionUtils", "runtests.jl"))
 include(joinpath("ReferenceModels", "runtests.jl"))
 include(joinpath("ReferenceStats", "runtests.jl"))


### PR DESCRIPTION
## Changes

Adds learning rate schedulers `PiecewiseConstantDecay` and `PiecewiseConstantGrowth` to the calibration pipeline.

## Issue number (if applicable)

#314

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.