### PR TITLE
Allow relative Tikhonov for non_PCA reference_stats

### DIFF
--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -138,9 +138,8 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real, IT <: Integer}
         Γ = cat(Γ_vec..., dims = (1, 2))
         # Condition global covariance matrix, PCA
         if tikhonov_mode == "relative"
-            @assert perform_PCA "Relative Tikhonov mode only available after PCA change of basis."
             tikhonov_noise = max(tikhonov_noise, 10 * sqrt(eps(FT)))
-            Γ = Γ + tikhonov_noise * maximum(diag(Γ)) * I
+            Γ = Γ + tikhonov_noise * eigmax(Γ) * I
         else
             Γ = Γ + tikhonov_noise * I
         end

--- a/test/ReferenceStats/runtests.jl
+++ b/test/ReferenceStats/runtests.jl
@@ -68,10 +68,10 @@ using CalibrateEDMF.DistributionUtils
     @test length(y) == 1
 
     # Test only tikhonov vs PCA and tikhonov
-    pca_list = [false, true]
-    norm_list = [false, true]
-    mode_list = ["absolute", "relative"]
-    dim_list = [false, true]
+    pca_list = [false, true, false]
+    norm_list = [false, true, true]
+    mode_list = ["absolute", "relative", "relative"]
+    dim_list = [false, true, true]
     for (perform_PCA, norm, tikhonov_mode, dim_scaling) in zip(pca_list, norm_list, mode_list, dim_list)
         ref_stats = ReferenceStatistics(
             ref_models;
@@ -114,16 +114,6 @@ using CalibrateEDMF.DistributionUtils
             end
         end
     end
-
-    # Verify that incorrect definitions throw error
-    @test_throws AssertionError ReferenceStatistics(
-        ref_models;
-        perform_PCA = false,
-        normalize = false,
-        tikhonov_mode = "relative",
-        y_type = SCM(),
-        Σ_type = SCM(),
-    )
 
     l2_reg = Dict("foo" => [0.1], "bar" => [0.3, 0.0, 0.4])
     reg_indices = flat_dict_keys_where(l2_reg, above_eps)


### PR DESCRIPTION
## Changes

This PR allows using the relative covariance Tikhonov regularization, by using eigmax(), instead of the maximum of the covariance matrix.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.