### PR TITLE
Centralize serial julia drivers

### DIFF
--- a/driver/create_tc_so.jl
+++ b/driver/create_tc_so.jl
@@ -1,0 +1,28 @@
+using Glob
+
+if isempty(Glob.glob("CEDMF.so"))
+
+    using Pkg
+    using PackageCompiler
+    using CalibrateEDMF
+
+    cedmf = pkgdir(CalibrateEDMF)
+    pkgs = [:CalibrateEDMF]
+    append!(pkgs, [Symbol(v.name) for v in values(Pkg.dependencies()) if v.is_direct_dep])
+
+    create_sysimage(
+        pkgs;
+        sysimage_path = "CEDMF.so",
+        # Caltech Central CPU architecture, `native` leads to issues as well.
+        # This one works most of the time, but needs a failsafe mechanism.
+        cpu_target = "skylake-avx512",
+        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
+    )
+
+    # Other cpu_target options
+    #cpu_target = "native", # Default 
+    #cpu_target = PackageCompiler.default_app_cpu_target(),
+    #cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)", # Same as Julia Base
+    #cpu_target = "generic",
+
+end

--- a/driver/global_parallel/init.jl
+++ b/driver/global_parallel/init.jl
@@ -1,0 +1,21 @@
+"""Initializes a SCM calibration process."""
+
+using ArgParse
+using CalibrateEDMF
+using CalibrateEDMF.Pipeline
+
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--config"
+    help = "Inverse problem config file"
+    arg_type = String
+    "--job_id"
+    help = "Job identifier"
+    arg_type = String
+    default = "12345"
+end
+parsed_args = parse_args(ARGS, s)
+include(parsed_args["config"])
+config = get_config()
+
+init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])

--- a/driver/global_parallel/parallel_scm_eval.jl
+++ b/driver/global_parallel/parallel_scm_eval.jl
@@ -1,0 +1,37 @@
+"""Evaluates a set of SCM configurations for a single parameter vector."""
+
+@everywhere using Pkg
+@everywhere Pkg.activate("../../..")
+@everywhere using ArgParse
+@everywhere using CalibrateEDMF
+@everywhere using CalibrateEDMF.Pipeline
+@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
+
+@everywhere src_dir = dirname(pathof(CalibrateEDMF))
+@everywhere using CalibrateEDMF.HelperFuncs
+@everywhere include(joinpath(src_dir, "parallel.jl"))
+using JLD2
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--version"
+    help = "Calibration process number"
+    arg_type = String
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+    "--mode"
+    help = "Forward model evaluation mode: `train` or `validation`"
+    arg_type = String
+    default = "train"
+end
+parsed_args = parse_args(ARGS, s)
+outdir_path = parsed_args["job_dir"]
+include(joinpath(outdir_path, "config.jl"))
+
+config = get_config()
+version = parsed_args["version"]
+mode = parsed_args["mode"]
+versioned_model_eval_parallel(version, outdir_path, mode, config)

