### PR TITLE
Use abstract typing, move exports up.

### DIFF
--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -145,9 +145,9 @@ version = "0.1.4"
 
 [[deps.BlockArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "6bf9cdd29d7f0fb7a1a342026d5cefbdb61e25fb"
+git-tree-sha1 = "43b09ac794ed8347592dd90539756d1c3416e5f2"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.18"
+version = "0.16.19"
 
 [[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -220,10 +220,10 @@ uuid = "7057c7e9-c182-5462-911a-8362d720325c"
 version = "0.3.10"
 
 [[deps.ChainRules]]
-deps = ["ChainRulesCore", "Compat", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics"]
-git-tree-sha1 = "b06ed86d99c982cbe9047a45a93ac62d9605a361"
+deps = ["ChainRulesCore", "Compat", "Distributed", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics"]
+git-tree-sha1 = "cc81c5c6bab557f89e4b5951b252d7ab863639a4"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.36.2"
+version = "1.37.0"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -443,9 +443,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "d530092b57aef8b96b27694e51c575b09c7f0b2e"
+git-tree-sha1 = "429077fd74119f5ac495857fd51f4120baf36355"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.64"
+version = "0.25.65"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -476,9 +476,9 @@ version = "1.0.1"
 
 [[deps.EnsembleKalmanProcesses]]
 deps = ["Convex", "Distributions", "DocStringExtensions", "LinearAlgebra", "Optim", "QuadGK", "Random", "SCS", "SparseArrays", "Statistics", "StatsBase", "TOML"]
-git-tree-sha1 = "6dcab92ea11d067edd287ec50a4f69df48a80e7a"
+git-tree-sha1 = "345b6b7fd42517ece0d91752a63f176dcecccafa"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
-version = "0.9.0"
+version = "0.9.1"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -555,9 +555,9 @@ version = "0.13.2"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterfaceCore", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "ee13c773ce60d9e95a6c6ea134f25605dce2eda3"
+git-tree-sha1 = "e3af8444c9916abed11f4357c2f59b6801e5b376"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.13.0"
+version = "2.13.1"
 
 [[deps.FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
@@ -641,9 +641,9 @@ version = "3.3.6+0"
 
 [[deps.GPUArrays]]
 deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
-git-tree-sha1 = "73a4c9447419ce058df716925893e452ba5528ad"
+git-tree-sha1 = "470dcaf29237a0818bc2cc97f0c408f0bc052653"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "8.4.0"
+version = "8.4.1"
 
 [[deps.GPUArraysCore]]
 deps = ["Adapt"]
@@ -665,9 +665,9 @@ version = "0.64.4"
 
 [[deps.GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "3a233eeeb2ca45842fe100e0413936834215abf5"
+git-tree-sha1 = "c8ab731c9127cd931c93221f65d6a1008dad7256"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.64.4+0"
+version = "0.66.0+0"
 
 [[deps.GaussQuadrature]]
 deps = ["SpecialFunctions"]
@@ -729,9 +729,9 @@ version = "1.7.1"
 
 [[deps.GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
-git-tree-sha1 = "a88992eaa3073e65c970ce73f4636c080b68e21e"
+git-tree-sha1 = "9d9c9b62f0f63242b8f5a9c33bbcda5f3ac5c551"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
-version = "0.7.9"
+version = "0.7.10"
 
 [[deps.Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
@@ -1273,9 +1273,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[deps.NonlinearSolve]]
 deps = ["ArrayInterfaceCore", "FiniteDiff", "ForwardDiff", "IterativeSolvers", "LinearAlgebra", "RecursiveArrayTools", "RecursiveFactorization", "Reexport", "SciMLBase", "Setfield", "StaticArrays", "UnPack"]
-git-tree-sha1 = "8a00c7b9418270f1fa57da319d11febbe5f92101"
+git-tree-sha1 = "932bbdc22e6a2e0bae8dec35d32e4c8cb6c50f98"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "0.3.20"
+version = "0.3.21"
 
 [[deps.Observables]]
 git-tree-sha1 = "dfd8d34871bc3ad08cd16026c1828e271d554db9"
@@ -1316,9 +1316,9 @@ uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9a36165cf84cff35851809a40a928e1103702013"
+git-tree-sha1 = "e60321e3f2616584ff98f0a4f18d98ae6f89bbb3"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.16+0"
+version = "1.1.17+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1369,9 +1369,9 @@ version = "8.44.0+0"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "ca433b9e2f5ca3a0ce6702a032fce95a3b6e1e48"
+git-tree-sha1 = "cf494dca75a69712a72b80bc48f59dcf3dea63ec"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.14"
+version = "0.11.16"
 
 [[deps.PNGFiles]]
 deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
@@ -1579,9 +1579,9 @@ version = "0.5.2"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "7ddd4f1ac52f9cc1b784212785f86a75602a7e4b"
+git-tree-sha1 = "7a5f08bdeb79cf3f8ce60125fe1b2a04041c1d26"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "2.31.0"
+version = "2.31.1"
 
 [[deps.RecursiveFactorization]]
 deps = ["LinearAlgebra", "LoopVectorization", "Polyester", "StrideArraysCore", "TriangularSolve"]
@@ -1693,9 +1693,9 @@ version = "0.3.2"
 
 [[deps.SciMLBase]]
 deps = ["ArrayInterfaceCore", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "RecipesBase", "RecursiveArrayTools", "StaticArraysCore", "Statistics", "Tables", "TreeViews"]
-git-tree-sha1 = "3243a883fa422a0a5cfe2d3b6ea6287fc396018f"
+git-tree-sha1 = "55f38a183d472deb6893bdc3a962a13ea10c60e4"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "1.42.2"
+version = "1.42.4"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1978,9 +1978,9 @@ version = "0.1.2"
 
 [[deps.VectorizationBase]]
 deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "39e55018bccc5a858217db32aa3d9e7decbefd0c"
+git-tree-sha1 = "70b86ab24cf5321e51d1b6c22a7076106c979ccb"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.40"
+version = "0.21.41"
 
 [[deps.VertexSafeGraphs]]
 deps = ["Graphs"]

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -1,8 +1,22 @@
 module AbstractTypes
 
-export OptVec
+export OptVec, OptString, OptInt, OptReal, Opt
 
 # abstract types
+
+"Optional argument"
+const Opt{T} = Union{Nothing, T}
+
+"Optional vector"
 const OptVec{T} = Union{Nothing, Vector{T}}
+
+"Optional string"
+const OptString = Union{String, Nothing}
+
+"Optional integer"
+const OptInt = Union{Integer, Nothing}
+
+"Optional real"
+const OptReal = Union{Real, Nothing}
 
 end # module

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -5,7 +5,6 @@ Generic utils.
 """
 module HelperFuncs
 
-# We can work on qualifying these later
 export vertical_interpolation,
     nc_fetch_interpolate,
     fetch_interpolate_transform,
@@ -43,6 +42,9 @@ using LinearAlgebra
 using Glob
 using JSON
 using Random
+
+using ..AbstractTypes
+import ..AbstractTypes: OptVec
 
 """
     struct ParameterMap
@@ -274,11 +276,7 @@ function vertical_interpolation(var_name::String, filename::String, z_scm::Vecto
 end
 
 """
-    nc_fetch_interpolate(
-        var_name::String,
-        filename::String,
-        z_scm::Union{Vector{<:Real}, Nothing};
-    )
+    nc_fetch_interpolate(var_name::String, filename::String, z_scm::OptVec{<:Real})
 
 Returns the netcdf variable var_name, possibly interpolated to heights z_scm.
 
@@ -289,7 +287,7 @@ Inputs:
 Output:
  - The interpolated vector.
 """
-function nc_fetch_interpolate(var_name::String, filename::String, z_scm::Union{Vector{<:Real}, Nothing};)
+function nc_fetch_interpolate(var_name::String, filename::String, z_scm::OptVec{<:Real})
     if !is_timeseries(filename, var_name) && !isnothing(z_scm)
         return vertical_interpolation(var_name, filename, z_scm)
     else
@@ -298,11 +296,7 @@ function nc_fetch_interpolate(var_name::String, filename::String, z_scm::Union{V
 end
 
 """
-    fetch_interpolate_transform(
-        var_name::String,
-        filename::String,
-        z_scm::Union{Vector{<:Real}, Nothing};
-    )
+    fetch_interpolate_transform(var_name::String, filename::String, z_scm::OptVec{<:Real})
 
 Returns the netcdf variable var_name, possibly interpolated to heights z_scm. If the
 variable needs to be transformed to be equivalent to an SCM variable, applies the
@@ -315,7 +309,7 @@ Inputs:
 Output:
  - The interpolated and transformed vector.
 """
-function fetch_interpolate_transform(var_name::String, filename::String, z_scm::Union{Vector{<:Real}, Nothing};)
+function fetch_interpolate_transform(var_name::String, filename::String, z_scm::OptVec{<:Real})
     # PyCLES vertical fluxes are per volume, not mass
     if occursin("resolved_z_flux", var_name)
         var_ = nc_fetch_interpolate(var_name, filename, z_scm)
@@ -356,7 +350,7 @@ end
         y::Array{FT},
         norm_vec::Array{FT},
         prof_dof::IT,
-        prof_indices::Union{BitVector, Nothing} = nothing,
+        prof_indices::OptVec{Bool} = nothing,
     ) where {FT <: Real, IT <: Integer}
 
 Perform normalization of the aggregate observation vector `y` using separate
@@ -375,7 +369,7 @@ function normalize_profile(
     y::Array{FT},
     norm_vec::Array{FT},
     prof_dof::IT,
-    prof_indices::Union{Vector{Bool}, Nothing} = nothing,
+    prof_indices::OptVec{Bool} = nothing,
 ) where {FT <: Real, IT <: Integer}
     y_ = deepcopy(y)
     n_vars = length(norm_vec)

--- a/src/KalmanProcessUtils.jl
+++ b/src/KalmanProcessUtils.jl
@@ -5,6 +5,9 @@ Utils for the construction and handling of Kalman Process structs.
 """
 module KalmanProcessUtils
 
+export generate_ekp,
+    generate_tekp, get_sparse_indices, get_regularized_indices, get_Δt, PiecewiseConstantDecay, PiecewiseConstantGrowth
+
 using LinearAlgebra
 using Statistics
 using JLD2
@@ -22,11 +25,6 @@ using ..ModelTypes
 using ..LESUtils
 using ..HelperFuncs
 using ..DistributionUtils
-
-
-export generate_ekp, generate_tekp
-export get_sparse_indices, get_regularized_indices
-export get_Δt, PiecewiseConstantDecay, PiecewiseConstantGrowth
 
 abstract type LearningRateScheduler end
 

--- a/src/LESUtils.jl
+++ b/src/LESUtils.jl
@@ -1,12 +1,12 @@
 module LESUtils
 
+export get_les_names, get_cfsite_les_dir, find_alias, get_path_to_artifact
+
 import NCDatasets
 import ..ReferenceModels: ReferenceModel
 import TurbulenceConvection
 const TC = TurbulenceConvection
 using ..HelperFuncs
-
-export get_les_names, get_cfsite_les_dir, find_alias, get_path_to_artifact
 
 
 """

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -1,5 +1,7 @@
 module ReferenceStats
 
+export ReferenceStatistics, pca_length, full_length, get_obs, get_profile, obs_PCA, pca, pca_inds, full_inds
+
 using SparseArrays
 using Statistics
 using Interpolations
@@ -13,10 +15,7 @@ using ..LESUtils
 using ..HelperFuncs
 using ..DistributionUtils
 
-export ReferenceStatistics
-export pca_length, full_length
-export get_obs, get_profile, obs_PCA, pca
-export pca_inds, full_inds
+import ..AbstractTypes: OptVec, OptReal
 
 """
     ReferenceStatistics{FT <: Real, IT <: Integer}
@@ -300,7 +299,7 @@ end
         filename::String,
         y_names::Vector{String};
         ti::Real = 0.0,
-        tf::Union{Real, Nothing} = nothing,
+        tf::OptReal = nothing,
         z_scm::Union{Vector{T}, T} = nothing,
         prof_ind::Bool = false,
     ) where {T}
@@ -339,7 +338,7 @@ function get_profile(
     filename::String,
     y_names::Vector{String};
     ti::Real = 0.0,
-    tf::Union{Real, Nothing} = nothing,
+    tf::OptReal = nothing,
     z_scm::OptVec{T} = nothing,
     prof_ind::Bool = false,
 ) where {T}

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -1,30 +1,34 @@
 module TurbulenceConvectionUtils
 
+export ModelEvaluator,
+    run_SCM,
+    run_SCM_handler,
+    run_reference_SCM,
+    generate_scm_input,
+    parse_version_inds,
+    eval_single_ref_model,
+    save_full_ensemble_data,
+    precondition,
+    get_gcm_les_uuid,
+    save_tc_data
+
 import Logging
 using JLD2
 using JSON
 using Random
 using DocStringExtensions
+using TurbulenceConvection
+# EKP modules
+using EnsembleKalmanProcesses.ParameterDistributions
+import EnsembleKalmanProcesses: construct_initial_ensemble
 
 using ..ReferenceModels
 import ..ReferenceModels: NameList
 
 using ..ReferenceStats
 using ..HelperFuncs
-# EKP modules
-using EnsembleKalmanProcesses.ParameterDistributions
-import EnsembleKalmanProcesses: construct_initial_ensemble
-using TurbulenceConvection
-
-using ..HelperFuncs
-
-export ModelEvaluator
-export run_SCM, run_SCM_handler, run_reference_SCM
-export generate_scm_input, parse_version_inds, eval_single_ref_model
-export save_full_ensemble_data
-export precondition
-export get_gcm_les_uuid
-export save_tc_data
+using ..AbstractTypes
+import ..AbstractTypes: OptVec
 
 """
     ModelEvaluator
@@ -452,7 +456,7 @@ function generate_scm_input(
     model_evaluators::Vector{ModelEvaluator{FT}},
     iteration::Int,
     outdir_path::String = pwd(),
-    batch_indices::Union{Vector{Int}, Nothing} = nothing,
+    batch_indices::OptVec{Int} = nothing,
 ) where {FT <: AbstractFloat}
     versions = String[]
     for (ens_i, model_evaluator) in enumerate(model_evaluators)


### PR DESCRIPTION
## Changes

Centralized and expands use of abstract typing for optional arguments. Moves exports to top of each module, tidying convention.
 
## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.