### PR TITLE
fix: l2_reg scope

### DIFF
--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -424,6 +424,9 @@ function ek_update(
 
     val_config = get(config, "validation", nothing)
 
+    reg_config = config["regularization"]
+    l2_reg = get_entry(reg_config, "l2_reg", nothing)
+
     scm_args = load(scm_output_path(outdir_path, versions[1]))
     mod_evaluator = scm_args["model_evaluator"]
     batch_indices = scm_args["batch_indices"]
@@ -432,8 +435,6 @@ function ek_update(
 
     # Advance EKP
     if augmented
-        reg_config = config["regularization"]
-        l2_reg = get_entry(reg_config, "l2_reg", nothing)
         g, g_full = get_ensemble_g_eval_aug(outdir_path, versions, priors, l2_reg)
     else
         g, g_full = get_ensemble_g_eval(outdir_path, versions)


### PR DESCRIPTION
## Changes

The current code would fail for 
https://github.com/CliMA/CalibrateEDMF.jl/blob/369f479e9a723b446dfd4c77a3b58d4e1376cfa5/src/Pipeline.jl#L452-L454
since `l2_reg` would be undefined, unless `augmented` is `true`, so that the following preceding code was is called
https://github.com/CliMA/CalibrateEDMF.jl/blob/369f479e9a723b446dfd4c77a3b58d4e1376cfa5/src/Pipeline.jl#L434-L440

This PR moves the definition of `l2_reg` out of that conditional block.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] ~~I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.~~
- [x] ~~If core features are added, I have added appropriate test coverage.~~
- [x] ~~If new functions and structs are added, they are documented through docstrings.~~