--- a/driver/global_parallel/precondition_prior.jl
+++ b/driver/global_parallel/precondition_prior.jl
@@ -1,0 +1,45 @@
+"""Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
+
+using ArgParse
+using Distributions
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--version"
+    help = "Calibration process number"
+    arg_type = String
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+end
+parsed_args = parse_args(ARGS, s)
+version = parsed_args["version"]
+outdir_path = parsed_args["job_dir"]
+include(joinpath(outdir_path, "config.jl"))
+config = get_config()
+namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+
+scm_args = load(scm_init_path(outdir_path, version))
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
+
+# Preconditioning ensemble methods in unconstrained space
+if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
+    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
+    batch_indices = scm_args["batch_indices"]
+    rm(scm_init_path(outdir_path, version))
+    jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
+end

--- a/driver/global_parallel/restart.jl
+++ b/driver/global_parallel/restart.jl
@@ -1,0 +1,36 @@
+"""Restarts a calibration process."""
+
+# Import modules to all processes
+using ArgParse
+using Glob
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.Pipeline
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--output_dir"
+    help = "Results output directory"
+    arg_type = String
+    "--job_id"
+    help = "Job identifier"
+    arg_type = String
+    default = "12345"
+end
+parsed_args = parse_args(ARGS, s)
+# Recover inputs for restart
+outdir_path = parsed_args["output_dir"]
+include(joinpath(outdir_path, "config.jl"))
+ekobjs = glob("ekobj_iter_*.jld2", outdir_path)
+iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
+last_iteration = maximum(iters)
+
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, last_iteration))["ekp"]
+config = get_config()
+restart_calibration(ekobj, priors, last_iteration, config, outdir_path, job_id = parsed_args["job_id"])

--- a/driver/global_parallel/step_ekp.jl
+++ b/driver/global_parallel/step_ekp.jl
@@ -1,0 +1,36 @@
+"""Performs a single step of the EnsembleKalmanProcess."""
+
+# Import modules to all processes
+using ArgParse
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.Pipeline
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--iteration"
+    help = "Calibration iteration number"
+    arg_type = Int
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+end
+parsed_args = parse_args(ARGS, s)
+# Recover inputs for update
+iteration = parsed_args["iteration"]
+outdir_path = parsed_args["job_dir"]
+
+include(joinpath(outdir_path, "config.jl"))
+
+versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
+config = get_config()
+ek_update(ekobj, priors, iteration, config, versions, outdir_path)

--- a/driver/hpc_parallel/init.jl
+++ b/driver/hpc_parallel/init.jl
@@ -1,0 +1,21 @@
+"""Initializes a SCM calibration process."""
+
+using ArgParse
+using CalibrateEDMF
+using CalibrateEDMF.Pipeline
+
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--config"
+    help = "Inverse problem config file"
+    arg_type = String
+    "--job_id"
+    help = "Job identifier"
+    arg_type = String
+    default = "12345"
+end
+parsed_args = parse_args(ARGS, s)
+include(parsed_args["config"])
+config = get_config()
+
+init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])

--- a/driver/hpc_parallel/precondition_prior.jl
+++ b/driver/hpc_parallel/precondition_prior.jl
@@ -1,0 +1,46 @@
+"""Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
+
+using ArgParse
+using Distributions
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.TurbulenceConvectionUtils
+src_dir = dirname(pathof(CalibrateEDMF))
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--version"
+    help = "Calibration process number"
+    arg_type = String
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+end
+parsed_args = parse_args(ARGS, s)
+version = parsed_args["version"]
+outdir_path = parsed_args["job_dir"]
+include(joinpath(outdir_path, "config.jl"))
+config = get_config()
+namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+
+scm_args = load(scm_init_path(outdir_path, version))
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
+
+# Preconditioning ensemble methods in unconstrained space
+if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
+    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
+    batch_indices = scm_args["batch_indices"]
+    rm(scm_init_path(outdir_path, version))
+    jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
+end

--- a/driver/hpc_parallel/single_scm_eval.jl
+++ b/driver/hpc_parallel/single_scm_eval.jl
@@ -1,0 +1,32 @@
+"""Evaluates a set of SCM configurations for a single parameter vector."""
+
+using ArgParse
+using CalibrateEDMF
+using CalibrateEDMF.Pipeline
+src_dir = dirname(pathof(CalibrateEDMF))
+using CalibrateEDMF.HelperFuncs
+using JLD2
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--version"
+    help = "Calibration process number"
+    arg_type = String
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+    "--mode"
+    help = "Forward model evaluation mode: `train` or `validation`"
+    arg_type = String
+    default = "train"
+end
+parsed_args = parse_args(ARGS, s)
+outdir_path = parsed_args["job_dir"]
+include(joinpath(outdir_path, "config.jl"))
+
+config = get_config()
+version = parsed_args["version"]
+mode = parsed_args["mode"]
+versioned_model_eval(version, outdir_path, mode, config)

