### PR TITLE
fix `namelist_args` specification for `TCRunner` and `grid_search`

### DIFF
--- a/docs/src/API/HelperFuncs.md
+++ b/docs/src/API/HelperFuncs.md
@@ -26,4 +26,6 @@ jld2_path
 write_versions
 get_entry
 change_entry!
+update_namelist!
+merge_namelist_args
 ```

--- a/experiments/grid_search/grid_search.jl
+++ b/experiments/grid_search/grid_search.jl
@@ -115,6 +115,8 @@ using ArgParse
 
         # Get namelist for case
         namelist = NameList.default_namelist(case, write = false, set_seed = false)
+        # Set optional namelist args
+        update_namelist!(namelist, namelist_args)
 
         params = get_parameter_pairs(namelist, param1, param2, value1, value2)
 
@@ -126,7 +128,6 @@ using ArgParse
             u_names = collect(String, keys(params)),
             param_map = param_map,
             namelist = namelist,
-            namelist_args = namelist_args,
             uuid = "$ens_i",
             les = get(namelist["meta"], "lesfile", nothing),
         )
@@ -153,16 +154,19 @@ function grid_search(config::Dict, config_path::String, out_dir::String)
     # get config entries
     parameters = config["grid_search"]["parameters"]
     n_ens = config["grid_search"]["ensemble_size"]
+    cases = config[sim_type]["case_name"]
+
+    # get namelist_args
+    global_namelist_args = get_entry(config["scm"], "namelist_args", nothing)
+    case_namelist_args = expand_dict_entry(config[sim_type], "namelist_args", length(cases))
+    namelist_args_vec = merge_namelist_args.(Ref(global_namelist_args), case_namelist_args)
 
     # Get cases and count repeat instances of same case names
-    cases = config[sim_type]["case_name"]
-    case_name_id = Tuple[]
+    case_config = Tuple[]
     for (i, case) in enumerate(cases)
         case_id = length(cases[1:i][(cases .== case)[1:i]])
-        push!(case_name_id, (case, case_id))
+        push!(case_config, (case, case_id, namelist_args_vec[i]))
     end
-    # TODO: Fix case-specific handling of `namelist_args`
-    namelist_args = get_entry(config["scm"], "namelist_args", nothing)
     param_map = get_entry(get(config, "prior", Dict()), "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
 
     # Construct simulation configs
@@ -170,7 +174,7 @@ function grid_search(config::Dict, config_path::String, out_dir::String)
     param_pairs = combinations(param_names, 2)
     sim_configs = SimConfig[]
     for (param1, param2) in param_pairs
-        for (case, case_id) in case_name_id
+        for (case, case_id, namelist_args) in case_config
             config_product = Iterators.product(parameters[param1], parameters[param2], 1:n_ens)
             append!(
                 sim_configs,

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -337,9 +337,9 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c096d0e321368ac23eb1be1ea405814f8b32adb3"
+git-tree-sha1 = "59d00b3139a9de4eb961057eabb65ac6522be954"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-version = "1.3.1"
+version = "1.4.0"
 
 [[deps.Contour]]
 deps = ["StaticArrays"]
@@ -729,9 +729,9 @@ version = "1.7.1"
 
 [[deps.GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
-git-tree-sha1 = "d778af2dcb083169807d43aa9d15f9f7e3909d4c"
+git-tree-sha1 = "d62c4b3e4bf5b68c679c8552e987ec3e72b00280"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
-version = "0.7.7"
+version = "0.7.8"
 
 [[deps.Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
@@ -1380,10 +1380,10 @@ uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 version = "0.3.16"
 
 [[deps.PackageCompiler]]
-deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "UUIDs"]
-git-tree-sha1 = "b2a8aef45444677037af79f060f5cb2ed48a72c4"
+deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs"]
+git-tree-sha1 = "52ab501c2201e140954924365ef06a36ba1d97ed"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.0.6"
+version = "2.0.7"
 
 [[deps.Packing]]
 deps = ["GeometryBasics"]
@@ -1766,9 +1766,9 @@ version = "1.24.0"
 
 [[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "a9e798cae4867e3a41cae2dd9eb60c047f1212db"
+git-tree-sha1 = "d75bda01f8c31ebb72df80a46c88b25d1c79c56d"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.6"
+version = "2.1.7"
 
 [[deps.StackViews]]
 deps = ["OffsetArrays"]
@@ -1978,9 +1978,9 @@ version = "0.1.2"
 
 [[deps.VectorizationBase]]
 deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "9d87c8c1d27dc20ba8be6bdca85d36556c371172"
+git-tree-sha1 = "39e55018bccc5a858217db32aa3d9e7decbefd0c"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.38"
+version = "0.21.40"
 
 [[deps.VertexSafeGraphs]]
 deps = ["Graphs"]

--- a/integration_tests/grid_search_integration_test_config.jl
+++ b/integration_tests/grid_search_integration_test_config.jl
@@ -64,13 +64,16 @@ function get_reference_config(::GridSearchCases)
     # config["Σ_dir"] = [...]
     config["t_start"] = repeat([100.0], n_cases)
     config["t_end"] = repeat([200.0], n_cases)
+
+    # for purely testing purposes of case-specific & global `namelist_args` merging. 
+    # See also `test/HelperFuncs/runtests.jl > @testset "namelist utilities"`.
+    config["namelist_args"] = [[("time_stepping", "t_max", 199.0)], nothing, [("time_stepping", "t_max", 201.0)]]
     return config
 end
 
 function get_scm_config()
     config = Dict()
     # List of tuples like [("time_stepping", "dt_min", 1.0)], or nothing
-    config["namelist_args"] = nothing
     config["namelist_args"] = [
         ("time_stepping", "t_max", 200.0),
         ("turbulence", "EDMF_PrognosticTKE", "entrainment", "moisture_deficit"),

--- a/integration_tests/grid_search_test.jl
+++ b/integration_tests/grid_search_test.jl
@@ -10,6 +10,7 @@ using Distributed
     include(joinpath(gs, "quick_plots.jl"))
 end
 using Test
+import JSON
 
 config_path = joinpath(@__DIR__, "grid_search_integration_test_config.jl")
 include(config_path)
@@ -38,3 +39,18 @@ config["reference"]["y_dir"] = y_dirs
 end
 
 quick_plots(joinpath(out_dir, "loss.nc"), out_dir)
+
+# Additional testing:
+namelist_files = joinpath.(y_dirs, ["namelist_TRMM_LBA.in", "namelist_Rico.in", "namelist_TRMM_LBA.in"])
+nl1 = open(namelist_files[1], "r") do io
+    JSON.parse(io; dicttype = Dict, inttype = Int64)
+end
+@test nl1["time_stepping"]["t_max"] == 199.0
+nl2 = open(namelist_files[2], "r") do io
+    JSON.parse(io; dicttype = Dict, inttype = Int64)
+end
+@test nl2["time_stepping"]["t_max"] == 200.0
+nl3 = open(namelist_files[3], "r") do io
+    JSON.parse(io; dicttype = Dict, inttype = Int64)
+end
+@test nl3["time_stepping"]["t_max"] == 201.0

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -29,6 +29,8 @@ export vertical_interpolation,
     expand_dict_entry,
     get_entry,
     change_entry!,
+    update_namelist!,
+    merge_namelist_args,
     ParameterMap,
     do_nothing_param_map,
     expand_params,
@@ -204,6 +206,38 @@ end
 """ Get the namelist value for some parameter name"""
 get_namelist_value(namelist::Dict, param_name::AbstractString) =
     namelist_subdict_by_key(namelist, param_name)[param_name]
+
+"""
+    update_namelist!(namelist, namelist_args)
+
+Update `namelist` with arguments given by `namelist_args`.
+
+`namelist_args` is a `Vector` of `Tuple`s, where each `Tuple` specifies the keys to traverse the `namelist`, and the
+last element of the `Tuple` is the value to be set.
+"""
+function update_namelist!(namelist::Dict, namelist_args::Vector{<:Tuple})
+    for namelist_arg in namelist_args
+        change_entry!(namelist, namelist_arg)
+    end
+end
+update_namelist!(::Dict, ::Nothing) = nothing
+
+"""
+    merge_namelist_args(args, overwrite_args)
+
+Combine two lists of namelist arguments by joining the lists, in order.
+
+This method is intended to be used in the context of case-specific- and global namelist_args.
+In that case, `args = global_args` and `overwrite_args = case_args`.
+
+Either argument can be `nothing`, in which case the other argument is returned; if both are `nothing`, return `nothing`.
+
+See also [`update_namelist!`](@ref).
+"""
+merge_namelist_args(args::Vector{<:Tuple}, overwrite_args::Vector{<:Tuple}) = [args..., overwrite_args...]
+merge_namelist_args(args::Vector{<:Tuple}, ::Nothing) = args
+merge_namelist_args(::Nothing, overwrite_args::Vector{<:Tuple}) = overwrite_args
+merge_namelist_args(::Nothing, ::Nothing) = nothing
 
 """
     vertical_interpolation(

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -163,14 +163,9 @@ function get_scm_namelist(
         NameList.default_namelist(case_name; write = false, set_seed = true, seed = seed)
     end
 
-
     namelist["stats_io"]["calibrate_io"] = true
 
-    if !isnothing(namelist_args)
-        for namelist_arg in namelist_args
-            change_entry!(namelist, namelist_arg)
-        end
-    end
+    update_namelist!(namelist, namelist_args)
 
     # if `LES_driven_SCM` case, provide input LES stats file
     if case_name == "LES_driven_SCM"
@@ -214,14 +209,7 @@ function get_ref_model_kwargs(ref_config::Dict; global_namelist_args::Union{Noth
     # Construct namelist_args from case-specific args merged with global args
     # Note: Case-specific args takes precedence over global args
     case_namelist_args = expand_dict_entry(ref_config, "namelist_args", n_cases)
-    global_args = isnothing(global_namelist_args) ? [] : global_namelist_args
-    namelist_args = [
-        begin
-            case_arg = isnothing(case_arg) ? [] : case_arg
-            merged_args = [global_args..., case_arg...]
-            isempty(merged_args) ? nothing : merged_args
-        end for case_arg in case_namelist_args
-    ]
+    namelist_args = merge_namelist_args.(Ref(global_namelist_args), case_namelist_args)
 
     rm_kwargs = Dict(
         :y_names => ref_config["y_names"],

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -310,8 +310,7 @@ end
         u::Vector{FT},
         u_names::Vector{String},
         param_map::ParameterMap,
-        namelist::Union{Dict, Nothing} = nothing,
-        namelist_args::Union{Nothing, Vector{<:Tuple}} = nothing,
+        namelist::Dict,
         uuid::String = "01",
         les::Union{NamedTuple, String} = nothing,
     )
@@ -327,7 +326,6 @@ Inputs:
  - `param_map`   :: A mapping operator to define relations between parameters.
                     See [`ParameterMap`](@ref) for details.
  - namelist      :: namelist to use for simulation.
- - namelist_args :: Additional arguments passed to the TurbulenceConvection namelist.
  - uuid          :: uuid of SCM run
  - les           :: path to LES stats file, or NamedTuple with keywords {forcing_model, month, experiment, cfsite_number} needed to specify path. 
  Outputs:
@@ -340,29 +338,17 @@ function run_SCM_handler(
     u::Vector{FT},
     u_names::Vector{String},
     param_map::ParameterMap,
-    namelist::Union{Dict, Nothing} = nothing,
-    namelist_args::Union{Nothing, Vector{<:Tuple}} = nothing,
+    namelist::Dict,
     uuid::String = "01",
     les::Union{NamedTuple, String, Nothing} = nothing,
 ) where {FT <: AbstractFloat}
     model_error = false
-
-    # fetch default namelist if not provided
-    if isnothing(namelist)
-        namelist = NameList.default_namelist(case_name)
-    end
 
     namelist["meta"]["uuid"] = uuid
     # set output dir to `out_dir`
     namelist["output"]["output_root"] = out_dir
 
     u_names, u = create_parameter_vectors(u_names, u, param_map, namelist)
-    # Set optional namelist args
-    if !isnothing(namelist_args)
-        for namelist_arg in namelist_args
-            change_entry!(namelist, namelist_arg)
-        end
-    end
 
     # update learnable parameter values
     @assert length(u_names) == length(u)

--- a/test/TurbulenceConvectionUtils/runtests.jl
+++ b/test/TurbulenceConvectionUtils/runtests.jl
@@ -13,7 +13,7 @@ using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
 import CalibrateEDMF.TurbulenceConvectionUtils: create_parameter_vectors
-import CalibrateEDMF.HelperFuncs: do_nothing_param_map, change_entry!
+import CalibrateEDMF.HelperFuncs: do_nothing_param_map, change_entry!, update_namelist!
 
 @testset "TurbulenceConvectionUtils" begin
     @testset "test create_parameter_vectors" begin
@@ -155,9 +155,7 @@ import CalibrateEDMF.HelperFuncs: do_nothing_param_map, change_entry!
             ("turbulence", "EDMF_PrognosticTKE", "general_stochastic_ent_params", SA.SVector(0.2, 0.2, 0.01, 0.02)),
         ]
         # Set optional namelist args
-        for namelist_arg in namelist_args
-            change_entry!(ref_model1.namelist, namelist_arg)
-        end
+        update_namelist!(ref_model1.namelist, namelist_args)
 
         res_dir, model_error = run_SCM_handler(ref_model1, data_dir, u, u_names, param_map)
 


### PR DESCRIPTION
## Changes
Extend #400 by fixing `namelist_args` specification for `TCRunner` and `grid_search` setups.

Add method to update a `namelist` given set of `namelist_args`. With this, `namelist_args` is no longer a keyword argument to `run_SCM_handler`. Instead, any modifications to the `namelist` should be made prior to calling that function. Furthermore, since modifications to the `namelist` is disallowed, it made more sense to make the `namelist` a mandatory method argument, rather than an optional one.

In a future PR, we could optionally also remove `case_name` from the argument list of `run_SCM_handler` since that information is already contained in the `namelist` itself, but that isn't really too important.

## Issue number (if applicable)
Closes #407.

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.