### PR TITLE
simplify system-image test by not running a precompile execution file

### DIFF
--- a/integration_tests/test_create_tc_so.jl
+++ b/integration_tests/test_create_tc_so.jl
@@ -19,7 +19,7 @@ if isempty(Glob.glob("CEDMF.so"))
         # Caltech Central CPU architecture, `native` leads to issues as well.
         # This one works most of the time, but needs a failsafe mechanism.
         cpu_target = "skylake-avx512",
-        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
+        # precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
     )
 
     # Other cpu_target options


### PR DESCRIPTION
## Changes
reduces time to build system image from ~30-40 mins to < 15 mins
## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.