### PR TITLE
fix: SCT1 and SCT2 restart calibration bug

### DIFF
--- a/experiments/SCT1_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT1_benchmark/global_parallel/restart.jl
@@ -26,8 +26,8 @@ parsed_args = parse_args(ARGS, s)
 # Recover inputs for restart
 outdir_path = parsed_args["output_dir"]
 include(joinpath(outdir_path, "config.jl"))
-ekobjs = glob(joinpath(outdir_path, "ekobj_iter_*.jld2"))
-iters = [parse(Int64, split(split(split(ekobj, "/")[2], "_")[3], ".")[1]) for ekobj in ekobjs]
+ekobjs = glob("ekobj_iter_*.jld2", outdir_path)
+iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
 last_iteration = maximum(iters)
 
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))

--- a/experiments/SCT2_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT2_benchmark/global_parallel/restart.jl
@@ -26,8 +26,8 @@ parsed_args = parse_args(ARGS, s)
 # Recover inputs for restart
 outdir_path = parsed_args["output_dir"]
 include(joinpath(outdir_path, "config.jl"))
-ekobjs = glob(joinpath(outdir_path, "ekobj_iter_*.jld2"))
-iters = [parse(Int64, split(split(split(ekobj, "/")[2], "_")[3], ".")[1]) for ekobj in ekobjs]
+ekobjs = glob("ekobj_iter_*.jld2", outdir_path)
+iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
 last_iteration = maximum(iters)
 
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))


### PR DESCRIPTION
* do glob with prefix
* fetch most recent ekobj_iter_XX.jld file more robustly

## Changes

1. **glob bug**
if `outdir_path` is an absolute path, 
```julia
ekobjs = glob(joinpath(outdir_path, "ekobj_iter_*.jld2"))
```
will fail. instead, `outdir_path` should be specified as the prefix for the search query (`"ekobj_iter_*.jld2"`).

2. **ekobj_iter_XX.jld2 bug**
If `ekobjs` is an absolute path that contains `_` and/or `.` in the pathname, 
```julia
iters = [parse(Int64, split(split(split(ekobj, "/")[2], "_")[3], ".")[1]) for ekobj in ekobjs]
```
may fail. Instead, match a regex query to get the relevant integers.
## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [ ] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [ ] If core features are added, I have added appropriate test coverage.
- [ ] If new functions and structs are added, they are documented through docstrings.