### PR TITLE
Store z_obs vector and reference namelist in ReferenceModel.

### DIFF
--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -2,4 +2,4 @@
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 
 [compat]
-JuliaFormatter = "0.3"
+JuliaFormatter = "0.22"

--- a/docs/src/API/ReferenceModels.md
+++ b/docs/src/API/ReferenceModels.md
@@ -9,6 +9,7 @@ ReferenceModel
 construct_reference_models
 time_shift_reference_model
 get_z_obs
+get_scm_namelist
 ReferenceModelBatch
 get_minibatch!
 reshuffle_on_epoch_end

--- a/docs/src/API/TurbulenceConvectionUtils.md
+++ b/docs/src/API/TurbulenceConvectionUtils.md
@@ -10,7 +10,6 @@ run_SCM
 run_reference_SCM
 eval_single_ref_model
 run_SCM_handler
-get_scm_namelist
 create_parameter_vectors
 generate_scm_input
 get_gcm_les_uuid

--- a/experiments/SCT1_benchmark/config.jl
+++ b/experiments/SCT1_benchmark/config.jl
@@ -106,6 +106,9 @@ function get_reference_config(::SCT1Train)
     config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
     config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
     config["write_full_stats"] = false
+    # Namelist arguments can be passed for individual cases here, or for all cases through
+    # get_scm_config()
+    config["namelist_args"] = repeat([[("grid", "nz", 80)]], n_repeat)
     return config
 end
 
@@ -134,6 +137,9 @@ function get_reference_config(::SCT1Val)
     config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
     config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
     config["write_full_stats"] = false
+    # Namelist arguments can be passed for individual cases here, or for all cases through
+    # get_scm_config()
+    config["namelist_args"] = repeat([[("grid", "nz", 80)]], n_repeat)
     return config
 end
 
@@ -173,7 +179,6 @@ function get_scm_config()
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
         ("stats_io", "calibrate_io", false),
-        ("grid", "nz", 80),
     ]
     return config
 end

--- a/experiments/SCT2_benchmark/config.jl
+++ b/experiments/SCT2_benchmark/config.jl
@@ -72,7 +72,7 @@ function get_regularization_config()
     # in UKI. Feel free to set treat these as hyperparameters.
     config["l2_reg"] = Dict(
         # entrainment parameters
-        "general_ent_params" => repeat([0.0], 69),
+        "nn_ent_params" => repeat([0.0], 58),
         "turbulent_entrainment_factor" => [5.0 / 60.0],
 
         # diffusion parameters
@@ -183,7 +183,7 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 58)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
 
         # diffusion parameters
@@ -205,7 +205,7 @@ function get_prior_config()
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(58) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
 
         # diffusion parameters
@@ -236,10 +236,9 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
-        ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "none"),
+        ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
     ]
     return config
 end

--- a/integration_tests/Bomex_inversion_test_config.jl
+++ b/integration_tests/Bomex_inversion_test_config.jl
@@ -141,6 +141,6 @@ end
 function get_scm_config()
     config = Dict()
     # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
-    config["namelist_args"] = [("stats_io", "calibrate_io", true)]
+    config["namelist_args"] = [("stats_io", "calibrate_io", true), ("stats_io", "frequency", 60.0)]
     return config
 end

--- a/integration_tests/Bomex_sparseinversion_test_config.jl
+++ b/integration_tests/Bomex_sparseinversion_test_config.jl
@@ -143,6 +143,6 @@ end
 function get_scm_config()
     config = Dict()
     # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
-    config["namelist_args"] = [("stats_io", "calibrate_io", true)]
+    config["namelist_args"] = [("stats_io", "calibrate_io", true), ("stats_io", "frequency", 60.0)]
     return config
 end

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -388,9 +388,9 @@ version = "6.83.2"
 
 [[deps.DiffEqJump]]
 deps = ["ArrayInterface", "Compat", "DataStructures", "DiffEqBase", "DocStringExtensions", "FunctionWrappers", "Graphs", "LinearAlgebra", "Markdown", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "StaticArrays", "TreeViews", "UnPack"]
-git-tree-sha1 = "546fa9cc998bcd31bf9e3c928df757106cbf72b3"
+git-tree-sha1 = "649e9f7a17f7e5b1e07a2e0e9ad91c8f74dd1f0d"
 uuid = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
-version = "8.3.1"
+version = "8.4.0"
 
 [[deps.DiffEqNoiseProcess]]
 deps = ["DiffEqBase", "Distributions", "LinearAlgebra", "Optim", "PoissonRandom", "QuadGK", "Random", "Random123", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "Requires", "ResettableStacks", "SciMLBase", "StaticArrays", "Statistics"]
@@ -422,9 +422,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "221ff6c6c9ede484e9f8be4974697187c06eb06b"
+git-tree-sha1 = "70f5bfdfbdc6c9d2b7a143d70ae88f4cb7b193b1"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.55"
+version = "0.25.56"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -1027,9 +1027,9 @@ version = "1.15.0"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "44a7b7bb7dd1afe12bac119df6a7e540fa2c96bc"
+git-tree-sha1 = "76c987446e8d555677f064aaac1145c4c17662f8"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.13"
+version = "0.3.14"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -1305,9 +1305,9 @@ version = "1.2.0"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "c64338ef7b60f8458a9feaadd378261bd3279c89"
+git-tree-sha1 = "d05baca9ec540de3d8b12ef660c7353aae9f9477"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.28.0"
+version = "1.28.1"
 
 [[deps.PoissonRandom]]
 deps = ["Random", "Statistics", "Test"]

