### PR TITLE
refactor: simplify versions logic

### DIFF
--- a/docs/src/API/TurbulenceConvectionUtils.md
+++ b/docs/src/API/TurbulenceConvectionUtils.md
@@ -12,6 +12,7 @@ eval_single_ref_model
 run_SCM_handler
 create_parameter_vectors
 generate_scm_input
+parse_version_inds
 get_gcm_les_uuid
 precondition
 ```

--- a/experiments/SCT1_benchmark/NN_closure/buoy_vel_no_reg/e100/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/buoy_vel_no_reg/e100/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "buoy_vel"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/buoy_vel_no_reg/e50/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/buoy_vel_no_reg/e50/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "buoy_vel"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/buoy_vel_reg_0.1/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/buoy_vel_reg_0.1/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "buoy_vel"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/inv_z_l2_reg_0.1/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/inv_z_l2_reg_0.1/config.jl
@@ -136,14 +136,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -157,11 +157,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/inv_z_no_reg/e100/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/inv_z_no_reg/e100/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/inv_z_no_reg/e50/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/inv_z_no_reg/e50/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/none_no_reg/e100/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/none_no_reg/e100/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "none"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/none_no_reg/e50/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/none_no_reg/e50/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "none"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/NN_closure/none_reg_0.1/config.jl
+++ b/experiments/SCT1_benchmark/NN_closure/none_reg_0.1/config.jl
@@ -140,14 +140,14 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
     )
 
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
     )
 
@@ -161,11 +161,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "none"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
@@ -17,7 +17,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
@@ -19,7 +19,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/SCT1_benchmark/moisture_deficit_closure/config.jl
+++ b/experiments/SCT1_benchmark/moisture_deficit_closure/config.jl
@@ -174,7 +174,6 @@ function get_scm_config()
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
         ("stats_io", "calibrate_io", false),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
     ]
     return config

--- a/experiments/SCT2_benchmark/NN_closure/inv_z_no_NN_reg/config.jl
+++ b/experiments/SCT2_benchmark/NN_closure/inv_z_no_NN_reg/config.jl
@@ -72,7 +72,7 @@ function get_regularization_config()
     # in UKI. Feel free to set treat these as hyperparameters.
     config["l2_reg"] = Dict(
         # entrainment parameters
-        "general_ent_params" => repeat([0.0], 69),
+        "nn_ent_params" => repeat([0.0], 69),
         "turbulent_entrainment_factor" => [5.0 / 60.0],
 
         # diffusion parameters
@@ -183,7 +183,7 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # entrainment parameters
-        "general_ent_params" => [repeat([no_constraint()], 69)...],
+        "nn_ent_params" => [repeat([no_constraint()], 69)...],
         "turbulent_entrainment_factor" => [bounded(0.0, 10.0)],
 
         # diffusion parameters
@@ -205,7 +205,7 @@ function get_prior_config()
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # entrainment parameters
-        "general_ent_params" => 0.1 .* (rand(69) .- 0.5),
+        "nn_ent_params" => 0.1 .* (rand(69) .- 0.5),
         "turbulent_entrainment_factor" => [0.075],
 
         # diffusion parameters
@@ -236,11 +236,11 @@ function get_scm_config()
         ("time_stepping", "dt_min", 1.0),
         ("time_stepping", "dt_max", 2.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
         ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
         ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "inv_z"),
+        ("turbulence", "EDMF_PrognosticTKE", "nn_ent_biases", true),
     ]
     return config
 end

--- a/experiments/SCT2_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT2_benchmark/global_parallel/parallel_scm_eval.jl
@@ -17,7 +17,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/SCT2_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT2_benchmark/global_parallel/precondition_prior.jl
@@ -19,7 +19,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/les_strats/config.jl
+++ b/experiments/les_strats/config.jl
@@ -252,7 +252,6 @@ function get_scm_config()
         ("time_stepping", "dt_min", 2.0),
         ("time_stepping", "dt_max", 10.0),
         ("stats_io", "frequency", 60.0),
-        ("grid", "dz", 50.0),
         ("grid", "nz", 80),
     ]
     return config

--- a/experiments/les_strats/global_parallel/parallel_scm_eval.jl
+++ b/experiments/les_strats/global_parallel/parallel_scm_eval.jl
@@ -17,7 +17,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/les_strats/global_parallel/precondition_prior.jl
+++ b/experiments/les_strats/global_parallel/precondition_prior.jl
@@ -19,7 +19,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
@@ -20,7 +20,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
@@ -12,7 +12,7 @@ s = ArgParseSettings()
 @add_arg_table s begin
     "--version"
     help = "Calibration process number"
-    arg_type = Int
+    arg_type = String
     "--job_dir"
     help = "Job output directory"
     arg_type = String

--- a/integration_tests/continue_julia_parallel_test.jl
+++ b/integration_tests/continue_julia_parallel_test.jl
@@ -38,7 +38,7 @@ outdir_path = open(f -> read(f, String), string(folder, config_basename, ".txt")
 
 include(joinpath(outdir_path, "config.jl"))
 ekobjs = glob(joinpath(relpath(outdir_path), "ekobj_iter_*.jld2"))
-iters = [parse(Int64, first(split(split(split(ekobj, "/")[end], "_")[end], "."))) for ekobj in ekobjs]
+iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
 last_iteration = maximum(iters)
 
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -554,15 +554,13 @@ ekobj_path(root, iter; prefix = "ekobj_iter_") = jld2_path(root, iter, prefix)
 
 
 """
-    write_versions(versions::Vector{Int}, iteration::Int; outdir_path::String = pwd())
+    write_versions(versions, iteration; outdir_path = pwd())
 
 Writes versions associated with an EnsembleKalmanProcess iteration to a text file.
 """
-function write_versions(versions::Vector{Int}, iteration::Int; outdir_path::String = pwd())
+function write_versions(versions::Vector{String}, iteration::Int; outdir_path::String = pwd())
     open(joinpath(outdir_path, "versions_$(iteration).txt"), "w") do io
-        for version in versions
-            write(io, "$(version)\n")
-        end
+        println.(Ref(io), versions)
     end
 end
 


### PR DESCRIPTION
## Changes
This pair aims to simplify how naming of `versions` is done during calibration.
A `version` is currently a random 5-digit integer that is associated with an ensemble member in an EKP iteration.

For example, before every iteration, there is be a bunch of `scm_initializer_<version>.jld2` files in the results directory which contains the necessary information to run the simulations associated with each ensemble member.

This PR proposes that `version` is generated deterministically, and is on the form `ix_ey` where `x` is the current iteration index and `y` is the current ensemble index.

The PR serves two purposes, first, it simplifies the logic of #180, and second, it makes it potentially easier to debug calibration runs since you can easily see what each `jld2` file corresponds to.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.0.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.