### PR TITLE
Add CNRM-CM5 cases, add SCT3 benchmark

### DIFF
--- a/experiments/SCT3_benchmark/config_no_phys.jl
+++ b/experiments/SCT3_benchmark/config_no_phys.jl
@@ -1,0 +1,205 @@
+#= Custom calibration configuration file. =#
+
+using Distributions
+using StatsBase
+using LinearAlgebra
+using Random
+using CalibrateEDMF
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.ReferenceModels
+using CalibrateEDMF.ReferenceStats
+using CalibrateEDMF.LESUtils
+using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.ModelTypes
+using CalibrateEDMF.HelperFuncs
+import CalibrateEDMF.LESUtils: get_shallow_LES_library
+# Import EKP modules
+using JLD2
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Localizers
+using EnsembleKalmanProcesses.ParameterDistributions
+
+# Cases defined as structs for quick access to default configs
+struct SCT3Train end
+struct SCT3Val end
+
+batch = 15 # Possible batch sizes are [1, 3, 5, 9, 15, 27, 45, 135]
+
+dt_default = 135.0 / batch
+dt = dt_default * 1.0 # Treat as hyperparameter
+
+namelist_args = [
+    ("time_stepping", "dt_min", 0.5),
+    ("time_stepping", "dt_max", 5.0),
+    ("stats_io", "frequency", 60.0),
+    ("thermodynamics", "sgs", "quadrature"),
+    # Add namelist_args defining entrainment closure, e.g.
+    ("turbulence", "EDMF_PrognosticTKE", "area_limiter_power", 0.0),
+    ("turbulence", "EDMF_PrognosticTKE", "entr_dim_scale", "none"),
+    ("turbulence", "EDMF_PrognosticTKE", "entrainment", "NN"),
+]
+
+function get_config()
+    config = Dict()
+    # Flags for saving output data
+    config["output"] = get_output_config()
+    # Define regularization of inverse problem
+    config["regularization"] = get_regularization_config()
+    # Define reference used in the inverse problem 
+    config["reference"] = get_reference_config(SCT3Train())
+    # Define reference used for validation
+    config["validation"] = get_reference_config(SCT3Val())
+    # Define the parameter priors
+    config["prior"] = get_prior_config()
+    # Define the kalman process
+    config["process"] = get_process_config()
+    # Define the SCM static configuration
+    config["scm"] = get_scm_config()
+    return config
+end
+
+function get_output_config()
+    config = Dict()
+    config["outdir_root"] = pwd()
+    return config
+end
+
+function get_regularization_config()
+    config = Dict()
+    # Regularization of observations: mean and covariance
+    config["perform_PCA"] = true # Performs PCA on data
+    config["variance_loss"] = 1.0e-2 # Variance truncation level in PCA
+    config["normalize"] = true  # whether to normalize data by pooled variance
+    config["tikhonov_mode"] = "relative" # Tikhonov regularization
+    config["tikhonov_noise"] = 1.0e-6 # Tikhonov regularization
+    config["dim_scaling"] = true # Dimensional scaling of the loss
+
+    # Parameter regularization: L2 regularization with respect to prior mean.
+    #  - Set to `nothing` to use prior covariance as regularizer,
+    #  - Set to a float for isotropic parameter regularization.
+    #  - Pass a dictionary of lists similar to config["prior_mean"] for
+    #       anisotropic regularization. The dictionary must be complete.
+    #       If you want to avoid regularizing a certain parameter, set the entry
+    #       to [0].
+    # To turn off regularization, set config["process"]["augmented"] to false.
+    #
+    #
+    # Defaults set to batch_size/total_size to match total dataset uncertainty
+    # in UKI. Feel free to set treat these as hyperparameters.
+    config["l2_reg"] = Dict(
+        # entrainment parameters
+        "nn_ent_params" => repeat([0.0], 58),
+    )
+    return config
+end
+
+function get_process_config()
+    config = Dict()
+    config["N_iter"] = 50
+    config["N_ens"] = 50 # Must be 2p+1 when algorithm is "Unscented"
+    config["algorithm"] = "Inversion" # "Sampler", "Unscented", "Inversion"
+    config["noisy_obs"] = false # Choice of covariance in evaluation of y_{j+1} in EKI. True -> Γy, False -> 0
+    # Artificial time stepper of the EKI.
+    config["Δt"] = dt
+    # Whether to augment the outputs with the parameters for regularization
+    config["augmented"] = false
+    config["failure_handler"] = "sample_succ_gauss" #"high_loss" #"sample_succ_gauss"
+    # https://github.com/CliMA/EnsembleKalmanProcesses.jl/blob/main/src/Localizers.jl#L63
+    config["localizer"] = SEC(0.5, 0.1) # First arg is strength of localization, second is the minimum correlation retained
+    return config
+end
+
+function get_reference_config(::SCT3Train)
+    config = Dict()
+    # Get all 135 shallow cases from Shen et al (2022)
+    les_library = get_shallow_LES_library()
+
+    ref_dirs = []
+    for model in keys(les_library)
+        for month in keys(les_library[model])
+            cfsite_numbers = Tuple(les_library[model][month]["cfsite_numbers"])
+            les_kwargs = (forcing_model = model, month = parse(Int, month), experiment = "amip")
+            append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+        end
+    end
+    n_repeat = length(ref_dirs)
+
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "lwp_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    config["batch_size"] = batch # Possible batch sizes are [1, 3, 5, 9, 15, 27, 45, 135]
+    config["write_full_stats"] = false
+    config["namelist_args"] = repeat([namelist_args], n_repeat)
+    return config
+end
+
+function get_reference_config(::SCT3Val)
+    config = Dict()
+
+    # AMIP4K data: July, NE Pacific
+    cfsite_numbers = (17, 18, 20, 22, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 7, experiment = "amip4K")
+    ref_dirs = [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers]
+
+    # AMIP4K data: October, NE Pacific
+    cfsite_numbers = (17, 18, 20, 22, 23)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 10, experiment = "amip4K")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+
+    # AMIP4K data: January, SE Pacific
+    cfsite_numbers = (2, 4, 6, 11, 14)
+    les_kwargs = (forcing_model = "HadGEM2-A", month = 1, experiment = "amip4K")
+    append!(ref_dirs, [get_cfsite_les_dir(cfsite_number; les_kwargs...) for cfsite_number in cfsite_numbers])
+
+    n_repeat = length(ref_dirs)
+    config["case_name"] = repeat(["LES_driven_SCM"], n_repeat)
+    # Flag to indicate whether reference data is from a perfect model (i.e. SCM instead of LES)
+    config["y_reference_type"] = LES()
+    config["Σ_reference_type"] = LES()
+    config["y_names"] =
+        repeat([["s_mean", "ql_mean", "qt_mean", "total_flux_qt", "total_flux_s", "lwp_mean"]], n_repeat)
+    config["y_dir"] = ref_dirs
+    config["t_start"] = repeat([3.0 * 3600], n_repeat)
+    config["t_end"] = repeat([6.0 * 3600], n_repeat)
+    # Use full LES timeseries for covariance
+    config["Σ_t_start"] = repeat([-5.75 * 24 * 3600], n_repeat)
+    config["Σ_t_end"] = repeat([6.0 * 3600], n_repeat)
+    config["write_full_stats"] = false
+    config["namelist_args"] = repeat([namelist_args], n_repeat)
+    return config
+end
+
+function get_prior_config()
+    config = Dict()
+    config["constraints"] = Dict(
+        # data-driven entrainment parameters
+        "nn_ent_params" => [repeat([no_constraint()], 58)...],
+    )
+
+    # TC.jl prior mean
+    config["prior_mean"] = Dict(
+        # data-driven entrainment parameters
+        "nn_ent_params" => 0.1 .* (rand(58) .- 0.5),
+    )
+
+    config["unconstrained_σ"] = 1.0
+    # Tight initial prior for Unscented
+    # config["unconstrained_σ"] = 0.25
+    return config
+end
+
+function get_scm_config()
+    config = Dict()
+    config["namelist_args"] = namelist_args
+    return config
+end

