### PR TITLE
Ensure order-agnostic config prior specification

### DIFF
--- a/integration_tests/Manifest.toml
+++ b/integration_tests/Manifest.toml
@@ -1610,9 +1610,9 @@ version = "1.3.1"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "47e70b391ff314cc36e7c2400f7d2c5455dc9496"
+git-tree-sha1 = "5955a002262c08ab155ed2a6f1bb0787fedf5939"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.36.1"
+version = "1.36.2"
 
 [[deps.PoissonRandom]]
 deps = ["Random"]
@@ -1984,9 +1984,9 @@ version = "0.7.8"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "f86b3a049e5d05227b10e15dbb315c5b90f14988"
+git-tree-sha1 = "4e051b85454b4e4f66e6a6b7bdc452ad9da3dcf6"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.9"
+version = "1.5.10"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"

--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -24,6 +24,8 @@ export vertical_interpolation,
     scm_val_init_path,
     scm_val_output_path,
     ekobj_path,
+    keys_ordered,
+    values_ordered,
     write_versions,
     expand_dict_entry,
     get_entry,
@@ -623,6 +625,24 @@ function write_versions(versions::Vector{String}, iteration::Int; outdir_path::S
     open(joinpath(outdir_path, "versions_$(iteration).txt"), "w") do io
         println.(Ref(io), versions)
     end
+end
+
+"""
+    keys_ordered(dict::Dict{String, Vector{FT}})
+Return sorted keys in a dictionary.
+
+"""
+function keys_ordered(dict::Dict)
+    return sort(collect(keys(dict)))
+end
+
+"""
+    values_ordered(dict::Dict{String, Vector{FT}})
+Return sorted values in a dictionary in a manner complementary to `keys_ordered`.
+
+"""
+function values_ordered(dict::Dict)
+    return [dict[key] for key in keys_ordered(dict)]
 end
 
 "Returns the N-vector stored in `dict[key]`, or an N-vector of `nothing`"

--- a/src/KalmanProcessUtils.jl
+++ b/src/KalmanProcessUtils.jl
@@ -194,7 +194,7 @@ function generate_tekp(
         if any(1 .< [length(val) for val in collect(values(l2_reg))])
             _, l2_reg_values = flatten_config_dict(l2_reg)
         else
-            l2_reg_values = collect(values(l2_reg))
+            l2_reg_values = values_ordered(l2_reg)
         end
         l2_reg_values = vcat(l2_reg_values...)
 

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -109,7 +109,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     )
 
     if !isnothing(prior_μ)
-        @assert collect(keys(params)) == collect(keys(prior_μ))
+        @assert keys_ordered(params) == keys_ordered(prior_μ)
     else
         prior_μ = nothing
     end


### PR DESCRIPTION
## Changes
The behavior of `keys` seems to have changed in julia 1.8, such that calling `collect(keys())` on the prior constraint and mean dicts separately doesn't necessarily result in the same key ordering. This PR ensures `construct_priors` is order-agnostic.

## Checklist before requesting a review / merging
- [x] I have formatted the code using `julia --project=.dev .dev/climaformat.jl .`
- [x] I have updated all test manifests using `julia --project .dev/up_deps.jl .` with Julia 1.8.2.
- [x] If core features are added, I have added appropriate test coverage.
- [x] If new functions and structs are added, they are documented through docstrings.