### PR TITLE
Allow reference model time_shift to be specified in config

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,7 @@
 CalibrateEDMF = "fbaf683a-b9b3-4040-be64-6c4c04986dd0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+
+[compat]
+Documenter = "0.27"
+DocumenterCitations = "1"

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -129,7 +129,7 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         elseif algo_name == "Sampler"
             algo = Sampler(vcat(mean(priors)...), cov(priors))
         end
-        initial_params = construct_initial_ensemble(priors, N_ens, rng_seed = rand(1:1000))
+        initial_params = construct_initial_ensemble(priors, N_ens)
         if augmented
             ekobj = generate_tekp(ref_stats, priors, algo, initial_params; l2_reg = l2_reg, ekp_kwargs...)
         else
@@ -173,6 +173,7 @@ end
 
 function get_ref_stats_kwargs(ref_config::Dict{Any, Any}, reg_config::Dict{Any, Any})
     model_errors = get_entry(ref_config, "model_errors", nothing)
+    time_shift = get_entry(ref_config, "time_shift", 6.0 * 3600.0)
     perform_PCA = get_entry(reg_config, "perform_PCA", true)
     variance_loss = get_entry(reg_config, "variance_loss", 1.0e-2)
     normalize = get_entry(reg_config, "normalize", true)
@@ -187,6 +188,7 @@ function get_ref_stats_kwargs(ref_config::Dict{Any, Any}, reg_config::Dict{Any, 
         :tikhonov_mode => tikhonov_mode,
         :dim_scaling => dim_scaling,
         :model_errors => model_errors,
+        :time_shift => time_shift,
     )
 end
 

--- a/src/ReferenceModels.jl
+++ b/src/ReferenceModels.jl
@@ -316,7 +316,7 @@ function construct_reference_models(kwarg_ld::Dict; seed::OptInt = nothing)::Vec
 end
 
 """
-    time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
+    time_shift_reference_model(m::ReferenceModel, time_shift::FT) where {FT <: Real}
 
 Returns a time-shifted ReferenceModel, considering an interval relative to the last
 available time step of the original model. Only LES data (from y_dir or Σ_dir) are time shifted.
@@ -324,23 +324,23 @@ available time step of the original model. Only LES data (from y_dir or Σ_dir) 
 Inputs:
 
  - `m`     :: A ReferenceModel.
- - `Δt`  :: [LES last time - SCM start time (LES timeframe)]
+ - `time_shift`  :: [LES last time - SCM start time (LES timeframe)]
 
 Outputs:
 
  - The time-shifted ReferenceModel.
 """
-function time_shift_reference_model(m::ReferenceModel, Δt::FT) where {FT <: Real}
+function time_shift_reference_model(m::ReferenceModel, time_shift::FT) where {FT <: Real}
     filename = y_nc_file(m)
     t_mean = nc_fetch(filename, "t")
 
     filename = Σ_nc_file(m)
     t_Σ = nc_fetch(filename, "t")
 
-    t_start = isa(m.y_type, LES) ? t_mean[end] - Δt + get_t_start(m) : get_t_start(m)
-    t_end = isa(m.y_type, LES) ? t_mean[end] - Δt + get_t_end(m) : get_t_end(m)
-    Σ_t_start = isa(m.Σ_type, LES) ? t_Σ[end] - Δt + get_t_start_Σ(m) : get_t_start_Σ(m)
-    Σ_t_end = isa(m.Σ_type, LES) ? t_Σ[end] - Δt + get_t_end_Σ(m) : get_t_end_Σ(m)
+    t_start = isa(m.y_type, LES) ? t_mean[end] - time_shift + get_t_start(m) : get_t_start(m)
+    t_end = isa(m.y_type, LES) ? t_mean[end] - time_shift + get_t_end(m) : get_t_end(m)
+    Σ_t_start = isa(m.Σ_type, LES) ? t_Σ[end] - time_shift + get_t_start_Σ(m) : get_t_start_Σ(m)
+    Σ_t_end = isa(m.Σ_type, LES) ? t_Σ[end] - time_shift + get_t_end_Σ(m) : get_t_end_Σ(m)
 
     @assert t_start >= 0 "t_start must be positive after time shift, but $t_start was given."
     @assert Σ_t_start >= 0 "Σ_t_start must be positive after time shift, but $Σ_t_start was given."

--- a/src/ReferenceStats.jl
+++ b/src/ReferenceStats.jl
@@ -37,7 +37,7 @@ $(TYPEDFIELDS)
         tikhonov_noise::FT = 0.0,
         tikhonov_mode::String = "absolute",
         dim_scaling::Bool = false,
-        Δt::FT = 6 * 3600.0,
+        time_shift::FT = 6 * 3600.0,
         model_errors::OptVec{T} = nothing,
     ) where {FT <: Real}
 