--- a/experiments/SCT3_benchmark/global_parallel/create_tc_so.jl
+++ b/experiments/SCT3_benchmark/global_parallel/create_tc_so.jl
@@ -1,0 +1,4 @@
+using CalibrateEDMF
+
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "create_tc_so.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/ekp_par_calibration.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/ekp_par_calibration.sbatch
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#SBATCH --time=0:20:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH -J "sct_call"   # job name
+
+config_rel=${1?Error: no config file given}
+config=$(realpath $config_rel)
+
+# Job identifier
+job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+# Get size of the ensemble from config, trim comments and whitespace
+n=$(grep N_ens ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Number of calibration iterations, trim comments and whitespace
+n_it=$(grep N_iter ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Number of parallel processes for SCM evaluation, split evenly between train and validation
+n_proc_scm=10
+echo "Initializing calibration with ${n} ensemble members and ${n_it} iterations."
+
+module purge
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
+export JULIA_MPI_BINARY=system
+export JULIA_CUDA_USE_BINARYBUILDER=false
+
+# run instantiate/precompile serial
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.precompile()'
+
+for it in $(seq 1 1 $n_it)
+do
+# Parallel runs of forward model
+if [ "$it" = "1" ]; then
+    # Generate system image
+    id_so=$(sbatch --parsable -A esm sysimage.sbatch)
+    # Initialize calibration
+    id_init_ens=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_so init.sbatch $config $job_id)
+    # Precondition parameters
+    id_precond=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_init_ens --array=1-$n precondition_prior.sbatch $it $job_id)
+    # Run ensemble of forward models
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_precond --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+else
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+fi
+# Update ensemble
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
+done
+

--- a/experiments/SCT3_benchmark/global_parallel/init.jl
+++ b/experiments/SCT3_benchmark/global_parallel/init.jl
@@ -1,0 +1,6 @@
+"""Initializes a SCM calibration process."""
+
+using CalibrateEDMF
+
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "init.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/init.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/init.sbatch
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#SBATCH --time=2:00:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=20G   # memory per CPU core
+#SBATCH -J "sct_init"   # job name
+
+#julia package management
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1
+
+config=${1?Error: no config file given}
+job_id=${2?Error: no job ID given}
+
+julia --project -C skylake-avx512 -JCEDMF.so init.jl --config $config --job_id $job_id && (
+  echo sysimage loaded successfully
+) || (
+  julia --project init.jl --config $config --job_id $job_id
+)
+
+echo 'Ensemble initialized for calibration.'

--- a/experiments/SCT3_benchmark/global_parallel/parallel_scm_eval.jl
+++ b/experiments/SCT3_benchmark/global_parallel/parallel_scm_eval.jl
@@ -1,0 +1,19 @@
+"""Evaluates a set of SCM configurations for a single parameter vector."""
+
+@everywhere begin
+    using Pkg
+    Pkg.activate("../../..") # @__DIR__
+end
+
+@everywhere begin
+    using ArgParse
+    using JLD2
+    using CalibrateEDMF
+    using CalibrateEDMF.Pipeline
+
+    src_dir = dirname(pathof(CalibrateEDMF))
+    cedmf = pkgdir(CalibrateEDMF)
+    include(joinpath(src_dir, "parallel.jl"))
+end
+
+include(joinpath(cedmf, "driver", "global_parallel", "parallel_scm_eval.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/parallel_scm_eval.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/parallel_scm_eval.sbatch
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00   # walltime
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "sct_run"   # job name
+
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+iteration_=${1?Error: no iteration given}
+job_id=${2?Error: no job ID given}
+n_proc_scm=${3?Error: number of processes not given}
+
+run_num=${SLURM_ARRAY_TASK_ID}
+job_dir=$(head $job_id".txt" | tail -1)
+version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
+
+julia --project -C skylake-avx512 -JCEDMF.so -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train" && (
+  echo sysimage loaded successfully
+) || (
+  julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "train"
+) &
+P1=$!
+julia --project -C skylake-avx512 -JCEDMF.so -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation" && (
+  echo sysimage loaded successfully
+) || (
+  julia --project -p $((n_proc_scm/2)) parallel_scm_eval.jl --version $version --job_dir $job_dir --mode "validation"
+) &
+P2=$!
+wait $P1 $P2
+echo "SCM simulation for ${version} in iteration ${iteration_} finished"