--- a/integration_tests/SCT1_integration_test_config.jl
+++ b/integration_tests/SCT1_integration_test_config.jl
@@ -19,6 +19,14 @@ using EnsembleKalmanProcesses.ParameterDistributions
 struct SCT1Train end
 struct SCT1Val end
 
+namelist_args = [
+    ("time_stepping", "dt_min", 1.0),
+    ("time_stepping", "dt_max", 2.0),
+    ("stats_io", "frequency", 60.0),
+    ("stats_io", "calibrate_io", true),
+    ("grid", "nz", 50),
+]
+
 function get_config()
     config = Dict()
     # Flags for saving output data
@@ -106,6 +114,7 @@ function get_reference_config(::SCT1Train)
     config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
     config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
     config["write_full_stats"] = false
+    config["namelist_args"] = repeat([namelist_args], n_repeat)
     return config
 end
 
@@ -134,6 +143,7 @@ function get_reference_config(::SCT1Val)
     config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
     config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
     config["write_full_stats"] = false
+    config["namelist_args"] = repeat([namelist_args], n_repeat)
     return config
 end
 
@@ -158,12 +168,6 @@ end
 
 function get_scm_config()
     config = Dict()
-    config["namelist_args"] = [
-        ("time_stepping", "dt_min", 1.0),
-        ("time_stepping", "dt_max", 2.0),
-        ("stats_io", "frequency", 60.0),
-        ("stats_io", "calibrate_io", true),
-        ("grid", "nz", 80),
-    ]
+    config["namelist_args"] = nothing
     return config
 end

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -40,7 +40,7 @@ Elements:
  - `var_dof` :: Maximum number of degrees of freedom of each field per `ReferenceModel`.
  - `config_pca_dim` :: Dimensionality of the latent space associated with each `ReferenceModel`.
  - `config_name` :: Name of each `ReferenceModel` used to construct the inverse problem.
- - `config_dz` :: Vertical resolution of the observations of each `ReferenceModel`.
+ - `config_z_obs` :: Vertical locations of the observations of each `ReferenceModel`.
  - `norm_factor` :: Pooled variance used to normalize each field of each `ReferenceModel`.
 """
 function io_dictionary_reference()
@@ -55,7 +55,7 @@ function io_dictionary_reference()
         "var_dof" => (; dims = ("config",), group = "reference", type = Int16),
         "config_pca_dim" => (; dims = ("config",), group = "reference", type = Int16),
         "config_name" => (; dims = ("config",), group = "reference", type = String),
-        "config_dz" => (; dims = ("config",), group = "reference", type = Float64),
+        "config_z_obs" => (; dims = ("config", "dof"), group = "reference", type = Float64),
         "norm_factor" => (; dims = ("config", "config_field"), group = "reference", type = Float64),
     )
     return io_dict
@@ -75,7 +75,13 @@ function io_dictionary_reference(
         rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name
         for rm in ref_models
     ]
-    config_dz = [get_dz(scm_nc_file(rm)) for rm in ref_models]
+
+    config_z_obs = zeros(length(ref_models), maximum(var_dof))
+    for (i, rm) in enumerate(ref_models)
+        z_obs = get_z_obs(rm)
+        config_z_obs[i, 1:length(z_obs)] = z_obs
+    end
+
     P_pca_full = zeros(d_full, d)
     idx_row = 1
     idx_col = 1
@@ -95,7 +101,7 @@ function io_dictionary_reference(
         "var_dof" => Base.setindex(orig_dict["var_dof"], var_dof, :field),
         "config_pca_dim" => Base.setindex(orig_dict["config_pca_dim"], config_pca_dim, :field),
         "config_name" => Base.setindex(orig_dict["config_name"], config_name, :field),
-        "config_dz" => Base.setindex(orig_dict["config_dz"], config_dz, :field),
+        "config_z_obs" => Base.setindex(orig_dict["config_z_obs"], config_z_obs, :field),
     )
     max_num_fields = maximum([length(norm_vec) for norm_vec in ref_stats.norm_vec])
     norm_factor = zeros(length(ref_stats.norm_vec), max_num_fields)
@@ -133,7 +139,7 @@ Elements:
  - `var_dof_val` :: Maximum number of degrees of freedom of each field per validation `ReferenceModel`.
  - `config_pca_dim_val` :: Dimensionality of the latent space associated with each validation `ReferenceModel`.
  - `config_name_val` :: Name of each `ReferenceModel` in the validation set.
- - `config_dz_val` :: Vertical resolution of the observations of each validation `ReferenceModel`.
+ - `config_z_obs_val` :: Vertical locations of the observations of each validation `ReferenceModel`.
  - `norm_factor_val` :: Pooled variance used to normalize each field of each validation `ReferenceModel`.
 """
 function io_dictionary_val_reference()
@@ -148,7 +154,7 @@ function io_dictionary_val_reference()
         "var_dof_val" => (; dims = ("config_val",), group = "reference", type = Int16),
         "config_pca_dim_val" => (; dims = ("config_val",), group = "reference", type = Int16),
         "config_name_val" => (; dims = ("config_val",), group = "reference", type = String),
-        "config_dz_val" => (; dims = ("config_val",), group = "reference", type = Float64),
+        "config_z_obs_val" => (; dims = ("config_val", "dof_val"), group = "reference", type = Float64),
         "norm_factor_val" => (; dims = ("config_val", "config_field_val"), group = "reference", type = Float64),
     )
     return io_dict
