### PR TITLE
Update SCT3 to account for new LES cases

### DIFF
--- a/experiments/SCT3_benchmark/global_parallel/init.sbatch
+++ b/experiments/SCT3_benchmark/global_parallel/init.sbatch
@@ -3,7 +3,7 @@
 #SBATCH --time=2:00:00   # walltime
 #SBATCH --ntasks=1       # number of processor cores (i.e. tasks)
 #SBATCH --nodes=1         # number of nodes
-#SBATCH --mem-per-cpu=20G   # memory per CPU core
+#SBATCH --mem-per-cpu=50G   # memory per CPU core
 #SBATCH -J "sct_init"   # job name
 
 #julia package management

--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -364,9 +364,9 @@ uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
 version = "0.2.0"
 
 [[deps.DataAPI]]
-git-tree-sha1 = "1106fa7e1256b402a86a8e7b15c00c85036fef49"
+git-tree-sha1 = "46d2680e618f8abd007bce0c3026cb0c4a8f2032"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.11.0"
+version = "1.12.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -2000,9 +2000,9 @@ version = "0.3.5"
 
 [[deps.TurbulenceConvection]]
 deps = ["ClimaCore", "CloudMicrophysics", "Dierckx", "Distributions", "DocStringExtensions", "FastGaussQuadrature", "Flux", "LambertW", "LinearAlgebra", "OperatorFlux", "Random", "SciMLBase", "StaticArrays", "StatsBase", "StochasticDiffEq", "SurfaceFluxes", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "67835b31d60e7fa00d4acbb6fb8c6458f483a5a3"
+git-tree-sha1 = "dbe6eea6b0bf555554cb110e6ce0fc63c34edc06"
 uuid = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.URIs]]
 git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"


### PR DESCRIPTION
## Changes
Update SCT3 to account for new LES library included in TC `v1.2.0`. Specifies 200 LES cases instead of the full 203 to allow for more batch size options. 

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.