--- a/experiments/SCT3_benchmark/global_parallel/precondition_prior.jl
+++ b/experiments/SCT3_benchmark/global_parallel/precondition_prior.jl
@@ -1,0 +1,6 @@
+"""Evaluates the stability of a set of SCM configurations for a parameter vector and possibly draws a new one."""
+
+using CalibrateEDMF
+
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "precondition_prior.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/precondition_prior.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/precondition_prior.sbatch
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#SBATCH --time=2:00:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "precond"   # job name
+
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+iteration_=${1?Error: no iteration given}
+job_id=${2?Error: no job ID given}
+
+run_num=${SLURM_ARRAY_TASK_ID}
+job_dir=$(head $job_id".txt" | tail -1)
+version=$(head -"$run_num" $job_dir/"versions_"$iteration_".txt" | tail -1)
+
+julia --project -C skylake-avx512 -JCEDMF.so precondition_prior.jl --version $version --job_dir $job_dir && (
+  echo sysimage loaded successfully
+) || (
+  julia --project precondition_prior.jl --version $version --job_dir $job_dir
+)
+
+echo "Preconditioning for ${version} finished."
+

--- a/experiments/SCT3_benchmark/global_parallel/restart.jl
+++ b/experiments/SCT3_benchmark/global_parallel/restart.jl
@@ -1,0 +1,6 @@
+"""Restarts a calibration process."""
+
+using CalibrateEDMF
+
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "global_parallel", "restart.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/restart.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/restart.sbatch
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "restart"   # job name
+
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1
+
+output_dir=${1?Error: no output directory given}
+job_id=${2?Error: no job ID given}
+
+julia --project -C skylake-avx512 -JCEDMF.so restart.jl --output_dir $output_dir --job_id $job_id && (
+  echo sysimage loaded successfully
+) || (
+  julia --project restart.jl --output_dir $output_dir --job_id $job_id
+)
+
+echo "Calibration process at ${output_dir} restarted."

