### PR TITLE
Fix TC error handling corner case, allow calibration of stretched grid.

### DIFF
--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -180,9 +180,9 @@ version = "0.1.23"
 
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CompilerSupportLibraries_jll", "ExprTools", "GPUArrays", "GPUCompiler", "LLVM", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "SpecialFunctions", "TimerOutputs"]
-git-tree-sha1 = "e4e5ece72fa2f108fb20c3c5538a5fa9ef3d668a"
+git-tree-sha1 = "49549e2c28ffb9cc77b3689dc10e46e6271e9452"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "3.11.0"
+version = "3.12.0"
 
 [[deps.Cairo]]
 deps = ["Cairo_jll", "Colors", "Glib_jll", "Graphics", "Libdl", "Pango_jll"]
@@ -239,9 +239,9 @@ version = "1.9.0"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "1e315e3f4b0b7ce40feded39c73049692126cf53"
+git-tree-sha1 = "38f7a08f19d8810338d4f5085211c7dfa5d5bdd8"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.3"
+version = "0.1.4"
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "KernelAbstractions", "StaticArrays"]
@@ -751,9 +751,9 @@ version = "1.12.0+1"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "Dates", "IniFile", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "bd11d3220f89382f3116ed34c92badaa567239c9"
+git-tree-sha1 = "ed47af35905b7cc8f1a522ca684b35a212269bd8"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.0.5"
+version = "1.2.0"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
@@ -1096,9 +1096,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterfaceCore", "DocStringExtensions", "FastLapackInterface", "GPUArraysCore", "IterativeSolvers", "KLU", "Krylov", "KrylovKit", "LinearAlgebra", "RecursiveFactorization", "Reexport", "SciMLBase", "Setfield", "SparseArrays", "SuiteSparse", "UnPack"]
-git-tree-sha1 = "5011ab36cb55f2c849487f0a3edffba602c705c1"
+git-tree-sha1 = "0232b09cf528df0df605880cbdde89d2af8cbf76"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "1.22.1"
+version = "1.22.2"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
@@ -1456,9 +1456,9 @@ version = "1.3.0"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "b29873144e57f9fcf8d41d107138a4378e035298"
+git-tree-sha1 = "5a1e85f3aed2e0d3d99a4068037c8582597b89cf"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.31.2"
+version = "1.31.3"
 
 [[deps.PoissonRandom]]
 deps = ["Random"]
@@ -1590,9 +1590,9 @@ version = "0.6.2"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "7a5f08bdeb79cf3f8ce60125fe1b2a04041c1d26"
+git-tree-sha1 = "4ce7584604489e537b2ab84ed92b4107d03377f0"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "2.31.1"
+version = "2.31.2"
 
 [[deps.RecursiveFactorization]]
 deps = ["LinearAlgebra", "LoopVectorization", "Polyester", "StrideArraysCore", "TriangularSolve"]
@@ -1698,9 +1698,9 @@ version = "0.6.33"
 
 [[deps.ScanByte]]
 deps = ["Libdl", "SIMD"]
-git-tree-sha1 = "8c3e2c64dac132efa8828b1b045a47cbf0881def"
+git-tree-sha1 = "2436b15f376005e8790e318329560dcc67188e84"
 uuid = "7b38b023-a4d7-4c5e-8d43-3f3097f304eb"
-version = "0.3.2"
+version = "0.3.3"
 
 [[deps.SciMLBase]]
 deps = ["ArrayInterfaceCore", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "RecipesBase", "RecursiveArrayTools", "StaticArraysCore", "Statistics", "Tables", "TreeViews"]
@@ -1965,9 +1965,9 @@ uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 version = "0.27.6"
 
 [[deps.URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -199,6 +199,8 @@ function namelist_subdict_by_key(namelist::Dict, param_name::AbstractString)::Di
         namelist["microphysics"]
     elseif haskey(namelist["time_stepping"], param_name)
         namelist["time_stepping"]
+    elseif haskey(namelist["grid"]["stretch"], param_name)
+        namelist["grid"]["stretch"]
     else
         throw(ArgumentError("Parameter $param_name cannot be calibrated. Consider adding namelist dictionary if needed."))
     end

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -201,14 +201,15 @@ function eval_single_ref_model(
     filename = get_stats_path(sim_dir)
     z_obs = get_z_obs(m)
     if model_error
-        g_scm = get_profile(m, filename, z_scm = z_obs) # Get shape
-        g_scm = fill(NaN, length(g_scm))
+        d_full, d = size(RS.pca_vec[m_index])
+        g_scm = fill(NaN, d_full)
+        g_scm_pca = fill(NaN, d)
     else
         g_scm, prof_indices = get_profile(m, filename, z_scm = z_obs, prof_ind = true)
         g_scm = normalize_profile(g_scm, RS.norm_vec[m_index], length(z_obs), prof_indices)
+        # perform PCA reduction
+        g_scm_pca = RS.pca_vec[m_index]' * g_scm
     end
-    # perform PCA reduction
-    g_scm_pca = RS.pca_vec[m_index]' * g_scm
     return sim_dir, g_scm, g_scm_pca, model_error
 end
 

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -61,7 +61,6 @@ function eval_single_ref_model(
     u_names::Vector{String},
     param_map::ParameterMap,
 ) where {FT <: Real, IT <: Int}
-
     # create temporary directory to store SCM data in
     tmpdir = mktempdir(joinpath(pwd(), "tmp"))
     # run TurbulenceConvection.jl. Get output directory for simulation data
@@ -69,14 +68,15 @@ function eval_single_ref_model(
     filename = get_stats_path(sim_dir)
     z_obs = get_z_obs(m)
     if model_error
-        g_scm = get_profile(m, filename, z_scm = z_obs) # Get shape
-        g_scm = fill(NaN, length(g_scm))
+        d_full, d = size(RS.pca_vec[m_index])
+        g_scm = fill(NaN, d_full)
+        g_scm_pca = fill(NaN, d)
     else
         g_scm, prof_indices = get_profile(m, filename, z_scm = z_obs, prof_ind = true)
         g_scm = normalize_profile(g_scm, RS.norm_vec[m_index], length(z_obs), prof_indices)
+        # perform PCA reduction
+        g_scm_pca = RS.pca_vec[m_index]' * g_scm
     end
-    # perform PCA reduction
-    g_scm_pca = RS.pca_vec[m_index]' * g_scm
     return sim_dir, g_scm, g_scm_pca, model_error
 end
 

--- a/test/HelperFuncs/runtests.jl
+++ b/test/HelperFuncs/runtests.jl
@@ -97,6 +97,7 @@ end
         ),
         "microphysics" => Dict(),
         "time_stepping" => Dict("t_max" => 12.0),
+        "grid" => Dict("stretch" => Dict("dz_toa" => 20.0)),
     )
 
     @test namelist_subdict_by_key(namelist, "sorting_power")["sorting_power"] == 1.0


### PR DESCRIPTION
## Changes

- Fixes a corner case handling TC errors when the output is a scalar. Prior to this, it was assumed that the output of failed simulations was a vertical profile.
- Allows calibration of stretched grid parameters. 

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.