### PR TITLE
Ensure create_parameter_vectors preserves vector component order

### DIFF
--- a/src/HelperFuncs.jl
+++ b/src/HelperFuncs.jl
@@ -173,7 +173,7 @@ function expand_params(u_names_calib::AbstractVector, u_calib::AbstractVector, p
         end
     end
 
-    return collect.((keys(params), values(params)))
+    return (collect(keys_ordered(params)), collect(values_ordered(params)))
 end
 
 """
@@ -686,12 +686,30 @@ function write_versions(versions::Vector{String}, iteration::Int; outdir_path::S
 end
 
 """
+    increasing_sort(s1::String, s2::String)
+Custom sorting function used in keys_ordered. If parameter vectors are present, sort components
+in increasing order. (ie. paramA, paramB_{1}, paramB_{2}, ... paramB_{n}, paramC)
+
+"""
+function increasing_sort(s1::String, s2::String)
+    # Extract the numbers following the underscore, if any
+    match1 = match(r"_\{(\d+)\}", s1)
+    match2 = match(r"_\{(\d+)\}", s2)
+    num1 = isnothing(match1) ? -1 : parse(Int, match1.captures[1])
+    num2 = isnothing(match2) ? -1 : parse(Int, match2.captures[1])
+
+    # Sort by number, and then by the original strings
+    return num1 < num2 || (num1 == num2 && s1 < s2)
+end
+
+
+"""
     keys_ordered(dict::Dict{String, Vector{FT}})
 Return sorted keys in a dictionary.
 
 """
 function keys_ordered(dict::Dict)
-    return sort(collect(keys(dict)))
+    return sort(collect(keys(dict)), lt = increasing_sort)
 end
 
 """

--- a/src/TurbulenceConvectionUtils.jl
+++ b/src/TurbulenceConvectionUtils.jl
@@ -430,7 +430,6 @@ function create_parameter_vectors(
     filter_vec_params = filter(!isnothing, find_vec_params)
     u_vec_names = getindex.(filter_vec_params, 1)
     u_vec_inds = getindex.(filter_vec_params, 2)
-
     # collect scalar parameters
     scalar_param_inds = isnothing.(find_vec_params)
     append!(u_names_out, u_names[scalar_param_inds])
@@ -441,7 +440,8 @@ function create_parameter_vectors(
     for u_name in unique(u_vec_names)
         u_name_inds = u_vec_names .== u_name
         u_vals = u[vector_param_inds][u_name_inds]
-        u_vals_sort_inds = sortperm(u_vec_inds[u_name_inds])
+        u_inds_int = parse.(Int, u_vec_inds[u_name_inds])  # Parse indices as integers
+        u_vals_sort_inds = sortperm(u_inds_int)
         permute!(u_vals, u_vals_sort_inds)
         push!(u_names_out, u_name)
         push!(u_out, u_vals)

--- a/test/TurbulenceConvectionUtils/runtests.jl
+++ b/test/TurbulenceConvectionUtils/runtests.jl
@@ -40,6 +40,29 @@ import CalibrateEDMF.HelperFuncs: do_nothing_param_map, change_entry!, update_na
         @test all(u_names_out .∈ [["foo", "bar"]])
         @test only(u_out[u_names_out .== "foo"]) == 2.0
         @test only(u_out[u_names_out .== "bar"]) == [3.0, 1.0]
+
+        # scalars and larger vector parameter, sorted
+        vect_names = ["bar_{$(i)}" for i in 1:20]
+        u_names = ["foo", vect_names..., "baz"]
+        u = randn(length(u_names))
+        param_map = do_nothing_param_map()
+        u_names_out, u_out = create_parameter_vectors(u_names, u, param_map, namelist)
+        @test all(u_names_out .∈ [["foo", "bar", "baz"]])
+        @test only(u_out[u_names_out .== "foo"]) == u[1]
+        @test only(u_out[u_names_out .== "baz"]) == u[end]
+        @test only(u_out[u_names_out .== "bar"]) == u[2:21]
+
+        # scalars and larger vector parameter, decreasing order
+        # check that parameter vectors components are in increasing order (sorted by vector component index)
+        vect_names = ["bar_{$(i)}" for i in 22:-1:1]
+        u_names = ["foo", vect_names..., "baz"]
+        u = randn(length(u_names))
+        param_map = do_nothing_param_map()
+        u_names_out, u_out = create_parameter_vectors(u_names, u, param_map, namelist)
+        @test all(u_names_out .∈ [["foo", "bar", "baz"]])
+        @test only(u_out[u_names_out .== "foo"]) == u[1]
+        @test only(u_out[u_names_out .== "baz"]) == u[end]
+        @test only(u_out[u_names_out .== "bar"]) == u[23:-1:2]
     end
 
     @test get_gcm_les_uuid(1, forcing_model = "model1", month = 1, experiment = "experiment1") ==


### PR DESCRIPTION
Ensure `create_parameter_vectors` preserves vector component order. 
`sortperm` was previously sorting strings, not vector indices. This did not affect the quality of calibrations, but made it difficult to interpret vector components after calibration (since they were being reordered). 