--- a/driver/hpc_parallel/step_ekp.jl
+++ b/driver/hpc_parallel/step_ekp.jl
@@ -1,0 +1,37 @@
+"""Performs a single step of the EnsembleKalmanProcess."""
+
+# Import modules to all processes
+using ArgParse
+using CalibrateEDMF
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.Pipeline
+src_dir = dirname(pathof(CalibrateEDMF))
+using CalibrateEDMF.HelperFuncs
+# Import EKP modules
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using JLD2
+
+# Read iteration number of ensemble to be recovered
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--iteration"
+    help = "Calibration iteration number"
+    arg_type = Int
+    "--job_dir"
+    help = "Job output directory"
+    arg_type = String
+    default = "output"
+end
+parsed_args = parse_args(ARGS, s)
+# Recover inputs for update
+iteration = parsed_args["iteration"]
+outdir_path = parsed_args["job_dir"]
+
+include(joinpath(outdir_path, "config.jl"))
+
+versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
+config = get_config()
+ek_update(ekobj, priors, iteration, config, versions, outdir_path)

--- a/driver/julia_parallel/pmap_calibrate.jl
+++ b/driver/julia_parallel/pmap_calibrate.jl
@@ -1,0 +1,61 @@
+#
+# Calibration launch script that parallelizes forward model evaluations using Julia's pmap()
+# function. This parallelization strategy is very efficient for small ensembles (N_ens < 20), since
+# pmap() can only parallelize across processes within a single compute node (as of Julia 1.8.0).
+#
+# For calibration processes involving a larger number of ensemble members, parallelization
+# using HPC resources directly may be advantageous.
+
+# Import modules to all parallel processes
+using Distributed
+@everywhere using Pkg
+@everywhere Pkg.activate(dirname(dirname(dirname(@__DIR__))))
+@everywhere begin
+    using ArgParse
+    using CalibrateEDMF
+    using CalibrateEDMF.DistributionUtils
+    using CalibrateEDMF.Pipeline
+    src_dir = dirname(pathof(CalibrateEDMF))
+    using CalibrateEDMF.HelperFuncs
+    # Import EKP modules
+    using EnsembleKalmanProcesses
+    using EnsembleKalmanProcesses.ParameterDistributions
+end
+using JLD2
+import Dates
+
+# Parse calibration config file
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--config"
+    help = "Inverse problem config file path"
+    arg_type = String
+end
+parsed_args = parse_args(ARGS, s)
+include(parsed_args["config"])
+config = get_config()
+
+# Initialize calibration process
+outdir_path = init_calibration(config; config_path = parsed_args["config"], mode = "pmap")
+priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
+
+# Dispatch SCM eval functions to workers
+@everywhere begin
+    scm_eval_train(version) = versioned_model_eval(version, $outdir_path, "train", $config)
+    scm_eval_validation(version) = versioned_model_eval(version, $outdir_path, "validation", $config)
+end
+
+# Calibration process
+N_iter = config["process"]["N_iter"]
+@info "Running EK updates for $N_iter iterations"
+for iteration in 1:N_iter
+    @time begin
+        @info "   iter = $iteration"
+        versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+        ekp = load(ekobj_path(outdir_path, iteration))["ekp"]
+        pmap(scm_eval_train, versions)
+        pmap(scm_eval_validation, versions)
+        ek_update(ekp, priors, iteration, config, versions, outdir_path)
+    end
+end
+@info "Calibration completed. $(Dates.now())"

--- a/experiments/SCT1_benchmark/global_parallel/create_tc_so.jl
+++ b/experiments/SCT1_benchmark/global_parallel/create_tc_so.jl
@@ -1,28 +1,4 @@
-using Glob
+using CalibrateEDMF
 