@@ -54,7 +54,7 @@ Inputs:
     the inverse of the desired condition number. This value is enforced to be
     larger than the sqrt of the machine precision for stability.
  - `dim_scaling`      :: Whether to scale covariance blocks by their size.
- - `Δt`               :: [LES last time - SCM start time (LES timeframe)] for `LES_driven_SCM` cases.
+ - `time_shift`               :: [LES last time - SCM start time (LES timeframe)] for `LES_driven_SCM` cases.
  - `model_errors`     :: Vector of model errors added to the internal variability noise, each containing
                             the model error per variable normalized by the pooled variable variance.
 """
@@ -87,7 +87,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real, IT <: Integer}
         tikhonov_noise::FT = 0.0,
         tikhonov_mode::String = "absolute",
         dim_scaling::Bool = false,
-        Δt::FT = 6 * 3600.0,
+        time_shift::FT = 6 * 3600.0,
         model_errors::OptVec{T} = nothing,
     ) where {FT <: Real, T}
         IT = Int64
@@ -103,7 +103,7 @@ Base.@kwdef struct ReferenceStatistics{FT <: Real, IT <: Integer}
         zdof = IT[]
 
         for (i, m) in enumerate(RM)
-            model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, Δt) : m
+            model = m.case_name == "LES_driven_SCM" ? time_shift_reference_model(m, time_shift) : m
             model_error = !isnothing(model_errors) ? model_errors[i] : nothing
             # Get (interpolated and pool-normalized) observations, get pool variance vector
             y_, y_var_, pool_var = get_obs(model, normalize, z_scm = get_z_obs(model), model_error = model_error)

--- a/test/ReferenceModels/runtests.jl
+++ b/test/ReferenceModels/runtests.jl
@@ -109,19 +109,19 @@ end
     run_reference_SCM.(ref_models; output_root = data_dir, uuid = uuid, overwrite = true, run_single_timestep = false)
 
     # Test model 1 -- shifted
-    Δt = 3.0 * 3600
-    ref_model = time_shift_reference_model(ref_models[1], Δt)
+    time_shift = 3.0 * 3600
+    ref_model = time_shift_reference_model(ref_models[1], time_shift)
     z = get_z_obs(ref_model)
 
     @test get_t_start(ref_model) == t_max - 3600 # No shift
     @test get_t_end(ref_model) == t_max # No shift
-    @test get_t_start_Σ(ref_model) == t_max - Δt + (t_max - 2.0 * 3600)
-    @test get_t_end_Σ(ref_model) == t_max - Δt + (t_max - 0.5 * 3600)
+    @test get_t_start_Σ(ref_model) == t_max - time_shift + (t_max - 2.0 * 3600)
+    @test get_t_end_Σ(ref_model) == t_max - time_shift + (t_max - 0.5 * 3600)
     @test length(z) == 20
     @test z[2] - z[1] ≈ 150
 
-    Δt_error = 2 * t_max
-    @test_throws AssertionError time_shift_reference_model(ref_models[1], Δt_error)
+    time_shift_error = 2 * t_max
+    @test_throws AssertionError time_shift_reference_model(ref_models[1], time_shift_error)
 
     # Test model 2 -- not shifted
     ref_model = ref_models[2]
@@ -151,7 +151,7 @@ end
     )
     ref_models = construct_reference_models(kwargs_ref_model)
     # Check that no shift happens when all ModelTypes are SCM
-    ref_model_shifted = time_shift_reference_model(ref_models[1], Δt)
+    ref_model_shifted = time_shift_reference_model(ref_models[1], time_shift)
     ref_model_not_shifted = ref_models[2]
     @test get_t_start(ref_model_shifted) == get_t_start(ref_model_not_shifted)
     @test get_t_end(ref_model_shifted) == get_t_end(ref_model_not_shifted)
@@ -175,7 +175,7 @@ end
     )
     ref_models = construct_reference_models(kwargs_ref_model)
     # Check that they are equivalent when all ModelTypes are SCM
-    ref_model_shifted = time_shift_reference_model(ref_models[1], Δt)
+    ref_model_shifted = time_shift_reference_model(ref_models[1], time_shift)
     ref_model_not_shifted = ref_models[2]
     @test get_t_start(ref_model_shifted) != get_t_start(ref_model_not_shifted)
     @test get_t_end(ref_model_shifted) != get_t_end(ref_model_not_shifted)


### PR DESCRIPTION
Expose LES_driven_SCM timeshift, so that it can be modified from config files. 