### PR TITLE
Unify driver code for parallel_scm_eval

### DIFF
--- a/driver/global_parallel/parallel_scm_eval.jl
+++ b/driver/global_parallel/parallel_scm_eval.jl
@@ -1,17 +1,5 @@
 """Evaluates a set of SCM configurations for a single parameter vector."""
 
-@everywhere using Pkg
-@everywhere Pkg.activate("../../..")
-@everywhere using ArgParse
-@everywhere using CalibrateEDMF
-@everywhere using CalibrateEDMF.Pipeline
-@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
-
-@everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere using CalibrateEDMF.HelperFuncs
-@everywhere include(joinpath(src_dir, "parallel.jl"))
-using JLD2
-
 # Read iteration number of ensemble to be recovered
 s = ArgParseSettings()
 @add_arg_table s begin

--- a/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT1_benchmark/global_parallel/parallel_scm_eval.jl
@@ -1,37 +1,19 @@
 """Evaluates a set of SCM configurations for a single parameter vector."""
 
-@everywhere using Pkg
-@everywhere Pkg.activate("../../..")
-@everywhere using ArgParse
-@everywhere using CalibrateEDMF
-@everywhere using CalibrateEDMF.Pipeline
-@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
-
-@everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere using CalibrateEDMF.HelperFuncs
-@everywhere include(joinpath(src_dir, "parallel.jl"))
-using JLD2
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-    "--mode"
-    help = "Forward model evaluation mode: `train` or `validation`"
-    arg_type = String
-    default = "train"
+@everywhere begin
+    using Pkg
+    Pkg.activate("../../..") # @__DIR__
 end
-parsed_args = parse_args(ARGS, s)
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
 
-config = get_config()
-version = parsed_args["version"]
-mode = parsed_args["mode"]
-versioned_model_eval_parallel(version, outdir_path, mode, config)
+@everywhere begin
+    using ArgParse
+    using JLD2
+    using CalibrateEDMF
+    using CalibrateEDMF.Pipeline
+
+    src_dir = dirname(pathof(CalibrateEDMF))
+    cedmf = pkgdir(CalibrateEDMF)
+    include(joinpath(src_dir, "parallel.jl"))
+end
+
+include(joinpath(cedmf, "driver", "global_parallel", "parallel_scm_eval.jl"))

--- a/experiments/SCT2_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT2_benchmark/global_parallel/parallel_scm_eval.jl
@@ -1,37 +1,19 @@
 """Evaluates a set of SCM configurations for a single parameter vector."""
 
-@everywhere using Pkg
-@everywhere Pkg.activate("../../..")
-@everywhere using ArgParse
-@everywhere using CalibrateEDMF
-@everywhere using CalibrateEDMF.Pipeline
-@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
-
-@everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere using CalibrateEDMF.HelperFuncs
-@everywhere include(joinpath(src_dir, "parallel.jl"))
-using JLD2
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-    "--mode"
-    help = "Forward model evaluation mode: `train` or `validation`"
-    arg_type = String
-    default = "train"
+@everywhere begin
+    using Pkg
+    Pkg.activate("../../..") # @__DIR__
 end
-parsed_args = parse_args(ARGS, s)
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
 
-config = get_config()
-version = parsed_args["version"]
-mode = parsed_args["mode"]
-versioned_model_eval_parallel(version, outdir_path, mode, config)
+@everywhere begin
+    using ArgParse
+    using JLD2
+    using CalibrateEDMF
+    using CalibrateEDMF.Pipeline
+
+    src_dir = dirname(pathof(CalibrateEDMF))
+    cedmf = pkgdir(CalibrateEDMF)
+    include(joinpath(src_dir, "parallel.jl"))
+end
+
+include(joinpath(cedmf, "driver", "global_parallel", "parallel_scm_eval.jl"))

--- a/experiments/les_strats/global_parallel/parallel_scm_eval.jl
+++ b/experiments/les_strats/global_parallel/parallel_scm_eval.jl
@@ -1,37 +1,19 @@
 """Evaluates a set of SCM configurations for a single parameter vector."""
 
-@everywhere using Pkg
-@everywhere Pkg.activate("../../..")
-@everywhere using ArgParse
-@everywhere using CalibrateEDMF
-@everywhere using CalibrateEDMF.Pipeline
-@everywhere using CalibrateEDMF.TurbulenceConvectionUtils
-
-@everywhere src_dir = dirname(pathof(CalibrateEDMF))
-@everywhere using CalibrateEDMF.HelperFuncs
-@everywhere include(joinpath(src_dir, "parallel.jl"))
-using JLD2
-
-# Read iteration number of ensemble to be recovered
-s = ArgParseSettings()
-@add_arg_table s begin
-    "--version"
-    help = "Calibration process number"
-    arg_type = String
-    "--job_dir"
-    help = "Job output directory"
-    arg_type = String
-    default = "output"
-    "--mode"
-    help = "Forward model evaluation mode: `train` or `validation`"
-    arg_type = String
-    default = "train"
+@everywhere begin
+    using Pkg
+    Pkg.activate("../../..") # @__DIR__
 end
-parsed_args = parse_args(ARGS, s)
-outdir_path = parsed_args["job_dir"]
-include(joinpath(outdir_path, "config.jl"))
 
-config = get_config()
-version = parsed_args["version"]
-mode = parsed_args["mode"]
-versioned_model_eval_parallel(version, outdir_path, mode, config)
+@everywhere begin
+    using ArgParse
+    using JLD2
+    using CalibrateEDMF
+    using CalibrateEDMF.Pipeline
+
+    src_dir = dirname(pathof(CalibrateEDMF))
+    cedmf = pkgdir(CalibrateEDMF)
+    include(joinpath(src_dir, "parallel.jl"))
+end
+
+include(joinpath(cedmf, "driver", "global_parallel", "parallel_scm_eval.jl"))


### PR DESCRIPTION
## Changes

This PR further unifies code shared among different experiments. In this case, we unify most of the driver code for the `parallel_scm_eval.jl` call from any global_parallel driver of an experiment.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.