-if isempty(Glob.glob("CEDMF.so"))
-
-    using Pkg
-    using PackageCompiler
-    using CalibrateEDMF
-
-    cedmf = pkgdir(CalibrateEDMF)
-    pkgs = [:CalibrateEDMF]
-    append!(pkgs, [Symbol(v.name) for v in values(Pkg.dependencies()) if v.is_direct_dep])
-
-    create_sysimage(
-        pkgs;
-        sysimage_path = "CEDMF.so",
-        # Caltech Central CPU architecture, `native` leads to issues as well.
-        # This one works most of the time, but needs a failsafe mechanism.
-        cpu_target = "skylake-avx512",
-        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
-    )
-
-    # Other cpu_target options
-    #cpu_target = "native", # Default 
-    #cpu_target = PackageCompiler.default_app_cpu_target(),
-    #cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)", # Same as Julia Base
-    #cpu_target = "generic",
-
-end
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "create_tc_so.jl"))

--- a/experiments/SCT1_benchmark/global_parallel/ekp_par_calibration.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/ekp_par_calibration.sbatch
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1         # number of nodes
 #SBATCH -J "sct_call"   # job name
 
-config=${1?Error: no config file given}
+config_rel=${1?Error: no config file given}
+config=$(realpath $config_rel)
 
 # Job identifier
 job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')

--- a/experiments/SCT1_benchmark/global_parallel/init.jl
+++ b/experiments/SCT1_benchmark/global_parallel/init.jl
@@ -1,21 +1,6 @@
 """Initializes a SCM calibration process."""
 
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.Pipeline
 
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--config"
-    help = "Inverse problem config file"
-    arg_type = String
-    "--job_id"
-    help = "Job identifier"
-    arg_type = String
-    default = "12345"
-end
-parsed_args = parse_args(ARGS, s)
-include(parsed_args["config"])
-config = get_config()
-
-init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "init.jl"))