--- a/experiments/SCT3_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/restart_ekp_par_calibration.sbatch
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#SBATCH --time=0:20:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH -J "restart_call"   # job name
+
+output_dir_rel=${1?Error: no output directory given}
+output_dir=$(realpath $output_dir_rel)
+config=${output_dir}/"config.jl"
+
+# Job identifier
+job_id=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
+# Get size of the ensemble from config, trim comments and whitespace
+n=$(grep N_ens ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Total umber of calibration iterations (previous+new), trim comments and whitespace
+n_it=$(grep N_iter ${config} | cut -d=   -f2 | cut -d#   -f1 | xargs)
+# Get last iteration
+last_ekobj=$(ls -v ${output_dir}/ekobj_iter_* | tail -1)
+last_iter=${last_ekobj%.*} # Remove trailing file format
+last_iter=${last_iter##*_} # Remove leading filename
+first_new_iter=$(($last_iter + 1))
+
+# Number of parallel processes for SCM evaluation, split evenly between train and validation
+n_proc_scm=10
+echo "Restarting calibration with ${n} ensemble members and ${n_it} iterations (grand total)."
+
+module purge
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+export JULIA_NUM_THREADS=${SLURM_CPUS_PER_TASK:=1}
+export JULIA_MPI_BINARY=system
+export JULIA_CUDA_USE_BINARYBUILDER=false
+
+# run instantiate/precompile serial
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
+julia --project -C skylake-avx512 -e 'using Pkg; Pkg.precompile()'
+
+for it in $(seq $first_new_iter 1 $n_it)
+do
+# Parallel runs of forward model
+if [ "$it" = "$first_new_iter" ]; then
+    # Generate system image
+    id_so=$(sbatch --parsable -A esm sysimage.sbatch)
+    # Restart calibration
+    id_restart_ens=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_so restart.sbatch $output_dir $job_id)
+    # Run ensemble of forward models
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_restart_ens --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+else
+    id_ens_array=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ek_upd --array=1-$n -n $n_proc_scm parallel_scm_eval.sbatch $it $job_id $n_proc_scm)
+fi
+# Update ensemble
+id_ek_upd=$(sbatch --parsable --kill-on-invalid-dep=yes -A esm --dependency=afterok:$id_ens_array --export=n=$n step_ekp.sbatch $it $job_id)
+done
+

--- a/experiments/SCT3_benchmark/global_parallel/step_ekp.jl
+++ b/experiments/SCT3_benchmark/global_parallel/step_ekp.jl
@@ -1,0 +1,6 @@
+"""Performs a single step of the EnsembleKalmanProcess."""
+
+using CalibrateEDMF
+
+cedmf = pkgdir(CalibrateEDMF)
+include(joinpath(cedmf, "driver", "hpc_parallel", "step_ekp.jl"))

--- a/experiments/SCT3_benchmark/global_parallel/step_ekp.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/step_ekp.sbatch
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00   # walltime
+#SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=6G   # memory per CPU core
+#SBATCH -J "sct_cont"   # job name
+
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1
+iteration_=${1?Error: no iteration given}
+job_id=${2?Error: no job ID given}
+job_dir=$(head $job_id".txt" | tail -1)
+
+julia --project -C skylake-avx512 -JCEDMF.so step_ekp.jl --iteration $iteration_ --job_dir $job_dir && (
+  echo sysimage loaded successfully
+) || (
+  julia --project step_ekp.jl --iteration $iteration_ --job_dir $job_dir
+)
+
+echo "Ensemble at iteration ${iteration_} stepped forward."

--- a/experiments/SCT3_benchmark/global_parallel/sysimage.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/sysimage.sbatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#SBATCH --time=3:00:00   # walltime
+#SBATCH --ntasks=1  # number of processor cores (i.e. tasks)
+#SBATCH --nodes=1   # number of nodes
+#SBATCH --mem-per-cpu=20G   # memory per CPU core
+#SBATCH -J "sys_im"   # job name
+
+module load julia/1.7.3 hdf5/1.10.1 netcdf-c/4.6.1 openmpi/4.0.1
+
+julia --project -C skylake-avx512 create_tc_so.jl
+
+echo "System image creation/check finished."

--- a/integration_tests/Het_batch_unscented_test_config.jl
+++ b/integration_tests/Het_batch_unscented_test_config.jl
@@ -16,6 +16,13 @@ struct ObsCampaigns end
 struct ObsCampaignsVal end
 # struct MyAwesomeSetup end
 
+namelist_args = [
+    ("time_stepping", "dt_min", 1.0),
+    ("time_stepping", "dt_max", 10.0),
+    ("stats_io", "frequency", 60.0),
+    ("thermodynamics", "sgs", "mean"),
+]
+
 function get_config()
     config = Dict()
     # Flags for saving output data
@@ -83,7 +90,7 @@ function get_reference_config(::ObsCampaigns)
     # Flag to indicate source of data (LES or SCM) for reference data and covariance
     config["y_reference_type"] = LES()
     config["Σ_reference_type"] = LES()
-    config["y_names"] = [["thetal_mean", "u_mean", "v_mean", "tke_mean"], ["thetal_mean", "ql_mean", "qt_mean"]]
+    config["y_names"] = [["thetal_mean", "v_mean", "tke_mean"], ["thetal_mean", "ql_mean", "qt_mean"]]
     config["y_dir"] = ["/groups/esm/ilopezgo/Output.GABLS.iles128wCov", "/groups/esm/ilopezgo/Output.DYCOMS_RF01.may20"]
     # provide list of dirs if different from `y_dir`
     # config["Σ_dir"] = [...]
@@ -93,24 +100,29 @@ function get_reference_config(::ObsCampaigns)
     # config["Σ_t_start"] = [...]
     # config["Σ_t_end"] = [...]
     config["batch_size"] = 1
+    config["namelist_args"] = [namelist_args, namelist_args]
     return config
 end
 
 function get_reference_config(::ObsCampaignsVal)
     config = Dict()
-    config["case_name"] = ["DYCOMS_RF01"]
+    config["case_name"] = ["GABLS", "DYCOMS_RF01"]
     # Flag to indicate source of data (LES or SCM) for reference data and covariance
     config["y_reference_type"] = LES()
     config["Σ_reference_type"] = LES()
-    config["y_names"] = [["total_flux_h", "total_flux_qt"]]
-    config["y_dir"] = ["/groups/esm/ilopezgo/Output.DYCOMS_RF01.may20"]
+    config["y_names"] = [
+        ["thetal_mean", "u_mean", "v_mean", "tke_mean"],
+        ["thetal_mean", "ql_mean", "qt_mean", "total_flux_h", "total_flux_qt"],
+    ]
+    config["y_dir"] = ["/groups/esm/ilopezgo/Output.GABLS.iles128wCov", "/groups/esm/ilopezgo/Output.DYCOMS_RF01.may20"]
     # provide list of dirs if different from `y_dir`
     # config["Σ_dir"] = [...]
-    config["t_start"] = [2] * 3600.0
-    config["t_end"] = [4] * 3600.0
+    config["t_start"] = [7, 2] * 3600.0
+    config["t_end"] = [9, 4] * 3600.0
     # Specify averaging intervals for covariance, if different from mean vector (`t_start` & `t_end`)
     # config["Σ_t_start"] = [...]
     # config["Σ_t_end"] = [...]
+    config["namelist_args"] = [namelist_args, namelist_args]
     return config
 end
 
@@ -118,29 +130,24 @@ function get_prior_config()
     config = Dict()
     config["constraints"] = Dict(
         # diffusion parameters
-        "tke_ed_coeff" => [bounded(0.01, 1.0)],
-        "tke_diss_coeff" => [bounded(0.01, 1.0)],
-        "static_stab_coeff" => [bounded(0.1, 1.0)],
+        "tke_ed_coeff" => [bounded(0.1, 1.0)],
+        "tke_diss_coeff" => [bounded(0.4, 1.0)],
+        "static_stab_coeff" => [bounded(0.5, 1.0)],
     )
     # TC.jl prior mean
     config["prior_mean"] = Dict(
         # diffusion parameters
-        "tke_ed_coeff" => [0.05],
-        "tke_diss_coeff" => [0.5],
-        "static_stab_coeff" => [0.9],
+        "tke_ed_coeff" => [0.6],
+        "tke_diss_coeff" => [0.75],
+        "static_stab_coeff" => [0.7],
     )
 
-    config["unconstrained_σ"] = 0.5
+    config["unconstrained_σ"] = 1.0
     return config
 end
 
 function get_scm_config()
     config = Dict()
-    config["namelist_args"] = [
-        ("time_stepping", "dt_min", 1.0),
-        ("time_stepping", "dt_max", 10.0),
-        ("stats_io", "frequency", 60.0),
-        ("thermodynamics", "sgs", "mean"),
-    ]
+    config["namelist_args"] = namelist_args
     return config
 end

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -22,9 +22,9 @@ version = "0.3.4"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
+git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.3.3"
+version = "3.4.0"
 
 [[deps.Animations]]
 deps = ["Colors"]
@@ -55,9 +55,9 @@ version = "6.0.17"
 
 [[deps.ArrayInterfaceCore]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "8d9e48436c5589fbd51ae8c8165a299a219188c0"
+git-tree-sha1 = "40debc9f72d0511e12d817c7ca06a721b6423ba3"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.15"
+version = "0.1.17"
 
 [[deps.ArrayInterfaceGPUArrays]]
 deps = ["Adapt", "ArrayInterfaceCore", "GPUArraysCore", "LinearAlgebra"]
@@ -85,9 +85,9 @@ version = "0.1.0"
 
 [[deps.ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "ebe4bbfc4de38ef88323f67d60a4e848fb550f0e"
+git-tree-sha1 = "ac5cc6021f32a272ee572dd2a325049a1fa0d034"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "0.8.9"
+version = "0.8.11"
 
 [[deps.ArtifactWrappers]]
 deps = ["DocStringExtensions", "Downloads", "Pkg"]
@@ -145,9 +145,9 @@ version = "0.1.4"
 
 [[deps.BlockArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "43b09ac794ed8347592dd90539756d1c3416e5f2"
+git-tree-sha1 = "0c0dd27be59bc76a3da6243d8172aeedd6420037"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.19"
+version = "0.16.20"
 
 [[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -168,9 +168,9 @@ version = "0.1.2"
 
 [[deps.CLIMAParameters]]
 deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "5a8b3def6f3367c3972a7e0449e611c2efc7357d"
+git-tree-sha1 = "ae2d47cc5f23c894474552a91c62ce3921082aef"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
-version = "0.6.4"
+version = "0.6.5"
 
 [[deps.CPUSummary]]
 deps = ["CpuId", "IfElse", "Static"]
@@ -192,9 +192,9 @@ version = "1.0.5"
 
 [[deps.CairoMakie]]
 deps = ["Base64", "Cairo", "Colors", "FFTW", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "SHA"]
-git-tree-sha1 = "0483b660cfc7bff57e986c6d5af5179bcccdd8dc"
+git-tree-sha1 = "387e0102f240244102814cf73fe9fbbad82b9e9e"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.8.12"
+version = "0.8.13"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -220,10 +220,10 @@ uuid = "7057c7e9-c182-5462-911a-8362d720325c"
 version = "0.3.10"
 
 [[deps.ChainRules]]
-deps = ["ChainRulesCore", "Compat", "Distributed", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics"]
-git-tree-sha1 = "e762b70af7c1d914f677d9588a1d3b32e5f832af"
+deps = ["Adapt", "ChainRulesCore", "Compat", "Distributed", "GPUArraysCore", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics", "StructArrays"]
+git-tree-sha1 = "82e91ef81cc0022a185ca3d0e6f9ca393e423c86"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.39.1"
+version = "1.44.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -414,9 +414,9 @@ version = "6.89.0"
 
 [[deps.DiffEqNoiseProcess]]
 deps = ["DiffEqBase", "Distributions", "GPUArraysCore", "LinearAlgebra", "Markdown", "Optim", "PoissonRandom", "QuadGK", "Random", "Random123", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArrays", "Statistics"]
-git-tree-sha1 = "6f3fe6ebe1b6e6e3a9b72739ada313aa17c9bb66"
+git-tree-sha1 = "baddd892e9a5dec5ccd3d8e71ec198251d3c5522"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.12.0"
+version = "5.12.1"
 
 [[deps.DiffResults]]
 deps = ["StaticArrays"]
@@ -496,6 +496,11 @@ git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.8"
 
+[[deps.Extents]]
+git-tree-sha1 = "5e1e4c53fa39afe63a7d356e30452249365fba99"
+uuid = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+version = "0.1.1"
+
 [[deps.FFMPEG]]
 deps = ["FFMPEG_jll"]
 git-tree-sha1 = "b57e3acbe22f8484b4b5ff66a7499717fe1a9cc8"
@@ -539,15 +544,15 @@ version = "0.4.9"
 
 [[deps.FastLapackInterface]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "9c77a18eddbc4f7b5edbd2f1c28467ba4ba787bd"
+git-tree-sha1 = "f2f624311f5e3e74c0d7f8d17ec280d867cd342f"
 uuid = "29a986be-02c6-4525-aec4-84b980013641"
-version = "1.1.0"
+version = "1.2.2"
 
 [[deps.FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "9267e5f50b0e12fdfd5a2455534345c4cf2c7f7a"
+git-tree-sha1 = "94f5101b96d2d968ace56f7f2db19d0a5f592e28"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.14.0"
+version = "1.15.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -560,9 +565,9 @@ version = "0.13.2"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterfaceCore", "LinearAlgebra", "Requires", "Setfield", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "cb8c5f0074153ace28ce5100714df4378ad885e0"
+git-tree-sha1 = "5a2cff9b6b77b33b89f3d97a4d367747adce647e"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.14.0"
+version = "2.15.0"
 
 [[deps.FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
@@ -578,9 +583,9 @@ version = "0.8.4"
 
 [[deps.Flux]]
 deps = ["Adapt", "ArrayInterface", "CUDA", "ChainRulesCore", "Functors", "LinearAlgebra", "MLUtils", "MacroTools", "NNlib", "NNlibCUDA", "Optimisers", "ProgressLogging", "Random", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "Test", "Zygote"]
-git-tree-sha1 = "96dc065bf4a998e8adeebc0ff1302902b6e59362"
+git-tree-sha1 = "9b5419ad6f043ac2b52f1b7f9a8ecb8762231214"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.4"
+version = "0.13.5"
 
 [[deps.Fontconfig_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
@@ -596,9 +601,9 @@ version = "0.4.2"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "2f18915445b248731ec5db4e4a17e451020bf21e"
+git-tree-sha1 = "187198a4ed8ccd7b5d99c41b69c679269ea2b2d4"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.30"
+version = "0.10.32"
 
 [[deps.FreeType]]
 deps = ["CEnum", "FreeType2_jll"]
@@ -630,9 +635,10 @@ uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 version = "1.1.2"
 
 [[deps.Functors]]
-git-tree-sha1 = "223fffa49ca0ff9ce4f875be001ffe173b2b7de4"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "a2657dd0f3e8a61dbe70fc7c122038bd33790af5"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.2.8"
+version = "0.3.0"
 
 [[deps.Future]]
 deps = ["Random"]
@@ -640,9 +646,9 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[deps.GLFW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
-git-tree-sha1 = "51d2dfe8e590fbd74e7a842cf6d13d8a2f45dc01"
+git-tree-sha1 = "d972031d28c8c8d9d7b41a536ad7bb0c2579caca"
 uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
-version = "3.3.6+0"
+version = "3.3.8+0"
 
 [[deps.GPUArrays]]
 deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
@@ -658,9 +664,9 @@ version = "0.1.1"
 
 [[deps.GPUCompiler]]
 deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "1067cd05184719ba86f19cf1d49d57f0bcbabbf6"
+git-tree-sha1 = "122d7bcc92abf94cf1a86281ad7a4d0e838ab9e0"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "0.16.2"
+version = "0.16.3"
 
 [[deps.GR]]
 deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
@@ -686,11 +692,17 @@ git-tree-sha1 = "fb69b2a645fa69ba5f474af09221b9308b160ce6"
 uuid = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 version = "0.5.3"
 
+[[deps.GeoInterface]]
+deps = ["Extents"]
+git-tree-sha1 = "fb28b5dc239d0174d7297310ef7b84a11804dfab"
+uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+version = "1.0.1"
+
 [[deps.GeometryBasics]]
-deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "83ea630384a13fc4f002b77690bc0afeb4255ac9"
+deps = ["EarCut_jll", "GeoInterface", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "a7a97895780dab1085a97769316aa348830dc991"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.4.2"
+version = "0.4.3"
 
 [[deps.Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -757,9 +769,9 @@ version = "1.12.0+1"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "Dates", "IniFile", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "ed47af35905b7cc8f1a522ca684b35a212269bd8"
+git-tree-sha1 = "f0956f8d42a92816d2bf062f8a6a6a0ad7f9b937"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
@@ -834,10 +846,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.Interpolations]]
-deps = ["AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
-git-tree-sha1 = "b7bc05649af456efc75d178846f47006c2c4c3c7"
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "64f138f9453a018c8f3562e7bae54edc059af249"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.13.6"
+version = "0.14.4"
 
 [[deps.IntervalSets]]
 deps = ["Dates", "Random", "Statistics"]
@@ -910,9 +922,9 @@ version = "2.1.2+0"
 
 [[deps.JumpProcesses]]
 deps = ["ArrayInterfaceCore", "DataStructures", "DiffEqBase", "DocStringExtensions", "FunctionWrappers", "Graphs", "LinearAlgebra", "Markdown", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SciMLBase", "StaticArrays", "TreeViews", "UnPack"]
-git-tree-sha1 = "4aa139750616fee7216ddcb30652357c60c3683e"
+git-tree-sha1 = "065462b4dcf2ca4de9701cc86e20f24570ae4bac"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
-version = "9.0.1"
+version = "9.1.0"
 
 [[deps.KLU]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
@@ -928,9 +940,9 @@ version = "0.7.2"
 
 [[deps.KernelDensity]]
 deps = ["Distributions", "DocStringExtensions", "FFTW", "Interpolations", "StatsBase"]
-git-tree-sha1 = "0a7ca818440ce8c70ebb5d42ac4ebf3205675f04"
+git-tree-sha1 = "9816b296736292a80b9a3200eb7fbb57aaa3917a"
 uuid = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
-version = "0.6.4"
+version = "0.6.5"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
@@ -1102,15 +1114,15 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterfaceCore", "DocStringExtensions", "FastLapackInterface", "GPUArraysCore", "IterativeSolvers", "KLU", "Krylov", "KrylovKit", "LinearAlgebra", "RecursiveFactorization", "Reexport", "SciMLBase", "Setfield", "SparseArrays", "SuiteSparse", "UnPack"]
-git-tree-sha1 = "92cc95b66f1459d230af9e67089eeeea6c6b2ee9"
+git-tree-sha1 = "c48c190442b22c94499a446b8b452f16d04a258c"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "1.23.0"
+version = "1.23.3"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7c88f63f9f0eb5929f15695af9a4d7d3ed278a91"
+git-tree-sha1 = "361c2b088575b07946508f135ac556751240091c"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.16"
+version = "0.3.17"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -1147,15 +1159,15 @@ version = "0.5.9"
 
 [[deps.Makie]]
 deps = ["Animations", "Base64", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Distributions", "DocStringExtensions", "FFMPEG", "FileIO", "FixedPointNumbers", "Formatting", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MakieCore", "Markdown", "Match", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "Printf", "Random", "RelocatableFolders", "Serialization", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "UnicodeFun"]
-git-tree-sha1 = "c27ed640732b1e9bd7bb8f40d987873d8f5b4bca"
+git-tree-sha1 = "b0323393a7190c9bf5b03af442fc115756df8e59"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.17.12"
+version = "0.17.13"
 
 [[deps.MakieCore]]
 deps = ["Observables"]
-git-tree-sha1 = "9bd42b962d5c6182fa0d74b1970edb075fe313e5"
+git-tree-sha1 = "fbf705d2bdea8fc93f1ae8ca2965d8e03d4ca98c"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.3.6"
+version = "0.4.0"
 
 [[deps.ManualMemory]]
 git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
@@ -1190,9 +1202,9 @@ version = "0.4.3"
 
 [[deps.MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "Random", "Sockets"]
-git-tree-sha1 = "9f4f5a42de3300439cb8300236925670f844a555"
+git-tree-sha1 = "d9ab10da9de748859a7780338e1d6566993d1f25"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.1.1"
+version = "1.1.3"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -1290,9 +1302,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[deps.NonlinearSolve]]
 deps = ["ArrayInterfaceCore", "FiniteDiff", "ForwardDiff", "IterativeSolvers", "LinearAlgebra", "RecursiveArrayTools", "RecursiveFactorization", "Reexport", "SciMLBase", "Setfield", "StaticArrays", "UnPack"]
-git-tree-sha1 = "932bbdc22e6a2e0bae8dec35d32e4c8cb6c50f98"
+git-tree-sha1 = "a754a21521c0ab48d37f44bbac1eefd1387bdcfc"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "0.3.21"
+version = "0.3.22"
 
 [[deps.Observables]]
 git-tree-sha1 = "dfd8d34871bc3ad08cd16026c1828e271d554db9"
@@ -1357,9 +1369,9 @@ version = "1.7.1"
 
 [[deps.Optimisers]]
 deps = ["ChainRulesCore", "Functors", "LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "62844c5525c3f13b3107aa2c25a06208ecadde88"
+git-tree-sha1 = "1ef34738708e3f31994b52693286dabcb3d29f6b"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
-version = "0.2.8"
+version = "0.2.9"
 
 [[deps.Opus_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1398,9 +1410,9 @@ version = "0.3.16"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs"]
-git-tree-sha1 = "52ab501c2201e140954924365ef06a36ba1d97ed"
+git-tree-sha1 = "c497e2bb9c2127a411b74dbff56b11f258d67d12"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.0.7"
+version = "2.0.9"
 
 [[deps.Packing]]
 deps = ["GeometryBasics"]
@@ -1461,10 +1473,10 @@ uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.3.0"
 
 [[deps.Plots]]
-deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "0a0da27969e8b6b2ee67c112dcf7001a659049a0"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
+git-tree-sha1 = "a19652399f43938413340b2068e11e55caa46b65"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.31.4"
+version = "1.31.7"
 
 [[deps.PoissonRandom]]
 deps = ["Random"]
@@ -1480,9 +1492,9 @@ version = "0.6.12"
 
 [[deps.PolyesterWeave]]
 deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
-git-tree-sha1 = "cf82af4e114b0da31c4896aef6c5b8be3fe0916d"
+git-tree-sha1 = "cf8155767df6ec8fd21b49e81ec8a8099e1a5f96"
 uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.PolygonOps]]
 git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
@@ -1496,10 +1508,10 @@ uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
 version = "0.2.4"
 
 [[deps.PreallocationTools]]
-deps = ["Adapt", "ArrayInterfaceCore", "ForwardDiff"]
-git-tree-sha1 = "ba66bf03b84ca3bd0a26aa2bbe96cd9df2f4f9b9"
+deps = ["Adapt", "ArrayInterfaceCore", "ForwardDiff", "ReverseDiff"]
+git-tree-sha1 = "5c076a409ec8d2a86d3685a7e4fed330cd489889"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.0"
+version = "0.4.2"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -1561,9 +1573,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Random123]]
 deps = ["Random", "RandomNumbers"]
-git-tree-sha1 = "afeacaecf4ed1649555a19cb2cad3c141bbc9474"
+git-tree-sha1 = "7a1a306b72cfa60634f03a911405f4e64d1b718b"
 uuid = "74087812-796a-5b5d-8853-05524746bad3"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.RandomNumbers]]
 deps = ["Random", "Requires"]
@@ -1590,15 +1602,15 @@ version = "1.2.1"
 
 [[deps.RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "2690681814016887462cf5ac37102b51cd9ec781"
+git-tree-sha1 = "e7eac76a958f8664f2718508435d058168c7953d"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.6.2"
+version = "0.6.3"
 
 [[deps.RecursiveArrayTools]]
-deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "4ce7584604489e537b2ab84ed92b4107d03377f0"
+deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArraysCore", "ChainRulesCore", "DocStringExtensions", "FillArrays", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "Tables", "ZygoteRules"]
+git-tree-sha1 = "3004608dc42101a944e44c1c68b599fa7c669080"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "2.31.2"
+version = "2.32.0"
 
 [[deps.RecursiveFactorization]]
 deps = ["LinearAlgebra", "LoopVectorization", "Polyester", "StrideArraysCore", "TriangularSolve"]
@@ -1628,6 +1640,12 @@ deps = ["StaticArrays"]
 git-tree-sha1 = "256eeeec186fa7f26f2801732774ccf277f05db9"
 uuid = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
 version = "1.1.1"
+
+[[deps.ReverseDiff]]
+deps = ["ChainRulesCore", "DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
+git-tree-sha1 = "b8e2eb3d8e1530acb73d8949eab3cedb1d43f840"
+uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+version = "1.14.1"
 
 [[deps.Richardson]]
 deps = ["LinearAlgebra"]
@@ -1710,9 +1728,9 @@ version = "0.3.3"
 
 [[deps.SciMLBase]]
 deps = ["ArrayInterfaceCore", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "RecipesBase", "RecursiveArrayTools", "StaticArraysCore", "Statistics", "Tables"]
-git-tree-sha1 = "7cb46ff55af945a8b68e148bf22f9325f7221d8d"
+git-tree-sha1 = "bcbc793b4006179c5a146d3d6afa9c699a14d03c"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "1.45.0"
+version = "1.48.1"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1724,10 +1742,10 @@ version = "1.1.1"
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[deps.Setfield]]
-deps = ["ConstructionBase", "Future", "MacroTools", "Requires"]
-git-tree-sha1 = "77172cadd2fdfa0c84c87e3a01215a4ca7723310"
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "e5364b687e552d73543cf09e583b944eaffff6c4"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "1.0.0"
+version = "1.1.0"
 
 [[deps.SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
@@ -1767,6 +1785,11 @@ git-tree-sha1 = "8fb59825be681d451c246a795117f317ecbcaa28"
 uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
 version = "0.1.2"
 
+[[deps.SnoopPrecompile]]
+git-tree-sha1 = "3841791b9d1a4d5a4394d7eb4c43f42303a20e0c"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+version = "1.0.0"
+
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -1782,9 +1805,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.SparseDiffTools]]
 deps = ["Adapt", "ArrayInterfaceCore", "ArrayInterfaceStaticArrays", "Compat", "DataStructures", "FiniteDiff", "ForwardDiff", "Graphs", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays", "VertexSafeGraphs"]
-git-tree-sha1 = "32025c052719c6353f22f7c6de7d7b97b7cd2c88"
+git-tree-sha1 = "9287f8a1831e7b978f609a4c52c8b94ba6e863ad"
 uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "1.24.0"
+version = "1.25.1"
 
 [[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -1806,14 +1829,14 @@ version = "0.6.6"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "23368a3313d12a2326ad0035f0db0c0966f438ef"
+git-tree-sha1 = "2d4e51cfad63d2d34acde558027acbc66700349b"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.2"
+version = "1.5.3"
 
 [[deps.StaticArraysCore]]
-git-tree-sha1 = "66fe9eb253f910fe8cf161953880cfdaef01cdf0"
+git-tree-sha1 = "5b413a57dd3cea38497d745ce088ac8592fbb5be"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.0.1"
+version = "1.1.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -1821,15 +1844,15 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "2c11d7290036fe7aac9038ff312d3b3a2a5bf89e"
+git-tree-sha1 = "f9af7f195fb13589dd2e2d57fdb401717d2eb1f6"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.4.0"
+version = "1.5.0"
 
 [[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "0005d75f43ff23688914536c5e9d5ac94f8077f7"
+git-tree-sha1 = "d1bf48bfcc554a3761a133fe3a9bb01488e06916"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.20"
+version = "0.33.21"
 
 [[deps.StatsFuns]]
 deps = ["ChainRulesCore", "HypergeometricFunctions", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
@@ -1839,9 +1862,9 @@ version = "1.0.1"
 
 [[deps.StochasticDiffEq]]
 deps = ["Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqNoiseProcess", "DocStringExtensions", "FillArrays", "FiniteDiff", "ForwardDiff", "JumpProcesses", "LevyArea", "LinearAlgebra", "Logging", "MuladdMacro", "NLsolve", "OrdinaryDiffEq", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SciMLBase", "SparseArrays", "SparseDiffTools", "StaticArrays", "UnPack"]
-git-tree-sha1 = "a518b59fe62a07e007c8f7913e14e2fae697c8a7"
+git-tree-sha1 = "a13569d9c5b2a7b35ce0462864138383fceab26f"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "6.51.0"
+version = "6.52.0"
 
 [[deps.StrideArraysCore]]
 deps = ["ArrayInterface", "CloseOpenIntervals", "IfElse", "LayoutPointers", "ManualMemory", "SIMDTypes", "Static", "ThreadingUtilities"]
@@ -1865,9 +1888,9 @@ uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
 
 [[deps.SurfaceFluxes]]
 deps = ["DocStringExtensions", "KernelAbstractions", "RootSolvers", "StaticArrays", "Thermodynamics"]
-git-tree-sha1 = "dd0ec993bf32e20ca385c8ac554dc8123ffe3b21"
+git-tree-sha1 = "a2271e67a53379a1547ddb4846a47e5e3248ab65"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
-version = "0.4.1"
+version = "0.4.3"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -1918,9 +1941,9 @@ version = "1.0.1"
 
 [[deps.Thermodynamics]]
 deps = ["DocStringExtensions", "KernelAbstractions", "Random", "RootSolvers"]
-git-tree-sha1 = "72c84f7322bf3f03ed648b2ca6b491e1d74b087f"
+git-tree-sha1 = "0ff7428af31cc2925d29384144d495aef19b9047"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
-version = "0.9.1"
+version = "0.9.3"
 
 [[deps.ThreadingUtilities]]
 deps = ["ManualMemory"]
@@ -1953,10 +1976,10 @@ uuid = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 version = "0.3.0"
 
 [[deps.TriangularSolve]]
-deps = ["CloseOpenIntervals", "IfElse", "LayoutPointers", "LinearAlgebra", "LoopVectorization", "Polyester", "Static", "VectorizationBase"]
-git-tree-sha1 = "caf797b6fccbc0d080c44b4cb2319faf78c9d058"
+deps = ["CloseOpenIntervals", "IfElse", "LayoutPointers", "LinearAlgebra", "LoopVectorization", "Polyester", "SnoopPrecompile", "Static", "VectorizationBase"]
+git-tree-sha1 = "8987cf4a0f8d6c375e4ab1438a048e0a185151e4"
 uuid = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
-version = "0.1.12"
+version = "0.1.13"
 
 [[deps.Tullio]]
 deps = ["ChainRulesCore", "DiffRules", "LinearAlgebra", "Requires"]
@@ -1966,9 +1989,9 @@ version = "0.3.4"
 
 [[deps.TurbulenceConvection]]
 deps = ["ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "Random", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "e29d602a3df6a23567d6b17e5968b2579d6a471c"
+git-tree-sha1 = "0c04cb4ee2f6e92ab8b2ccbf26398a8e50c5524c"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "0.34.3"
+version = "0.34.6"
 
 [[deps.URIs]]
 git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"
@@ -2000,9 +2023,9 @@ version = "0.1.2"
 
 [[deps.VectorizationBase]]
 deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static"]
-git-tree-sha1 = "81d19dae338dd4cf3ecd6331fb4763a1002f9580"
+git-tree-sha1 = "a0b74e8247f30420ba25c8fcfc1c69cb84ff8cff"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.21.43"
+version = "0.21.46"
 
 [[deps.VertexSafeGraphs]]
 deps = ["Graphs"]
@@ -2183,10 +2206,10 @@ uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
 version = "1.5.2+0"
 
 [[deps.Zygote]]
-deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "3cfdb31b517eec4173584fba2b1aa65daad46e09"
+deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "GPUArrays", "GPUArraysCore", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
+git-tree-sha1 = "91822d41345b9b9b84babe4debd18dd6ccf45311"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.41"
+version = "0.6.43"
 
 [[deps.ZygoteRules]]
 deps = ["MacroTools"]
@@ -2262,6 +2285,6 @@ version = "3.5.0+0"
 
 [[deps.xkbcommon_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
-git-tree-sha1 = "ece2350174195bb31de1a63bea3a41ae1aa593b6"
+git-tree-sha1 = "9ebfc140cc56e8c2156a15ceac2f0302e327ac0a"
 uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
-version = "0.9.1+5"
+version = "1.4.1+0"

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -221,9 +221,9 @@ version = "0.3.10"
 
 [[deps.ChainRules]]
 deps = ["Adapt", "ChainRulesCore", "Compat", "Distributed", "GPUArraysCore", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "Statistics", "StructArrays"]
-git-tree-sha1 = "82e91ef81cc0022a185ca3d0e6f9ca393e423c86"
+git-tree-sha1 = "650415ad4c2a007b17f577cb081d9376cc908b6f"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.44.1"
+version = "1.44.2"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -1829,9 +1829,9 @@ version = "0.6.6"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "2d4e51cfad63d2d34acde558027acbc66700349b"
+git-tree-sha1 = "8803c6dea034ab8cd988abe4a91e5589d61c7416"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.3"
+version = "1.5.4"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "5b413a57dd3cea38497d745ce088ac8592fbb5be"

--- a/run_tests.sbatch
+++ b/run_tests.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --time=0:20:00   # walltime
+#SBATCH --time=0:40:00   # walltime
 #SBATCH --ntasks=1  # number of processor cores (i.e. tasks)
 #SBATCH --nodes=1   # number of nodes
 #SBATCH --mem-per-cpu=10G   # memory per CPU core


### PR DESCRIPTION
## Changes

- Adds the CNRM-CM5 cases to the allowable TC cases through TC functions, unifies LES libraries with TC codebase.
- Adds a new benchmark, SCT3, with 135 training sites from the AMIP archive (HadGEM2-A + CNRM-CM5), and 15 AMIP4K validation sites from the HadGEM2-A model.
- The SCT3 benchmark should at least contain a config file to calibrate exclusively the data-driven entrainment closure, used as an additive term to the MD closure.
- No regularization used.
- Localization used.
- All physical parameters trained a priori and set to the trained values as defaults through `namelist_args`.

## Issue number (if applicable)

Closes #436 

## Checklist before requesting a review / merging
- [ ] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [ ] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [ ] If core features are added, I have added appropriate test coverage.
- [ ] If new functions and structs are added, they are documented through docstrings.