@@ -168,7 +174,13 @@ function io_dictionary_val_reference(
         rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name
         for rm in ref_models
     ]
-    config_dz = [get_dz(scm_nc_file(rm)) for rm in ref_models]
+
+    config_z_obs = zeros(length(ref_models), maximum(var_dof))
+    for (i, rm) in enumerate(ref_models)
+        z_obs = get_z_obs(rm)
+        config_z_obs[i, 1:length(z_obs)] = z_obs
+    end
+
     P_pca_full = zeros(d_full, d)
     idx_row = 1
     idx_col = 1
@@ -188,7 +200,7 @@ function io_dictionary_val_reference(
         "var_dof_val" => Base.setindex(orig_dict["var_dof_val"], var_dof, :field),
         "config_pca_dim_val" => Base.setindex(orig_dict["config_pca_dim_val"], config_pca_dim, :field),
         "config_name_val" => Base.setindex(orig_dict["config_name_val"], config_name, :field),
-        "config_dz_val" => Base.setindex(orig_dict["config_dz_val"], config_dz, :field),
+        "config_z_obs_val" => Base.setindex(orig_dict["config_z_obs_val"], config_z_obs, :field),
     )
     max_num_fields = maximum([length(norm_vec) for norm_vec in ref_stats.norm_vec])
     norm_factor = zeros(length(ref_stats.norm_vec), max_num_fields)

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -72,8 +72,8 @@ function io_dictionary_reference(
     var_dof = Int.([size(P_pca, 1) for P_pca in ref_stats.pca_vec] ./ num_vars)
     config_pca_dim = [size(P_pca, 2) for P_pca in ref_stats.pca_vec]
     config_name = [
-        rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name
-        for rm in ref_models
+        rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name for
+        rm in ref_models
     ]
 
     config_z_obs = zeros(length(ref_models), maximum(var_dof))
@@ -171,8 +171,8 @@ function io_dictionary_val_reference(
     var_dof = Int.([size(P_pca, 1) for P_pca in ref_stats.pca_vec] ./ num_vars)
     config_pca_dim = [size(P_pca, 2) for P_pca in ref_stats.pca_vec]
     config_name = [
-        rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name
-        for rm in ref_models
+        rm.case_name == "LES_driven_SCM" ? join(split(basename(rm.y_dir), ".")[2:end], "_") : rm.case_name for
+        rm in ref_models
     ]
 
     config_z_obs = zeros(length(ref_models), maximum(var_dof))
@@ -192,7 +192,8 @@ function io_dictionary_val_reference(
     end
     io_dict = Dict(
         "Gamma_val" => Base.setindex(orig_dict["Gamma_val"], ref_stats.Γ, :field),
-        "Gamma_full_diag_val" => Base.setindex(orig_dict["Gamma_full_diag_val"], Array(diag(ref_stats.Γ_full)), :field),
+        "Gamma_full_diag_val" =>
+            Base.setindex(orig_dict["Gamma_full_diag_val"], Array(diag(ref_stats.Γ_full)), :field),
         "y_val" => Base.setindex(orig_dict["y_val"], ref_stats.y, :field),
         "y_full_val" => Base.setindex(orig_dict["y_full_val"], ref_stats.y_full, :field),
         "P_pca_val" => Base.setindex(orig_dict["P_pca_val"], P_pca_full, :field),
@@ -565,7 +566,8 @@ Elements:
 function io_dictionary_val_particle_eval()
     io_dict = Dict(
         "val_g" => (; dims = ("particle", "out_aug_val", "iteration"), group = "particle_diags", type = Float64),
-        "val_g_full" => (; dims = ("particle", "out_full_val", "iteration"), group = "particle_diags", type = Float64),
+        "val_g_full" =>
+            (; dims = ("particle", "out_full_val", "iteration"), group = "particle_diags", type = Float64),
         "val_mse_full" => (; dims = ("particle", "iteration"), group = "particle_diags", type = Float64),
         "val_batch_indices" => (; dims = ("batch_index_val", "iteration"), group = "particle_diags", type = Int16),
     )

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -10,7 +10,6 @@ export vertical_interpolation,
     nc_fetch_interpolate,
     fetch_interpolate_transform,
     get_height,
-    get_dz,
     normalize_profile,
     nc_fetch,
     is_face_variable,
@@ -76,7 +75,7 @@ end
     nc_fetch_interpolate(
         var_name::String,
         filename::String,
-        z_scm::Union{Vector{Float64}, Nothing};
+        z_scm::Union{Vector{<:Real}, Nothing};
     )
 
 Returns the netcdf variable var_name, possibly interpolated to heights z_scm.
@@ -88,7 +87,7 @@ Inputs:
 Output:
  - The interpolated vector.
 """
-function nc_fetch_interpolate(var_name::String, filename::String, z_scm::Union{Vector{Float64}, Nothing};)
+function nc_fetch_interpolate(var_name::String, filename::String, z_scm::Union{Vector{<:Real}, Nothing};)
     if !isnothing(z_scm)
         return vertical_interpolation(var_name, filename, z_scm)
     else
@@ -100,7 +99,7 @@ end
     fetch_interpolate_transform(
         var_name::String,
         filename::String,
-        z_scm::Union{Vector{Float64}, Nothing};
+        z_scm::Union{Vector{<:Real}, Nothing};
     )
 
 Returns the netcdf variable var_name, possibly interpolated to heights z_scm. If the
@@ -114,7 +113,7 @@ Inputs:
 Output:
  - The interpolated and transformed vector.
 """
-function fetch_interpolate_transform(var_name::String, filename::String, z_scm::Union{Vector{Float64}, Nothing};)
+function fetch_interpolate_transform(var_name::String, filename::String, z_scm::Union{Vector{<:Real}, Nothing};)
     # PyCLES vertical fluxes are per volume, not mass
     if occursin("resolved_z_flux", var_name)
         var_ = nc_fetch_interpolate(var_name, filename, z_scm)
@@ -148,21 +147,6 @@ function get_height(filename::String; get_faces::Bool = false)
     else
         return nc_fetch(filename, ("zc", "z_half"))
     end
-end
-
-"""
-    get_dz(filename::String)
-
-Returns the vertical grid size of the given configuration.
-
-Inputs:
- - filename :: nc filename
-Output:
- - The vertical grid size.
-"""
-function get_dz(filename::String)
-    z = get_height(filename)
-    return z[2] - z[1]
 end
 
 """

--- a/src/KalmanProcessUtils.jl
+++ b/src/KalmanProcessUtils.jl
@@ -117,7 +117,8 @@ function generate_ekp(
     else
         fh = IgnoreFailures()
     end
-    ekp = isnothing(u) ? EnsembleKalmanProcess(ref_stats.y, ref_stats.Γ, process, failure_handler_method = fh) :
+    ekp =
+        isnothing(u) ? EnsembleKalmanProcess(ref_stats.y, ref_stats.Γ, process, failure_handler_method = fh) :
         EnsembleKalmanProcess(u, ref_stats.y, ref_stats.Γ, process, failure_handler_method = fh)
     if to_file
         jldsave(ekobj_path(outdir_path, 1); ekp)
@@ -210,7 +211,8 @@ function generate_tekp(
     Γ_aug_list = [ref_stats.Γ, Array(Γ_θ)]
     Γ_aug = cat(Γ_aug_list..., dims = (1, 2))
 
-    ekp = isnothing(u) ? EnsembleKalmanProcess(y_aug, Γ_aug, process, failure_handler_method = fh) :
+    ekp =
+        isnothing(u) ? EnsembleKalmanProcess(y_aug, Γ_aug, process, failure_handler_method = fh) :
         EnsembleKalmanProcess(u, y_aug, Γ_aug, process, failure_handler_method = fh)
     if to_file
         jldsave(ekobj_path(outdir_path, 1); ekp)

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -173,17 +173,18 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     end
 
     # Initialize validation
-    val_ref_models, val_ref_stats = isnothing(val_config) ? repeat([nothing], 2) :
+    val_ref_models, val_ref_stats =
+        isnothing(val_config) ? repeat([nothing], 2) :
         init_validation(
-        val_config,
-        reg_config,
-        ekobj,
-        priors,
-        versions,
-        outdir_path,
-        overwrite = overwrite_scm_file,
-        namelist_args = namelist_args,
-    )
+            val_config,
+            reg_config,
+            ekobj,
+            priors,
+            versions,
+            outdir_path,
+            overwrite = overwrite_scm_file,
+            namelist_args = namelist_args,
+        )
 
     # Diagnostics IO
     init_diagnostics(config, outdir_path, io_ref_models, io_ref_stats, ekobj, priors, val_ref_models, val_ref_stats)
@@ -306,8 +307,8 @@ function init_validation(
     params = [c[:] for c in eachcol(params_cons_i)]
     mod_evaluators = [ModelEvaluator(param, get_name(priors), ref_models, ref_stats) for param in params]
     [
-        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-        for (model_evaluator, version) in zip(mod_evaluators, versions)
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices) for
+        (model_evaluator, version) in zip(mod_evaluators, versions)
     ]
     return ref_models, ref_stats
 end
@@ -367,8 +368,8 @@ function update_validation(
     # Save new ModelEvaluators using the new versions
     versions = readlines(joinpath(outdir_path, "versions_$(iteration + 1).txt"))
     [
-        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-        for (model_evaluator, version) in zip(mod_evaluators, versions)
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices) for
+        (model_evaluator, version) in zip(mod_evaluators, versions)
     ]
     return
 end
@@ -630,8 +631,8 @@ function restart_validation(
     # Save new ModelEvaluators using the new versions
     versions = readlines(joinpath(outdir_path, "versions_$(last_iteration + 1).txt"))
     [
-        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-        for (model_evaluator, version) in zip(mod_evaluators, versions)
+        jldsave(scm_val_init_path(outdir_path, version); model_evaluator, version, batch_indices) for
+        (model_evaluator, version) in zip(mod_evaluators, versions)
     ]
     return
 end

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -78,8 +78,6 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         @info "Training using mini-batches."
         ref_model_batch = ReferenceModelBatch(kwargs_ref_model)
         global_ref_models = deepcopy(ref_model_batch.ref_models)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
         ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
@@ -88,8 +86,6 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         io_ref_models = global_ref_models
     else
         ref_models = construct_reference_models(kwargs_ref_model)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
         io_ref_stats = ref_stats
         io_ref_models = ref_models
@@ -298,13 +294,11 @@ function init_validation(
     if !isnothing(batch_size)
         @info "Validation using mini-batches."
         ref_model_batch = ReferenceModelBatch(kwargs_ref_model)
-        run_reference_SCM.(ref_model_batch.ref_models, overwrite = overwrite, namelist_args = namelist_args)
         ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
         write_val_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
     else
         ref_models = construct_reference_models(kwargs_ref_model)
-        run_reference_SCM.(ref_models, overwrite = overwrite, namelist_args = namelist_args)
         batch_indices = nothing
     end
     ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
@@ -543,8 +537,6 @@ function restart_calibration(
     if !isnothing(batch_size)
         ref_model_batch = load(joinpath(outdir_path, "ref_model_batch.jld2"))["ref_model_batch"]
         global_ref_models = deepcopy(ref_model_batch.ref_models)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(global_ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
         ekp, ref_models, ref_stats, ref_model_batch, batch_indices =
             update_minibatch_inverse_problem(ref_model_batch, ekobj, priors, batch_size, outdir_path, config)
         rm(joinpath(outdir_path, "ref_model_batch.jld2"))
@@ -552,8 +544,6 @@ function restart_calibration(
     else
         ekp = ekobj
         ref_models = construct_reference_models(kwargs_ref_model)
-        # Create input scm stats and namelist file if files don't already exist
-        run_reference_SCM.(ref_models, overwrite = overwrite_scm_file, namelist_args = namelist_args)
         ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
         batch_indices = nothing
     end
@@ -624,14 +614,12 @@ function restart_validation(
 
     if !isnothing(batch_size)
         ref_model_batch = load(joinpath(outdir_path, "val_ref_model_batch.jld2"))["ref_model_batch"]
-        run_reference_SCM.(ref_model_batch.ref_models, overwrite = overwrite, namelist_args = namelist_args)
         ref_models, batch_indices = get_minibatch!(ref_model_batch, batch_size)
         ref_model_batch = reshuffle_on_epoch_end(ref_model_batch)
         rm(joinpath(outdir_path, "val_ref_model_batch.jld2"))
         write_val_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
     else
         ref_models = construct_reference_models(kwargs_ref_model)
-        run_reference_SCM.(ref_models, overwrite = overwrite, namelist_args = namelist_args)
         batch_indices = nothing
     end
     ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -273,10 +273,12 @@ function construct_reference_models(kwarg_ld::Dict{Symbol, Vector{T} where T})::
             # construct ref_models using `scm_parent_dir` and `scm_suffix`
             (kw[j] for j in (:y_names, :y_dir, :scm_parent_dir, :scm_suffix, :case_name, :t_start, :t_end))
         else
-            throw(ArgumentError(
-                "You need to specify either `scm_dir` or all of " *
-                "(`scm_parent_dir`, `case_name`, `scm_suffix`) to construct a `ReferenceModel`",
-            ))
+            throw(
+                ArgumentError(
+                    "You need to specify either `scm_dir` or all of " *
+                    "(`scm_parent_dir`, `case_name`, `scm_suffix`) to construct a `ReferenceModel`",
+                ),
+            )
         end
         push!(
             ref_models,

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -5,17 +5,27 @@ using ..HelperFuncs
 using Random
 using DocStringExtensions
 
+import JSON
+import TurbulenceConvection
+tc = pkgdir(TurbulenceConvection)
+include(joinpath(tc, "driver", "main.jl"))
+include(joinpath(tc, "driver", "generate_namelist.jl"))
+export main1d
+
+import NCDatasets
+NC = NCDatasets
+
 export ReferenceModel, ReferenceModelBatch
 export get_t_start, get_t_end, get_t_start_Σ, get_t_end_Σ, get_z_obs
 export y_dir, Σ_dir, scm_dir, num_vars, uuid
-export y_nc_file, Σ_nc_file, scm_nc_file
+export y_nc_file, Σ_nc_file, get_scm_namelist
 export data_directory, namelist_directory
 export construct_reference_models
 export get_minibatch!, reshuffle_on_epoch_end, write_ref_model_batch
 export time_shift_reference_model, write_val_ref_model_batch
 
 """
-    ReferenceModel
+    ReferenceModel{FT <: Real}
 
 A structure containing information about the 'true' reference model
 and the observation map used to compare the parameterized and
@@ -37,6 +47,8 @@ $(TYPEDFIELDS)
         Σ_dir::Union{String, Nothing} = nothing,
         Σ_t_start::Union{Real, Nothing} = nothing,
         Σ_t_end::Union{Real, Nothing} = nothing,
+        n_obs::Union{Integer, Nothing} = nothing,
+        namelist_args = nothing,
     )
 
 `ReferenceModel` constructor allowing for any or all of `Σ_dir`, `Σ_t_start`, `Σ_t_end` to be
@@ -53,11 +65,13 @@ unspecified, in which case they take their values from `y_dir`, `t_start` and `t
         Σ_dir::Union{String, Nothing} = nothing,
         Σ_t_start::Union{Real, Nothing} = nothing,
         Σ_t_end::Union{Real, Nothing} = nothing,
+        n_obs::Union{Integer, Nothing} = nothing,
+        namelist_args = nothing,
     )
 
 `ReferenceModel` constructor using `scm_parent_dir`, `case_name`, `scm_suffix`, to define `scm_dir`.
 """
-Base.@kwdef struct ReferenceModel
+Base.@kwdef struct ReferenceModel{FT <: Real}
     "Vector of reference variable names"
     y_names::Vector{String}
     "Directory for reference data to compute `y` mean vector"
@@ -70,15 +84,17 @@ Base.@kwdef struct ReferenceModel
     case_name::String
     # TODO: Make t_start and t_end vectors for multiple time intervals per reference model.
     "Start time for computing mean statistics over"
-    y_t_start::Real
+    y_t_start::FT
     "End time for computing mean statistics over"
-    y_t_end::Real
+    y_t_end::FT
     "Start time for computing covariance statistics over"
-    Σ_t_start::Real
+    Σ_t_start::FT
     "End time for computing covariance statistics over"
-    Σ_t_end::Real
-    "Number of observed vertical locations, if not the native grid"
-    n_obs::Union{Integer, Nothing}
+    Σ_t_end::FT
+    "Vector of observed vertical locations"
+    z_obs::Vector{FT}
+    "TurbulenceConvection namelist"
+    namelist::Dict
 end  # ReferenceModel struct
 
 function ReferenceModel(
@@ -92,12 +108,31 @@ function ReferenceModel(
     Σ_t_start::Union{Real, Nothing} = nothing,
     Σ_t_end::Union{Real, Nothing} = nothing,
     n_obs::Union{Integer, Nothing} = nothing,
+    namelist_args = nothing,
 )
+    # Always create new namelist
+    namelist = get_scm_namelist(scm_dir, case_name, y_dir = y_dir, namelist_args = namelist_args, overwrite = true)
+    z_obs = construct_z_obs(namelist)
+    z_obs = !isnothing(n_obs) ? Array(LinRange(z_obs[1], z_obs[end], n_obs)) : z_obs
+    FT = eltype(z_obs)
+
     Σ_dir = isnothing(Σ_dir) ? y_dir : Σ_dir
     Σ_t_start = isnothing(Σ_t_start) ? t_start : Σ_t_start
     Σ_t_end = isnothing(Σ_t_end) ? t_end : Σ_t_end
 
-    ReferenceModel(y_names, y_dir, Σ_dir, scm_dir, case_name, t_start, t_end, Σ_t_start, Σ_t_end, n_obs)
+    ReferenceModel{FT}(
+        y_names,
+        y_dir,
+        Σ_dir,
+        scm_dir,
+        case_name,
+        FT(t_start),
+        FT(t_end),
+        FT(Σ_t_start),
+        FT(Σ_t_end),
+        z_obs,
+        namelist,
+    )
 end
 
 function ReferenceModel(
@@ -112,10 +147,18 @@ function ReferenceModel(
     Σ_t_start::Union{Real, Nothing} = nothing,
     Σ_t_end::Union{Real, Nothing} = nothing,
     n_obs::Union{Integer, Nothing} = nothing,
+    namelist_args = nothing,
 )
     scm_dir = data_directory(scm_parent_dir, case_name, scm_suffix)
     args = (y_names, y_dir, scm_dir, case_name, t_start, t_end)
-    return ReferenceModel(args..., Σ_dir = Σ_dir, Σ_t_start = Σ_t_start, Σ_t_end = Σ_t_end, n_obs = n_obs)
+    return ReferenceModel(
+        args...,
+        Σ_dir = Σ_dir,
+        Σ_t_start = Σ_t_start,
+        Σ_t_end = Σ_t_end,
+        n_obs = n_obs,
+        namelist_args = namelist_args,
+    )
 end
 
 get_t_start(m::ReferenceModel) = m.y_t_start
@@ -124,20 +167,16 @@ get_t_start_Σ(m::ReferenceModel) = m.Σ_t_start
 get_t_end_Σ(m::ReferenceModel) = m.Σ_t_end
 
 "Returns the observed vertical locations for a reference model"
-function get_z_obs(m::ReferenceModel)
-    filename = scm_nc_file(m)
-    z_scm = get_height(filename)
-    return isnothing(m.n_obs) ? z_scm : Array(LinRange(z_scm[1], z_scm[end], m.n_obs))
-end
+get_z_obs(m::ReferenceModel) = m.z_obs
 
 y_dir(m::ReferenceModel) = m.y_dir
 Σ_dir(m::ReferenceModel) = m.Σ_dir
 scm_dir(m::ReferenceModel) = m.scm_dir
+get_scm_namelist(m::ReferenceModel) = deepcopy(m.namelist)
 
 # TODO: cache filename and move `get_stats_path` call to constructor.
 y_nc_file(m::ReferenceModel) = get_stats_path(y_dir(m))
 Σ_nc_file(m::ReferenceModel) = get_stats_path(Σ_dir(m))
-scm_nc_file(m::ReferenceModel) = get_stats_path(scm_dir(m))
 
 data_directory(root::S, name::S, suffix::S) where {S <: AbstractString} = joinpath(root, "Output.$name.$suffix")
 uuid(m::ReferenceModel) = String(split(scm_dir(m), ".")[end])
@@ -146,6 +185,68 @@ namelist_directory(root::String, m::ReferenceModel) = namelist_directory(root, m
 namelist_directory(root::S, casename::S) where {S <: AbstractString} = joinpath(root, "namelist_$casename.in")
 
 num_vars(m::ReferenceModel) = length(m.y_names)
+
+"""
+    get_scm_namelist(
+        output_dir::String,
+        case_name::String;
+        y_dir::Union{String, Nothing} = nothing,
+        overwrite::Bool = false,
+        namelist_args = nothing,
+    )::Dict
+
+Returns a TurbulenceConvection.jl namelist, given the case and a list of namelist arguments.
+
+Inputs:
+
+ - `output_dir`     :: Directory where the namelist will be stored or should be located.
+ - `case_name`      :: Name of the TurbulenceConvection.jl case considered.
+ - `y_dir`          :: Directory with LES data to drive the SCM with, if `case_name` is `LES_driven_SCM`.
+ - `overwrite`      :: Whether to overwrite the namelist file, if it exists.
+ - `namelist_args`  :: Vector of non-default arguments to be used in the namelist, defined as a vector of tuples.
+Outputs:
+ - `namelist`   :: The TurbulenceConvection.jl namelist.
+"""
+function get_scm_namelist(
+    output_dir::String,
+    case_name::String;
+    y_dir::Union{String, Nothing} = nothing,
+    overwrite::Bool = true,
+    namelist_args = nothing,
+)::Dict
+    namelist_path = namelist_directory(output_dir, case_name)
+    namelist = if ~isfile(namelist_path) | overwrite
+        NameList.default_namelist(case_name, root = output_dir)
+    else
+        JSON.parsefile(namelist_path)
+    end
+    namelist["stats_io"]["calibrate_io"] = true
+    if !isnothing(namelist_args)
+        for namelist_arg in namelist_args
+            change_entry!(namelist, namelist_arg)
+        end
+    end
+
+    namelist["meta"]["uuid"] = String(split(output_dir, ".")[end])
+    namelist["output"]["output_root"] = dirname(output_dir)
+    # if `LES_driven_SCM` case, provide input LES stats file
+    if case_name == "LES_driven_SCM"
+        @assert !isnothing(y_dir) "lesfile must be specified in the construction of LES_driven_SCM namelist."
+        namelist["meta"]["lesfile"] = get_stats_path(y_dir)
+    end
+
+    return namelist
+end
+
+"""
+    construct_z_obs(namelist::Dict)
+
+Constructs the vector of observed locations given a TurbulenceConvection.jl namelist.
+"""
+function construct_z_obs(namelist::Dict)
+    grid = construct_grid(namelist)
+    return vec(grid.zc)
+end
 
 """
     construct_reference_models(kwarg_ld::Dict{Symbol, Vector{T} where T})::Vector{ReferenceModel}
@@ -185,6 +286,7 @@ function construct_reference_models(kwarg_ld::Dict{Symbol, Vector{T} where T})::
                 Σ_t_start = get(kw, :Σ_t_start, nothing),
                 Σ_t_end = get(kw, :Σ_t_end, nothing),
                 n_obs = get(kw, :n_obs, nothing),
+                namelist_args = get(kw, :namelist_args, nothing),
             ),
         )
     end
@@ -230,7 +332,8 @@ function time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Rea
         t_end,
         Σ_t_start,
         Σ_t_end,
-        m.n_obs,
+        m.z_obs,
+        m.namelist,
     )
 end
 

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -101,7 +101,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real}
         for m in RM
             model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, Δt) : m
             # Get (interpolated and pool-normalized) observations, get pool variance vector
-            y_, y_var_, pool_var = get_obs(model, y_type, Σ_type, normalize, z_scm = get_z_obs(m))
+            y_, y_var_, pool_var = get_obs(model, y_type, Σ_type, normalize, z_scm = get_z_obs(model))
             push!(norm_vec, pool_var)
             if perform_PCA
                 y_pca, y_var_pca, P_pca = obs_PCA(y_, y_var_, variance_loss)

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -365,7 +365,9 @@ function run_SCM_handler(
         elseif haskey(namelist["time_stepping"], pName)
             namelist["time_stepping"][pName] = pVal
         else
-            throw(ArgumentError("Parameter $pName cannot be calibrated. Consider adding namelist dictionary if needed."))
+            throw(
+                ArgumentError("Parameter $pName cannot be calibrated. Consider adding namelist dictionary if needed."),
+            )
         end
     end
 
@@ -373,12 +375,14 @@ function run_SCM_handler(
         if isnothing(les)
             error("les path or keywords required for LES_driven_SCM case!")
         elseif isa(les, NamedTuple)
-            les = get_stats_path(get_cfsite_les_dir(
-                les.cfsite_number;
-                forcing_model = les.forcing_model,
-                month = les.month,
-                experiment = les.experiment,
-            ))
+            les = get_stats_path(
+                get_cfsite_les_dir(
+                    les.cfsite_number;
+                    forcing_model = les.forcing_model,
+                    month = les.month,
+                    experiment = les.experiment,
+                ),
+            )
         end
         namelist["meta"]["lesfile"] = les
     end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -66,6 +66,7 @@ function eval_single_ref_model(
     u_names::Vector{String},
     namelist_args = nothing,
 ) where {FT <: Real, IT <: Int}
+
     # create temporary directory to store SCM data in
     tmpdir = mktempdir(joinpath(pwd(), "tmp"))
     # run TurbulenceConvection.jl. Get output directory for simulation data

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -34,10 +34,11 @@ using EnsembleKalmanProcesses.ParameterDistributions
         :case_name => repeat(["Bomex"], 2),
         :t_start => repeat([t_max - 2.0 * 3600], 2),
         :t_end => repeat([t_max], 2),
+        :namelist_args => repeat([namelist_args], 2),
     )
     # Generate ref_stats
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
     ref_stats = ReferenceStatistics(ref_models, y_type = SCM(), Σ_type = SCM())
     # Generate config
     config = Dict()

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -17,6 +17,15 @@ using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
 using JLD2
 
+namelist_args = [
+    ("time_stepping", "t_max", 2.0 * 3600),
+    ("time_stepping", "dt_max", 30.0),
+    ("time_stepping", "dt_min", 20.0),
+    ("stats_io", "frequency", 120.0),
+    ("grid", "dz", 150.0),
+    ("grid", "nz", 20),
+]
+
 # Cases defined as structs for quick access to default configs
 struct Bomex end
 
@@ -76,6 +85,7 @@ function get_reference_config(::Bomex)
     config["scm_parent_dir"] = [ref_root_dir]
     config["t_start"] = [0.0]
     config["t_end"] = [2.0 * 3600]
+    config["namelist_args"] = repeat([namelist_args], 2)
     return config
 end
 
@@ -89,13 +99,6 @@ end
 
 function get_scm_config()
     config = Dict()
-    config["namelist_args"] = [
-        ("time_stepping", "t_max", 2.0 * 3600),
-        ("time_stepping", "dt_max", 30.0),
-        ("time_stepping", "dt_min", 20.0),
-        ("grid", "dz", 150.0),
-        ("stats_io", "frequency", 120.0),
-        ("grid", "nz", 20),
-    ]
+    config["namelist_args"] = nothing
     return config
 end

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -31,7 +31,7 @@ ref_model = ReferenceModel(
 )
 namelist_args = config["scm"]["namelist_args"]
 # Generate "true" data
-run_reference_SCM(ref_model, run_single_timestep = false, namelist_args = namelist_args)
+run_reference_SCM(ref_model, run_single_timestep = false)
 
 # Test a range of calibration initializations
 @testset "init_calibration" begin

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -23,10 +23,11 @@ using CalibrateEDMF.DistributionUtils
         ("time_stepping", "t_max", t_max),
         ("time_stepping", "dt_max", dt_max),
         ("time_stepping", "dt_min", dt_min),
+        ("stats_io", "frequency", io_frequency),
         ("grid", "dz", 150.0),
         ("grid", "nz", 20),
-        ("stats_io", "frequency", io_frequency),
     ]
+
     kwargs_ref_model = Dict(
         :y_names => [["u_mean"], ["v_mean"]],
         :y_dir => scm_dirs,
@@ -34,9 +35,10 @@ using CalibrateEDMF.DistributionUtils
         :case_name => repeat(["Bomex"], 2),
         :t_start => repeat([t_max - 2.0 * 3600], 2),
         :t_end => repeat([t_max], 2),
+        :namelist_args => repeat([namelist_args], 2),
     )
     ref_models = construct_reference_models(kwargs_ref_model)
-    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false, namelist_args = namelist_args)
+    run_reference_SCM.(ref_models, overwrite = false, run_single_timestep = false)
 
     # Test penalty behavior of ReferenceStatistics.get_profile
     filename = get_stats_path(scm_dirs[1])

--- a/test/TurbulenceConvectionUtils/runtests.jl
+++ b/test/TurbulenceConvectionUtils/runtests.jl
@@ -8,6 +8,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
 using CalibrateEDMF.ModelTypes
 using CalibrateEDMF.ReferenceModels
+import CalibrateEDMF.ReferenceModels: NameList
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
@@ -37,6 +38,7 @@ import CalibrateEDMF.TurbulenceConvectionUtils: create_parameter_vectors
             ("grid", "nz", 20),
             ("stats_io", "frequency", 720.0),
         ]
+
         kwargs_ref_model = Dict(
             :y_names => [["u_mean", "v_mean"]],
             :y_dir => scm_dirs,
@@ -46,13 +48,10 @@ import CalibrateEDMF.TurbulenceConvectionUtils: create_parameter_vectors
             :t_end => [t_max],
             :Σ_t_start => [t_max - 2.0 * 3600],
             :Σ_t_end => [t_max],
+            :namelist_args => repeat([namelist_args], 2),
         )
         ref_models = construct_reference_models(kwargs_ref_model)
-        @test_logs (:warn,) match_mode = :any run_reference_SCM.(
-            ref_models,
-            run_single_timestep = false,
-            namelist_args = namelist_args,
-        )
+        @test_logs (:warn,) match_mode = :any run_reference_SCM.(ref_models, run_single_timestep = false)
 
         u_names = ["entrainment_factor", "dt_max", "τ_acnv_rai"]
         u = [0.15, 210.0, 2500.0]
@@ -100,7 +99,7 @@ import CalibrateEDMF.TurbulenceConvectionUtils: create_parameter_vectors
 
         # ensure namelist generated with `run_reference_SCM` matches default namelist
         init_namelist_path = namelist_directory(scm_dir(ref_models[1]), ref_models[1])
-        default_namelist = TurbulenceConvectionUtils.NameList.default_namelist(case_name, root = scm_dir(ref_models[1]))
+        default_namelist = NameList.default_namelist(case_name, root = scm_dir(ref_models[1]))
         reference_namelist = JSON.parsefile(init_namelist_path)
 
         namelist_compare_entries = ["microphysics", "time_stepping", "stats_io", "grid", "thermodynamics"]


### PR DESCRIPTION
## Changes

Constructs the vector of observations and reference namelist at ReferenceModel construction time and stores them within the struct. This approach has a number of advantages:

- Reduces number of calls to the infamous `get_stats_path`,
- Stores observational grid points within ReferenceModel, which enables writing them to the Diagnostics. Right now it was only possible to reconstruct them implicitly based on constant `dz` assumptions, which we want to move away from,
- Enables passing non-default grid namelist arguments separately to each ReferenceModel. This allows greater flexibility than the current approach, in which we either calibrated to the default resolution or to a common resolution for all cases.
- Removes the need to use `run_reference_SCM`! We retain the function to be able to call TC.jl without calibration, which may be useful. But `run_reference_SCM` is no longer used in the calibration pipeline.
- Reduces the time spent in the initialization step.

## Issue number (if applicable)

This closes issue #319, and should be a helpful step towards resolving #311 and #230. 

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.