--- a/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT1_benchmark/global_parallel/precondition_prior.jl
@@ -1,45 +1,6 @@
 """Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
 
-using ArgParse
-using Distributions
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.ReferenceModels
-using CalibrateEDMF.ReferenceStats
-using CalibrateEDMF.TurbulenceConvectionUtils
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-version = parsed_args["version"]
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
-config = get_config()
-namelist_args = get_entry(config["scm"], "namelist_args", nothing)
-
-scm_args = load(scm_init_path(outdir_path, version))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
-
-# Preconditioning ensemble methods in unconstrained space
-if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
-    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
-    batch_indices = scm_args["batch_indices"]
-    rm(scm_init_path(outdir_path, version))
-    jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-end
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "precondition_prior.jl"))

--- a/experiments/SCT1_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT1_benchmark/global_parallel/restart.jl
@@ -1,36 +1,6 @@
 """Restarts a calibration process."""
 
-# Import modules to all processes
-using ArgParse
-using Glob
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.Pipeline
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--output_dir"
-    help = "Results output directory"
-    arg_type = String
-    "--job_id"
-    help = "Job identifier"
-    arg_type = String
-    default = "12345"
-end
-parsed_args = parse_args(ARGS, s)
-# Recover inputs for restart
-outdir_path = parsed_args["output_dir"]
-include(joinpath(outdir_path, "config.jl"))
-ekobjs = glob("ekobj_iter_*.jld2", outdir_path)
-iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
-last_iteration = maximum(iters)
-
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, last_iteration))["ekp"]
-config = get_config()
-restart_calibration(ekobj, priors, last_iteration, config, outdir_path, job_id = parsed_args["job_id"])
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "restart.jl"))

--- a/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
+++ b/experiments/SCT1_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1         # number of nodes
 #SBATCH -J "restart_call"   # job name
 
-output_dir=${1?Error: no output directory given}
+output_dir_rel=${1?Error: no output directory given}
+output_dir=$(realpath $output_dir_rel)
 config=${output_dir}/"config.jl"
 
 # Job identifier

--- a/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
+++ b/experiments/SCT1_benchmark/global_parallel/step_ekp.jl
@@ -1,36 +1,6 @@
 """Performs a single step of the EnsembleKalmanProcess."""
 
-# Import modules to all processes
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.Pipeline
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--iteration"
-    help = "Calibration iteration number"
-    arg_type = Int
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-# Recover inputs for update
-iteration = parsed_args["iteration"]
-outdir_path = parsed_args["job_dir"]
-
-include(joinpath(outdir_path, "config.jl"))
-
-versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
-config = get_config()
-ek_update(ekobj, priors, iteration, config, versions, outdir_path)
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "step_ekp.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/create_tc_so.jl
+++ b/experiments/SCT2_benchmark/global_parallel/create_tc_so.jl
@@ -1,28 +1,4 @@
-using Glob
+using CalibrateEDMF
 
-if isempty(Glob.glob("CEDMF.so"))
-
-    using Pkg
-    using PackageCompiler
-    using CalibrateEDMF
-
-    cedmf = pkgdir(CalibrateEDMF)
-    pkgs = [:CalibrateEDMF]
-    append!(pkgs, [Symbol(v.name) for v in values(Pkg.dependencies()) if v.is_direct_dep])
-
-    create_sysimage(
-        pkgs;
-        sysimage_path = "CEDMF.so",
-        # Caltech Central CPU architecture, `native` leads to issues as well.
-        # This one works most of the time, but needs a failsafe mechanism.
-        cpu_target = "skylake-avx512",
-        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
-    )
-
-    # Other cpu_target options
-    #cpu_target = "native", # Default 
-    #cpu_target = PackageCompiler.default_app_cpu_target(),
-    #cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)", # Same as Julia Base
-    #cpu_target = "generic",
-
-end
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "create_tc_so.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/ekp_par_calibration.sbatch
+++ b/experiments/SCT2_benchmark/global_parallel/ekp_par_calibration.sbatch
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1         # number of nodes
 #SBATCH -J "sct_call"   # job name
 
-config=${1?Error: no config file given}
+config_rel=${1?Error: no config file given}
+config=$(realpath $config_rel)
 
 # Job identifier
 job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')

--- a/experiments/SCT2_benchmark/global_parallel/init.jl
+++ b/experiments/SCT2_benchmark/global_parallel/init.jl
@@ -1,21 +1,6 @@
 """Initializes a SCM calibration process."""
 
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.Pipeline
 
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--config"
-    help = "Inverse problem config file"
-    arg_type = String
-    "--job_id"
-    help = "Job identifier"
-    arg_type = String
-    default = "12345"
-end
-parsed_args = parse_args(ARGS, s)
-include(parsed_args["config"])
-config = get_config()
-
-init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "init.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT2_benchmark/global_parallel/precondition_prior.jl
@@ -1,45 +1,6 @@
 """Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
 
-using ArgParse
-using Distributions
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.ReferenceModels
-using CalibrateEDMF.ReferenceStats
-using CalibrateEDMF.TurbulenceConvectionUtils
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-version = parsed_args["version"]
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
-config = get_config()
-namelist_args = get_entry(config["scm"], "namelist_args", nothing)
-
-scm_args = load(scm_init_path(outdir_path, version))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
-
-# Preconditioning ensemble methods in unconstrained space
-if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
-    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
-    batch_indices = scm_args["batch_indices"]
-    rm(scm_init_path(outdir_path, version))
-    jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-end
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "precondition_prior.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT2_benchmark/global_parallel/restart.jl
@@ -1,36 +1,6 @@
 """Restarts a calibration process."""
 
