### PR TITLE
fix: unify case-specific and global namelist args

### DIFF
--- a/docs/src/API/ReferenceModels.md
+++ b/docs/src/API/ReferenceModels.md
@@ -6,6 +6,7 @@ CurrentModule = CalibrateEDMF.ReferenceModels
 
 ```@docs
 ReferenceModel
+get_ref_model_kwargs
 construct_reference_models
 time_shift_reference_model
 get_z_obs

--- a/driver/hpc_parallel/precondition_prior.jl
+++ b/driver/hpc_parallel/precondition_prior.jl
@@ -30,7 +30,6 @@ version = parsed_args["version"]
 outdir_path = parsed_args["job_dir"]
 include(joinpath(outdir_path, "config.jl"))
 config = get_config()
-namelist_args = get_entry(config["scm"], "namelist_args", nothing)
 
 scm_args = load(scm_init_path(outdir_path, version))
 priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
@@ -38,7 +37,7 @@ ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
 
 # Preconditioning ensemble methods in unconstrained space
 if isa(ekobj.process, Inversion) || isa(ekobj.process, Sampler)
-    model_evaluator = precondition(scm_args["model_evaluator"], priors, namelist_args = namelist_args)
+    model_evaluator = precondition(scm_args["model_evaluator"], priors)
     batch_indices = scm_args["batch_indices"]
     rm(scm_init_path(outdir_path, version))
     jldsave(scm_init_path(outdir_path, version); model_evaluator, version, batch_indices)

--- a/experiments/grid_search/grid_search.jl
+++ b/experiments/grid_search/grid_search.jl
@@ -57,7 +57,7 @@ using ArgParse
         "Simulation output root directory"
         output_root::String
         "Additional namelist arguments"
-        namelist_args::Union{AbstractVector, Nothing}
+        namelist_args::Union{Nothing, Vector{<:Tuple}}
         "Parameter param_map, see [`ParameterMap`](@ref) for details"
         param_map::ParameterMap
     end
@@ -98,7 +98,7 @@ using ArgParse
         case::S,
         case_id::Integer,
         output_root::S,
-        namelist_args::Union{AbstractVector, Nothing},
+        namelist_args::Union{Nothing, Vector{<:Tuple}},
         param_map::ParameterMap,
     ) where {S <: AbstractString}
         # Create path to store forward model output
@@ -161,6 +161,7 @@ function grid_search(config::Dict, config_path::String, out_dir::String)
         case_id = length(cases[1:i][(cases .== case)[1:i]])
         push!(case_name_id, (case, case_id))
     end
+    # TODO: Fix case-specific handling of `namelist_args`
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
     param_map = get_entry(get(config, "prior", Dict()), "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
 

--- a/experiments/grid_search/loss_map.jl
+++ b/experiments/grid_search/loss_map.jl
@@ -9,7 +9,7 @@ using Distributed
     using CalibrateEDMF.LESUtils
     using CalibrateEDMF.ReferenceModels
     import CalibrateEDMF.ModelTypes: LES
-    import CalibrateEDMF.Pipeline: get_ref_model_kwargs, get_ref_stats_kwargs
+    import CalibrateEDMF.Pipeline: get_ref_stats_kwargs
     import LinearAlgebra: dot
     import Statistics: mean
     import JSON
@@ -131,7 +131,8 @@ function compute_loss_map(config::Dict, sim_dir::AbstractString)
     sim_type = get_entry(config["grid_search"], "sim_type", "reference")
     @assert sim_type in ("reference", "validation")
     ref_config = config[sim_type]  # or validation
-    kwargs_ref_model = get_ref_model_kwargs(ref_config)
+    namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+    kwargs_ref_model = get_ref_model_kwargs(ref_config; global_namelist_args = namelist_args)
     reg_config = config["regularization"]
     kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
 

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -11,9 +11,9 @@ version = "0.4.0"
 
 [[deps.AbstractFFTs]]
 deps = ["ChainRulesCore", "LinearAlgebra"]
-git-tree-sha1 = "6f1d9bc1c08f9f4a8fa92e3ea3cb50153a1b40d4"
+git-tree-sha1 = "8e9c3482c61d06343a6199814bf84f7df82f2b28"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.1.0"
+version = "1.2.0"
 
 [[deps.AbstractTrees]]
 git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
@@ -55,15 +55,15 @@ version = "6.0.17"
 
 [[deps.ArrayInterfaceCore]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "5e732808bcf7bbf730e810a9eaafc52705b38bb5"
+git-tree-sha1 = "7d255eb1d2e409335835dc8624c35d97453011eb"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.13"
+version = "0.1.14"
 
 [[deps.ArrayInterfaceGPUArrays]]
 deps = ["Adapt", "ArrayInterfaceCore", "GPUArraysCore", "LinearAlgebra"]
-git-tree-sha1 = "02ec61006f49c43607a34cbd036b3d68485d38aa"
+git-tree-sha1 = "febba7add2873aecc0b6620b55969e73ec875bce"
 uuid = "6ba088a2-8465-4c0a-af30-387133b534db"
-version = "0.2.0"
+version = "0.2.1"
 
 [[deps.ArrayInterfaceOffsetArrays]]
 deps = ["ArrayInterface", "OffsetArrays", "Static"]
@@ -221,15 +221,15 @@ version = "0.3.10"
 
 [[deps.ChainRules]]
 deps = ["ChainRulesCore", "Compat", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics"]
-git-tree-sha1 = "238f4cb4d7d58ad876d51bae45922b3fb7db29ad"
+git-tree-sha1 = "b06ed86d99c982cbe9047a45a93ac62d9605a361"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.36.1"
+version = "1.36.2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "9489214b993cd42d17f44c36e359bf6a7c919abf"
+git-tree-sha1 = "2dd813e5f2f7eec2d1268c57cf2373d3ee91fcea"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.0"
+version = "1.15.1"
 
 [[deps.ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
@@ -250,10 +250,10 @@ uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 version = "0.3.0"
 
 [[deps.ClimaCore]]
-deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
-git-tree-sha1 = "473da6d707d2f4efa92dc073ccbb170aa3750c9a"
+deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
+git-tree-sha1 = "e73007e7dabe872d90819d7e0a0e78eedbeb2e53"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.5"
+version = "0.10.6"
 
 [[deps.CloseOpenIntervals]]
 deps = ["ArrayInterface", "Static"]
@@ -413,12 +413,6 @@ git-tree-sha1 = "777660556c250ef2e25b346d055bf2f89b7962da"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 version = "6.89.0"
 
-[[deps.DiffEqJump]]
-deps = ["ArrayInterfaceCore", "DataStructures", "DiffEqBase", "DocStringExtensions", "FunctionWrappers", "Graphs", "LinearAlgebra", "Markdown", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "StaticArrays", "TreeViews", "UnPack"]
-git-tree-sha1 = "760a048fc34902bfd1b1e4ac4b67162da1f74972"
-uuid = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
-version = "8.6.2"
-
 [[deps.DiffEqNoiseProcess]]
 deps = ["DiffEqBase", "Distributions", "GPUArraysCore", "LinearAlgebra", "Markdown", "Optim", "PoissonRandom", "QuadGK", "Random", "Random123", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArrays", "Statistics"]
 git-tree-sha1 = "6f3fe6ebe1b6e6e3a9b72739ada313aa17c9bb66"
@@ -449,9 +443,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "0597dffe1268516192ff4ddebdb4d8937254512d"
+git-tree-sha1 = "d530092b57aef8b96b27694e51c575b09c7f0b2e"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.63"
+version = "0.25.64"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -699,6 +693,11 @@ git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
 uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
 version = "0.21.0+0"
 
+[[deps.GilbertCurves]]
+git-tree-sha1 = "3e076ca96e34a47e98a46657b2bec2655a366d80"
+uuid = "88fa7841-ef32-4516-bb70-c6ec135699d9"
+version = "0.1.0"
+
 [[deps.Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
 git-tree-sha1 = "a32d672ac2c967f3deb8a81d828afc739c838a06"
@@ -830,10 +829,10 @@ uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 version = "0.13.6"
 
 [[deps.IntervalSets]]
-deps = ["Dates", "Statistics"]
-git-tree-sha1 = "ad841eddfb05f6d9be0bff1fa48dcae32f134a2d"
+deps = ["Dates", "Random", "Statistics"]
+git-tree-sha1 = "57af5939800bce15980bddd2426912c4f83012d8"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.6.2"
+version = "0.7.1"
 
 [[deps.InverseFunctions]]
 deps = ["Test"]
@@ -897,6 +896,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "b53380851c6e6664204efb2e62cd24fa5c47e4ba"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
 version = "2.1.2+0"
+
+[[deps.JumpProcesses]]
+deps = ["ArrayInterfaceCore", "DataStructures", "DiffEqBase", "DocStringExtensions", "FunctionWrappers", "Graphs", "LinearAlgebra", "Markdown", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SciMLBase", "StaticArrays", "TreeViews", "UnPack"]
+git-tree-sha1 = "4aa139750616fee7216ddcb30652357c60c3683e"
+uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
+version = "9.0.1"
 
 [[deps.KLU]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
@@ -1086,9 +1091,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterfaceCore", "DocStringExtensions", "GPUArraysCore", "IterativeSolvers", "KLU", "Krylov", "KrylovKit", "LinearAlgebra", "RecursiveFactorization", "Reexport", "SciMLBase", "Setfield", "SparseArrays", "SuiteSparse", "UnPack"]
-git-tree-sha1 = "b3e7461184bd748e5dee98f9b11766be39634fae"
+git-tree-sha1 = "c08c4177cc7edbf42a92f08a04bf848dde73f0b9"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "1.19.0"
+version = "1.20.0"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
@@ -1167,10 +1172,10 @@ uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 version = "0.4.2"
 
 [[deps.MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "Random", "Sockets"]
+git-tree-sha1 = "891d3b4e8f8415f53108b4918d0183e61e18015b"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.0"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -1279,9 +1284,9 @@ version = "0.5.1"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "ec2e30596282d722f018ae784b7f44f3b88065e4"
+git-tree-sha1 = "1ea784113a6aa054c5ebd95945fa5e52c2f378e7"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.6"
+version = "1.12.7"
 
 [[deps.Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1688,9 +1693,9 @@ version = "0.3.2"
 
 [[deps.SciMLBase]]
 deps = ["ArrayInterfaceCore", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "RecipesBase", "RecursiveArrayTools", "StaticArraysCore", "Statistics", "Tables", "TreeViews"]
-git-tree-sha1 = "6a3f7d9b084b508e87d12135de950ac969187954"
+git-tree-sha1 = "3243a883fa422a0a5cfe2d3b6ea6287fc396018f"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "1.42.0"
+version = "1.42.2"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1811,16 +1816,16 @@ uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "1.0.1"
 
 [[deps.StochasticDiffEq]]
-deps = ["Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqJump", "DiffEqNoiseProcess", "DocStringExtensions", "FillArrays", "FiniteDiff", "ForwardDiff", "LevyArea", "LinearAlgebra", "Logging", "MuladdMacro", "NLsolve", "OrdinaryDiffEq", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SciMLBase", "SparseArrays", "SparseDiffTools", "StaticArrays", "UnPack"]
-git-tree-sha1 = "fea4cc29ff7d392ceb29bb64a717e6ed128bb5ff"
+deps = ["Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqNoiseProcess", "DocStringExtensions", "FillArrays", "FiniteDiff", "ForwardDiff", "JumpProcesses", "LevyArea", "LinearAlgebra", "Logging", "MuladdMacro", "NLsolve", "OrdinaryDiffEq", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SciMLBase", "SparseArrays", "SparseDiffTools", "StaticArrays", "UnPack"]
+git-tree-sha1 = "fbefdd80ccbabf9d7c402dbaf845afde5f4cf33d"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "6.49.1"
+version = "6.50.0"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "SIMDTypes", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "367989c5c0c856fdf7e7f6577b384e63104fb854"
+git-tree-sha1 = "ac730bd978bf35f9fe45daa0bd1f51e493e97eb4"
 uuid = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-version = "0.3.14"
+version = "0.3.15"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
@@ -1938,10 +1943,10 @@ uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 version = "0.3.4"
 
 [[deps.TurbulenceConvection]]
-deps = ["CLIMAParameters", "ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "StaticArrays", "StatsBase", "StochasticDiffEq", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "2ee4416855090a0da1a77b87dd5fb89f620ef002"
+deps = ["CLIMAParameters", "ClimaCore", "CloudMicrophysics", "Dierckx", "DiffEqBase", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "KernelAbstractions", "LambertW", "LinearAlgebra", "OperatorFlux", "RootSolvers", "StaticArrays", "StatsBase", "StochasticDiffEq", "Thermodynamics", "UnPack"]
+git-tree-sha1 = "fdecd0736b275194c0ab1ffa836210e5812b3736"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "0.27.5"
+version = "0.27.6"
 
 [[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
@@ -2156,10 +2161,10 @@ uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.2+0"
 
 [[deps.Zygote]]
-deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "MacroTools", "NaNMath", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "a49267a2e5f113c7afe93843deea7461c0f6b206"
+deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
+git-tree-sha1 = "3cfdb31b517eec4173584fba2b1aa65daad46e09"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.40"
+version = "0.6.41"
 
 [[deps.ZygoteRules]]
 deps = ["MacroTools"]

--- a/src/NetCDFIO.jl
+++ b/src/NetCDFIO.jl
@@ -244,6 +244,7 @@ function write_current(diags::NetCDFIO_Diags, var_name::String, data; group)
             "Failed to write array of dimension $(size(data)) as $var_name",
             " to NetCDF file. Expected array of dimension $(size(var)[1:end-1]).",
         )
+        # TODO: throw(e)
         e
     end
 end

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -8,7 +8,6 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
 using CalibrateEDMF.Pipeline
-using CalibrateEDMF.Pipeline: get_ref_model_kwargs
 using CalibrateEDMF.HelperFuncs
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
@@ -29,9 +28,8 @@ ref_model = ReferenceModel(
     y_dir,
     ref_config["case_name"][1],
     ref_config["t_start"][1],
-    ref_config["t_end"][1],
+    ref_config["t_end"][1];
 )
-namelist_args = config["scm"]["namelist_args"]
 # Generate "true" data
 output_root = dirname(y_dir)
 uuid = last(split(y_dir, "."))
@@ -113,8 +111,8 @@ end
     batch_indices = scm_args["batch_indices"]
     priors = deserialize_prior(load(joinpath(outdir_path, "prior.jld2")))
     model_evaluator = scm_args["model_evaluator"]
-    model_evaluator = precondition(model_evaluator, priors, namelist_args = namelist_args)
-    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator, namelist_args = namelist_args)
+    model_evaluator = precondition(model_evaluator, priors)
+    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator)
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
@@ -173,7 +171,7 @@ end
     scm_args = load(scm_init_path(outdir_path, versions[1]))
     batch_indices = scm_args["batch_indices"]
     model_evaluator = scm_args["model_evaluator"]
-    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator, namelist_args = namelist_args)
+    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator)
     for version in versions
         g_scm = g_scm_orig .* (1.0 + rand())
         g_scm_pca = g_scm_pca_orig .* (1.0 + rand())

--- a/tools/TCRunner.jl
+++ b/tools/TCRunner.jl
@@ -35,6 +35,7 @@ function run_TC_optimal(
     metric::String = "mse_full",
     n_ens::Int = 1,
 )
+    # TODO: Fix case-specific `namelist_args` for TCRunner
     namelist_args = get_entry(config["scm"], "namelist_args", nothing)
     param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
 


### PR DESCRIPTION
## Changes
Fix specification of both case-specific `namelist_args` and global (i.e. from `config["scm"]`) `namelist_args`.

Case-specific args has precedence over global args, which has precedence over default TC.jl args.

## Issue number (if applicable)
Generalizes a similar issue that was addressed in PR #394.
Closes #393.

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.