### PR TITLE
Fix mixed LES/SCM ReferenceModels for LES_driven_SCM.

### DIFF
--- a/driver/create_tc_so.jl
+++ b/driver/create_tc_so.jl
@@ -13,6 +13,7 @@ if isempty(Glob.glob("CEDMF.so"))
     # Avoid unnecessary pkgs, and packages that are in julia's Base.loaded_modules
     do_not_compile_pkgs = [
         :CairoMakie,
+        :Makie,
         :ForwardDiff,
         :PackageCompiler,
         :NPZ,

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -118,7 +118,7 @@ function ReferenceModel(
     seed::OptInt = nothing,
 )
     if case_name == "LES_driven_SCM"
-        @assert isa(y_type, LES) or isa (Σ_type, LES) "LES data must be used in the construction of LES_driven_SCM ReferenceModels."
+        @assert isa(y_type, LES) || isa(Σ_type, LES) "LES data must be used in the construction of LES_driven_SCM ReferenceModels."
     end
     les_dir = isa(y_type, LES) ? y_dir : Σ_dir
 
@@ -319,7 +319,7 @@ end
     time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
 
 Returns a time-shifted ReferenceModel, considering an interval relative to the last
-available time step of the original model.
+available time step of the original model. Only LES data (from y_dir or Σ_dir) are time shifted.
 
 Inputs:
 
@@ -332,11 +332,15 @@ Outputs:
 """
 function time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
     filename = y_nc_file(m)
-    t = nc_fetch(filename, "t")
-    t_start = t[end] - Δt + get_t_start(m)
-    t_end = t[end] - Δt + get_t_end(m)
-    Σ_t_start = t[end] - Δt + get_t_start_Σ(m)
-    Σ_t_end = t[end] - Δt + get_t_end_Σ(m)
+    t_mean = nc_fetch(filename, "t")
+
+    filename = Σ_nc_file(m)
+    t_Σ = nc_fetch(filename, "t")
+
+    t_start = isa(m.y_type, LES) ? t_mean[end] - Δt + get_t_start(m) : get_t_start(m)
+    t_end = isa(m.y_type, LES) ? t_mean[end] - Δt + get_t_end(m) : get_t_end(m)
+    Σ_t_start = isa(m.Σ_type, LES) ? t_Σ[end] - Δt + get_t_start_Σ(m) : get_t_start_Σ(m)
+    Σ_t_end = isa(m.Σ_type, LES) ? t_Σ[end] - Δt + get_t_end_Σ(m) : get_t_end_Σ(m)
 
     @assert t_start >= 0 "t_start must be positive after time shift, but $t_start was given."
     @assert Σ_t_start >= 0 "Σ_t_start must be positive after time shift, but $Σ_t_start was given."


### PR DESCRIPTION
## Changes

Fixes some issues regarding the use of perfect model experiments with LES_driven_SCM configs. In particular, the time_shift function assumed that the time coordinate was identical for the observations and the data used to generate the noise, which need not be the case if we take the mean from an `SCM()` and the noise from `LES()`.

## Issue number (if applicable)

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [ ] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.7.3.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.