-# Import modules to all processes
-using ArgParse
-using Glob
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.Pipeline
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--output_dir"
-    help = "Results output directory"
-    arg_type = String
-    "--job_id"
-    help = "Job identifier"
-    arg_type = String
-    default = "12345"
-end
-parsed_args = parse_args(ARGS, s)
-# Recover inputs for restart
-outdir_path = parsed_args["output_dir"]
-include(joinpath(outdir_path, "config.jl"))
-ekobjs = glob("ekobj_iter_*.jld2", outdir_path)
-iters = @. parse(Int64, getfield(match(r"(?<=ekobj_iter_)(\d+)", basename(ekobjs)), :match))
-last_iteration = maximum(iters)
-
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, last_iteration))["ekp"]
-config = get_config()
-restart_calibration(ekobj, priors, last_iteration, config, outdir_path, job_id = parsed_args["job_id"])
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "restart.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
+++ b/experiments/SCT2_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1         # number of nodes
 #SBATCH -J "restart_call"   # job name
 
-output_dir=${1?Error: no output directory given}
+output_dir_rel=${1?Error: no output directory given}
+output_dir=$(realpath $output_dir_rel)
 config=${output_dir}/"config.jl"
 
 # Job identifier

--- a/experiments/SCT2_benchmark/global_parallel/step_ekp.jl
+++ b/experiments/SCT2_benchmark/global_parallel/step_ekp.jl
@@ -1,36 +1,6 @@
 """Performs a single step of the EnsembleKalmanProcess."""
 
-# Import modules to all processes
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.Pipeline
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
 
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--iteration"
-    help = "Calibration iteration number"
-    arg_type = Int
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-# Recover inputs for update
-iteration = parsed_args["iteration"]
-outdir_path = parsed_args["job_dir"]
-
-include(joinpath(outdir_path, "config.jl"))
-
-versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
-config = get_config()
-ek_update(ekobj, priors, iteration, config, versions, outdir_path)
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "step_ekp.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/create_tc_so.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/create_tc_so.jl
@@ -1,27 +1,4 @@
-using PackageCompiler
-using Glob
-
-using TurbulenceConvection
 using CalibrateEDMF
-using EnsembleKalmanProcesses
-using OrdinaryDiffEq
-using NCDatasets
-using StochasticDiffEq
-using ClimaCore
 
 cedmf = pkgdir(CalibrateEDMF)
