### PR TITLE
Add `model_error` option to ReferenceStats constructor

### DIFF
--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -1,0 +1,8 @@
+module AbstractTypes
+
+export OptVec
+
+# abstract types
+const OptVec{T} = Union{Nothing, Vector{T}}
+
+end # module

--- a/src/CalibrateEDMF.jl
+++ b/src/CalibrateEDMF.jl
@@ -1,6 +1,7 @@
 module CalibrateEDMF
 
 # Submodules
+include("AbstractTypes.jl")
 include("HelperFuncs.jl")
 include("ModelTypes.jl")
 include("DistributionUtils.jl")

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -172,6 +172,7 @@ end
 function get_ref_stats_kwargs(ref_config::Dict{Any, Any}, reg_config::Dict{Any, Any})
     y_ref_type = ref_config["y_reference_type"]
     Σ_ref_type = get_entry(ref_config, "Σ_reference_type", y_ref_type)
+    model_errors = get_entry(ref_config, "model_errors", nothing)
     perform_PCA = get_entry(reg_config, "perform_PCA", true)
     variance_loss = get_entry(reg_config, "variance_loss", 1.0e-2)
     normalize = get_entry(reg_config, "normalize", true)
@@ -187,6 +188,7 @@ function get_ref_stats_kwargs(ref_config::Dict{Any, Any}, reg_config::Dict{Any, 
         :dim_scaling => dim_scaling,
         :y_type => y_ref_type,
         :Σ_type => Σ_ref_type,
+        :model_errors => model_errors,
     )
 end
 


### PR DESCRIPTION
## Changes

This PR adds the possibility to include a structural model error component to the error covariance matrix, with the following characteristics:
- For now, the structural error is taken to be constant per variable and reference model, so one can specify different structural errors for each spatial field of each reference model.
- The additive structural error is specified as a fraction of the pooled variance per variable. For instance, specifying a model error of 0.1 for `u_mean` of a reference model equates to adding to each component a noise with variance of 10% of the pooled variance.
-  The additive structural error is uncorrelated with the time covariance, so all its dimensions remain after performing PCA. This is a useful property because it allows to perform PCA on most variables, while retaining low-variance degrees of freedom of some variables.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.