### PR TITLE
Fix namelist_args handling during ReferenceModel construction

### DIFF
--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -55,9 +55,9 @@ version = "6.0.17"
 
 [[deps.ArrayInterfaceCore]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "d618d3cf75e8ed5064670e939289698ecf426c7f"
+git-tree-sha1 = "5e732808bcf7bbf730e810a9eaafc52705b38bb5"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.12"
+version = "0.1.13"
 
 [[deps.ArrayInterfaceGPUArrays]]
 deps = ["Adapt", "ArrayInterfaceCore", "GPUArraysCore", "LinearAlgebra"]
@@ -281,9 +281,9 @@ version = "0.4.0"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "Random"]
-git-tree-sha1 = "7297381ccb5df764549818d9a7d57e45f1057d30"
+git-tree-sha1 = "1fd869cc3875b57347f7027521f561cf46d1fcd8"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.18.0"
+version = "3.19.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -782,9 +782,9 @@ version = "0.9.4"
 
 [[deps.ImageIO]]
 deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs"]
-git-tree-sha1 = "d9a03ffc2f6650bd4c831b285637929d99a4efb5"
+git-tree-sha1 = "342f789fd041a55166764c351da1710db97ce0e0"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
-version = "0.6.5"
+version = "0.6.6"
 
 [[deps.Imath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1311,9 +1311,9 @@ uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ab05aa4cc89736e95915b01e7279e61b1bfe33b8"
+git-tree-sha1 = "9a36165cf84cff35851809a40a928e1103702013"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.14+0"
+version = "1.1.16+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1434,9 +1434,9 @@ version = "3.0.0"
 
 [[deps.PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "bb16469fd5224100e422f0b027d26c5a25de1200"
+git-tree-sha1 = "9888e59493658e476d3073f1ce24348bdc086660"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
@@ -1458,9 +1458,9 @@ version = "0.6.12"
 
 [[deps.PolyesterWeave]]
 deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "7e597df97e46ffb1c8adbaddfa56908a7a20194b"
+git-tree-sha1 = "4cd738fca4d826bef1a87cbe43196b34fa205e6d"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
-version = "0.1.5"
+version = "0.1.6"
 
 [[deps.PolygonOps]]
 git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
@@ -1813,15 +1813,15 @@ version = "6.49.1"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "SIMDTypes", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "fda504af359e7236b0332b1a2d6cf92c29f4f4dd"
+git-tree-sha1 = "e2b888f982b5b8ba89fd827ad8fc66dc9a628b68"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-version = "0.3.11"
+version = "0.3.13"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
-git-tree-sha1 = "9abba8f8fb8458e9adf07c8a2377a070674a24f1"
+git-tree-sha1 = "55ef24d228f9396fa9e2317eb60c953b8cec1ae7"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.8"
+version = "0.6.10"
 
 [[deps.SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
@@ -1897,10 +1897,10 @@ uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 version = "0.5.0"
 
 [[deps.TiffImages]]
-deps = ["ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "OffsetArrays", "PkgVersion", "ProgressMeter", "UUIDs"]
-git-tree-sha1 = "f90022b44b7bf97952756a6b6737d1a0024a3233"
+deps = ["ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "Mmap", "OffsetArrays", "PkgVersion", "ProgressMeter", "UUIDs"]
+git-tree-sha1 = "fcf41697256f2b759de9380a7e8196d6516f0310"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
-version = "0.5.5"
+version = "0.6.0"
 
 [[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -589,7 +589,7 @@ end
 """
     change_entry!(dict, keys_and_value)
 
-Changes the entry of a nested dictionary, giving a tuple of all its keys and the new value
+Changes the entry of a nested dictionary, given a tuple of all its keys and the new value
 
 Inputs:
  - `dict`           :: Parent dictionary with an arbitrary number of nested dictionaries.

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -177,6 +177,7 @@ function get_ref_model_kwargs(ref_config::Dict{Any, Any})
     Σ_t_start = expand_dict_entry(ref_config, "Σ_t_start", n_cases)
     Σ_t_end = expand_dict_entry(ref_config, "Σ_t_end", n_cases)
     n_obs = expand_dict_entry(ref_config, "n_obs", n_cases)
+    namelist_args = expand_dict_entry(ref_config, "namelist_args", n_cases)
     scm_path_kwargs = if haskey(ref_config, "scm_dir")
         Dict(:scm_dir => ref_config["scm_dir"])
     elseif all(haskey.(Ref(ref_config), ["scm_parent_dir", "scm_suffix"]))
@@ -198,6 +199,7 @@ function get_ref_model_kwargs(ref_config::Dict{Any, Any})
         :Σ_t_start => Σ_t_start,
         :Σ_t_end => Σ_t_end,
         :n_obs => n_obs,
+        :namelist_args => namelist_args,
     )
     merge!(rm_kwargs, scm_path_kwargs)
     n_RM = length(rm_kwargs[:case_name])

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -85,7 +85,7 @@ function get_reference_config(::Bomex)
     config["scm_parent_dir"] = [ref_root_dir]
     config["t_start"] = [0.0]
     config["t_end"] = [2.0 * 3600]
-    config["namelist_args"] = repeat([namelist_args], 2)
+    config["namelist_args"] = [namelist_args]
     return config
 end
 

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -45,6 +45,7 @@ pwdir = mktempdir()
     @test isa(z_stretch, Array)
     # Test stretching
     @test z_stretch[2] - z_stretch[1] < z_stretch[3] - z_stretch[2]
+    @test z_stretch[3] - z_stretch[2] < z_stretch[4] - z_stretch[3]
 end
 
 @testset "ReferenceModelBatch" begin


### PR DESCRIPTION
## Changes

There was a bug in the code, which caused the `get_ref_models_kwargs` function to ignore the namelist_args passed to ReferenceModels. This PR fixes that bug, and allows passing different namelist_args for each ReferenceModel.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.