-
-if isempty(Glob.glob("CEDMF.so"))
-    create_sysimage(
-        [
-            "TurbulenceConvection",
-            "EnsembleKalmanProcesses",
-            "OrdinaryDiffEq",
-            "NCDatasets",
-            "StochasticDiffEq",
-            "ClimaCore",
-        ];
-        sysimage_path = "CEDMF.so",
-        precompile_execution_file = joinpath(cedmf, "test", "runtests.jl"),
-    )
-end
+include(joinpath(cedmf, "driver", "create_tc_so.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/ekp_calibration.sbatch
@@ -5,7 +5,8 @@
 #SBATCH --nodes=1         # number of nodes
 #SBATCH -J "ekp_call"   # job name
 
-config=${1?Error: no config file given}
+config_rel=${1?Error: no config file given}
+config=$(realpath $config_rel)
 
 # Job identifier
 job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')

--- a/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/init.jl
@@ -1,21 +1,5 @@
 """Initializes a SCM calibration process."""
 
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.Pipeline
-
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--config"
-    help = "Inverse problem config file"
-    arg_type = String
-    "--job_id"
-    help = "Job identifier"
-    arg_type = String
-    default = "12345"
-end
-parsed_args = parse_args(ARGS, s)
-include(parsed_args["config"])
-config = get_config()
-
-init_calibration(config; job_id = parsed_args["job_id"], config_path = parsed_args["config"])
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "init.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/precondition_prior.jl
@@ -1,46 +1,5 @@
 """Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
 
-using ArgParse
-using Distributions
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.ReferenceModels
-using CalibrateEDMF.ReferenceStats
-using CalibrateEDMF.TurbulenceConvectionUtils
-src_dir = dirname(pathof(CalibrateEDMF))
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
-
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-version = parsed_args["version"]
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
-config = get_config()
-namelist_args = get_entry(config["scm"], "namelist_args", nothing)
-
-scm_args = load(scm_init_path(outdir_path, version))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
-
-# Preconditioning ensemble methods in unconstrained space
-if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
-    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
-    batch_indices = scm_args["batch_indices"]
-    rm(scm_init_path(outdir_path, version))
-    jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)
-end
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "precondition_prior.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/single_scm_eval.jl
@@ -1,32 +1,5 @@
 """Evaluates a set of SCM configurations for a single parameter vector."""
 
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.Pipeline
-src_dir = dirname(pathof(CalibrateEDMF))
-using CalibrateEDMF.HelperFuncs
-using JLD2
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-    "--mode"
-    help = "Forward model evaluation mode: `train` or `validation`"
-    arg_type = String
-    default = "train"
-end
-parsed_args = parse_args(ARGS, s)
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
-
-config = get_config()
-version = parsed_args["version"]
-mode = parsed_args["mode"]
-versioned_model_eval(version, outdir_path, mode, config)
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "single_scm_eval.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/step_ekp.jl
@@ -1,37 +1,5 @@
 """Performs a single step of the EnsembleKalmanProcess."""
 
-# Import modules to all processes
-using ArgParse
 using CalibrateEDMF
-using CalibrateEDMF.DistributionUtils
-using CalibrateEDMF.Pipeline
-src_dir = dirname(pathof(CalibrateEDMF))
-using CalibrateEDMF.HelperFuncs
-# Import EKP modules
-using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.ParameterDistributions
-using JLD2
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--iteration"
-    help = "Calibration iteration number"
-    arg_type = Int
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-end
-parsed_args = parse_args(ARGS, s)
-# Recover inputs for update
-iteration = parsed_args["iteration"]
-outdir_path = parsed_args["job_dir"]
-
-include(joinpath(outdir_path, "config.jl"))
-
-versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
-priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
-ekobj = load(ekobj_path(outdir_path, iteration))["ekp"]
-config = get_config()
-ek_update(ekobj, priors, iteration, config, versions, outdir_path)
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "step_ekp.jl"))

--- a/experiments/scm_pycles_pipeline/hpc_parallel/sysimage.sbatch
+++ b/experiments/scm_pycles_pipeline/hpc_parallel/sysimage.sbatch
@@ -8,3 +8,5 @@
 module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
 
 julia --project create_tc_so.jl
+
+echo "System image creation/check finished."

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -251,9 +251,9 @@ version = "0.10.5"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]
-git-tree-sha1 = "16cfdcff2db5e6e6b365ae3689b8694741f00a43"
+git-tree-sha1 = "5522c338564580adf5d58d91e43a55db0fa5fb39"
 uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
-version = "0.1.9"
+version = "0.1.10"
 
 [[deps.CloudMicrophysics]]
 deps = ["CLIMAParameters", "DocStringExtensions", "SpecialFunctions", "Thermodynamics"]
@@ -1813,9 +1813,9 @@ version = "6.49.1"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "SIMDTypes", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "e2b888f982b5b8ba89fd827ad8fc66dc9a628b68"
+git-tree-sha1 = "367989c5c0c856fdf7e7f6577b384e63104fb854"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-version = "0.3.13"
+version = "0.3.14"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
@@ -1968,9 +1968,9 @@ version = "0.1.2"
 
 [[deps.VectorizationBase]]
 deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "7d3de169cd221392082a5abc7f363726e1a30628"
+git-tree-sha1 = "0453988844dd8ded9d63b3cdfe9e4e26b062c396"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.36"
+version = "0.21.37"
 
 [[deps.VertexSafeGraphs]]
 deps = ["Graphs"]


### PR DESCRIPTION
## Changes

This PR centralizes all Julia driver scripts that do not employ pmap() in the new directory `driver`. Centralization is possible thanks to the use of `realpath` in the bash scripts, to get the real path of the configs. 

This change should make it easier to maintain code. I am still looking into how we can do the same for the scripts that use pmap.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.