### PR TITLE
add EKP learning rate schedulers 

### DIFF
--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -299,6 +299,7 @@ Elements:
  - `mse_full_var` :: Variance estimate of MSE(`g_full`, `y_full`), empirical (EKI/EKS) or quadrature (UKI).
  - `mse_full_nn_mean` :: MSE(`g_full`, `y_full`) of particle closest to the mean in parameter space. The mean in parameter space is the solution to the particle-based inversion.
  - `failures` :: Number of particle failures per iteration. If the calibration is run with the "high_loss" failure handler, this diagnostic will not capture the failures due to parameter mapping.
+ - `timestep` :: EKP timestep in current iteration.
  - `nn_mean_index` :: Particle index of the nearest neighbor to the ensemble mean in parameter space. This index is used to construct `..._nn_mean` metrics.
 """
 function io_dictionary_metrics()
@@ -315,6 +316,7 @@ function io_dictionary_metrics()
         "mse_full_var" => (; dims = ("iteration",), group = "metrics", type = Float64),
         "mse_full_nn_mean" => (; dims = ("iteration",), group = "metrics", type = Float64),
         "failures" => (; dims = ("iteration",), group = "metrics", type = Int16),
+        "timestep" => (; dims = ("iteration",), group = "metrics", type = Float64),
         "nn_mean_index" => (; dims = ("iteration",), group = "metrics", type = Int16),
     )
     return io_dict
@@ -340,6 +342,9 @@ function io_dictionary_metrics(ekp::EnsembleKalmanProcess, mse_full::Vector{FT})
     # Get loss at nearest_to_mean point
     loss_nn_mean = loss[nn_mean]
 
+    # get timestep in latest iteration
+    timestep = deepcopy(ekp.Δt[end])
+
     # Filter NaNs
     loss_filt = filter(!isnan, loss)
     mse_filt = filter(!isnan, mse_full)
@@ -357,6 +362,7 @@ function io_dictionary_metrics(ekp::EnsembleKalmanProcess, mse_full::Vector{FT})
         "mse_full_var" => Base.setindex(orig_dict["mse_full_var"], mse_full_var, :field),
         "mse_full_nn_mean" => Base.setindex(orig_dict["mse_full_nn_mean"], mse_full_nn_mean, :field),
         "failures" => Base.setindex(orig_dict["failures"], failures, :field),
+        "timestep" => Base.setindex(orig_dict["timestep"], timestep, :field),
         "nn_mean_index" => Base.setindex(orig_dict["nn_mean_index"], nn_mean, :field),
     )
     return io_dict

--- a/src/KalmanProcessUtils.jl
+++ b/src/KalmanProcessUtils.jl
@@ -6,7 +6,14 @@ Utils for the construction and handling of Kalman Process structs.
 module KalmanProcessUtils
 
 export generate_ekp,
-    generate_tekp, get_sparse_indices, get_regularized_indices, get_Δt, PiecewiseConstantDecay, PiecewiseConstantGrowth
+    generate_tekp,
+    get_sparse_indices,
+    get_regularized_indices,
+    get_Δt,
+    modify_field,
+    update_scheduler!,
+    PiecewiseConstantDecay,
+    PiecewiseConstantGrowth
 
 using LinearAlgebra
 using Statistics
@@ -86,6 +93,7 @@ get_Δt(lrs::PiecewiseConstantGrowth, iteration::IT) where {IT <: Int} = lrs.Δt
         localizer::LocalizationMethod = NoLocalization(),
         outdir_path::String = pwd(),
         to_file::Bool = true,
+        verbose::Bool = true,
     ) where {T}
 
 Generates, and possible writes to file, an EnsembleKalmanProcess
@@ -99,6 +107,7 @@ Inputs:
  - localizer :: Covariance localization method.
  - outdir_path :: Output path.
  - to_file :: Whether to write the serialized prior to a JLD2 file.
+ - verbose :: Whether to use verbose EKP object
 
 Output:
  - The generated EnsembleKalmanProcess.
@@ -109,8 +118,10 @@ function generate_ekp(
     u::Union{Matrix{T}, T} = nothing;
     failure_handler::String = "ignore_failures",
     localizer::LocalizationMethod = NoLocalization(),
+    scheduler = DefaultScheduler(),
     outdir_path::String = pwd(),
     to_file::Bool = true,
+    verbose::Bool = true,
 ) where {T}
 
     @assert isa(process, Unscented) || !isnothing(u) "Incorrect EKP constructor."
@@ -121,10 +132,17 @@ function generate_ekp(
         fh = IgnoreFailures()
     end
 
-    kwargs = Dict(:failure_handler_method => fh, :localization_method => localizer, :verbose => true)
+    kwargs = Dict(
+        :failure_handler_method => fh,
+        :localization_method => localizer,
+        :verbose => verbose,
+        :scheduler => scheduler,
+    )
     ekp =
         isnothing(u) ? EnsembleKalmanProcess(ref_stats.y, ref_stats.Γ, process; kwargs...) :
         EnsembleKalmanProcess(u, ref_stats.y, ref_stats.Γ, process; kwargs...)
+
+
     if to_file
         jldsave(ekobj_path(outdir_path, 1); ekp)
     end
@@ -142,6 +160,7 @@ end
         localizer::LocalizationMethod = NoLocalization(),
         outdir_path::String = pwd(),
         to_file::Bool = true,
+        verbose::Bool = true,
     ) where {T, R}
 
 Generates, and possible writes to file, a Tikhonov EnsembleKalmanProcess
@@ -164,6 +183,7 @@ Inputs:
  - localizer :: Covariance localization method.
  - outdir_path :: Output path.
  - to_file :: Whether to write the serialized prior to a JLD2 file.
+ - verbose :: Whether to use verbose EKP object
 
 Output:
  - The generated augmented EnsembleKalmanProcess.
@@ -176,8 +196,10 @@ function generate_tekp(
     l2_reg::Union{Dict{String, Vector{R}}, R} = nothing,
     failure_handler::String = "ignore_failures",
     localizer::LocalizationMethod = NoLocalization(),
+    scheduler = DefaultScheduler(),
     outdir_path::String = pwd(),
     to_file::Bool = true,
+    verbose::Bool = true,
 ) where {T, R}
 
     @assert isa(process, Unscented) || !isnothing(u) "Incorrect TEKP constructor."
@@ -219,7 +241,12 @@ function generate_tekp(
     Γ_aug_list = [ref_stats.Γ, Array(Γ_θ)]
     Γ_aug = cat(Γ_aug_list..., dims = (1, 2))
 
-    kwargs = Dict(:failure_handler_method => fh, :localization_method => localizer, :verbose => true)
+    kwargs = Dict(
+        :failure_handler_method => fh,
+        :localization_method => localizer,
+        :verbose => verbose,
+        :scheduler => scheduler,
+    )
     ekp =
         isnothing(u) ? EnsembleKalmanProcess(y_aug, Γ_aug, process; kwargs...) :
         EnsembleKalmanProcess(u, y_aug, Γ_aug, process; kwargs...)
@@ -244,5 +271,19 @@ end
 "Returns the indices of parameters to be regularized, given the l2 regularization configuration dictionary."
 get_regularized_indices(l2_config::Dict) = flat_dict_keys_where(l2_config, above_eps)
 
+"Return new EKP object with `field_name` overridden by `new_value`"
+function modify_field(ekp::EnsembleKalmanProcess, field_name::Symbol, new_value)
+    fields = fieldnames(EnsembleKalmanProcess)
+    values = [field_name == f ? new_value : getfield(ekp, f) for f in fields]
+    return EnsembleKalmanProcess(values...)
+end
+
+"Update inv_sqrt_noise of EKP object when using DMC"
+function update_scheduler!(ekp, iteration)
+    if typeof(ekp.scheduler) <: DataMisfitController && iteration > 1
+        inv_sqrt_Γ = inv(sqrt(posdef_correct(ekp.obs_noise_cov)))
+        push!(ekp.scheduler.inv_sqrt_noise, inv_sqrt_Γ)
+    end
+end
 
 end # module

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -59,6 +59,12 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
     Δt_scheduler = get_entry(proc_config, "Δt", 1.0)
     Δt = get_Δt(Δt_scheduler, 1)
 
+    scheduler = get_entry(proc_config, "scheduler", nothing)
+
+    if !isnothing(scheduler)
+        Δt = nothing
+    end
+
     augmented = get_entry(proc_config, "augmented", false)
     failure_handler = get_entry(proc_config, "failure_handler", "high_loss")
     localizer = get_entry(proc_config, "localizer", NoLocalization())
@@ -99,7 +105,6 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         ref_stats,
         outdir_root,
         algo_name,
-        Δt,
         n_param,
         N_ens,
         N_iter,
@@ -114,7 +119,13 @@ function init_calibration(config::Dict{Any, Any}; mode::String = "hpc", job_id::
         prior_μ = nothing
     end
     priors = construct_priors(params, outdir_path = outdir_path, unconstrained_σ = unc_σ, prior_mean = prior_μ)
-    ekp_kwargs = Dict(:outdir_path => outdir_path, :failure_handler => failure_handler, :localizer => localizer)
+    ekp_kwargs = Dict(
+        :outdir_path => outdir_path,
+        :failure_handler => failure_handler,
+        :localizer => localizer,
+        :verbose => true,
+        :scheduler => scheduler,
+    )
     # parameters are sampled in unconstrained space
     if algo_name in ["Inversion", "Sampler", "SparseInversion"]
         if algo_name == "Inversion"
@@ -197,7 +208,6 @@ function create_output_dir(
     ref_stats::ReferenceStatistics,
     outdir_root::String,
     algo_name::String,
-    Δt::FT,
     n_param::IT,
     N_ens::IT,
     N_iter::IT,
@@ -211,7 +221,7 @@ function create_output_dir(
     suffix = randstring(3)  # ensure output folder is unique
     outdir_path = joinpath(
         outdir_root,
-        "results_$(algo_name)_dt_$(Δt)_p$(n_param)_e$(N_ens)_i$(N_iter)_$(d)_$(typeof(y_ref_type))_$(now)_$(suffix)",
+        "results_$(algo_name)_p$(n_param)_e$(N_ens)_i$(N_iter)_$(d)_$(typeof(y_ref_type))_$(now)_$(suffix)",
     )
     @info "Name of outdir path for this EKP is: $outdir_path"
     mkpath(outdir_path)
@@ -365,6 +375,12 @@ function ek_update(
     Δt_scheduler = get_entry(proc_config, "Δt", 1.0)
     Δt = get_Δt(Δt_scheduler, iteration)
 
+    scheduler = ekobj.scheduler
+
+    if !isnothing(scheduler)
+        Δt = nothing
+    end
+
     deterministic_forward_map = get_entry(proc_config, "noisy_obs", false)
     augmented = get_entry(proc_config, "augmented", false)
     param_map = get_entry(config["prior"], "param_map", HelperFuncs.do_nothing_param_map())  # do-nothing param map by default
@@ -413,9 +429,17 @@ function ek_update(
                 update_minibatch_inverse_problem(ref_model_batch, ekobj, priors, batch_size, outdir_path, config)
             rm(joinpath(outdir_path, "ref_model_batch.jld2"))
             write_ref_model_batch(ref_model_batch, outdir_path = outdir_path)
+            # if ekp-native scheduler used, keep full Δt history
+            # this is needed because `update_minibatch_inverse_problem` creates a new ekp object and erases Δt history
+            if !isnothing(scheduler)
+                ekp = modify_field(ekp, :Δt, deepcopy(ekobj.Δt))
+            end
+
         else
             ekp = ekobj
         end
+
+        update_scheduler!(ekp, iteration)
 
         # Write to file new EKP and ModelEvaluators
         jldsave(ekobj_path(outdir_path, iteration + 1); ekp)
@@ -426,8 +450,13 @@ function ek_update(
             reg_config = config["regularization"]
             update_validation(val_config, reg_config, ekobj, priors, param_map, versions, outdir_path, iteration)
         end
-    end
 
+    else
+        # If final iteration, update saved ekp object for current iteration
+        ekp = ekobj
+        update_scheduler!(ekp, iteration)
+        jldsave(ekobj_path(outdir_path, iteration); ekp)
+    end
 
     # Clean up
     for version in versions
@@ -482,7 +511,6 @@ function restart_calibration(
 
     reg_config = config["regularization"]
     kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
-
     val_config = get(config, "validation", nothing)
 
     # Prepare updated EKP and ReferenceModelBatch if minibatching.
@@ -766,14 +794,20 @@ function update_minibatch_inverse_problem(
 
     augmented = get_entry(proc_config, "augmented", false)
     failure_handler = get_entry(proc_config, "failure_handler", "high_loss")
+
+    scheduler = deepcopy(ekp_old.scheduler)
     localizer = get_entry(proc_config, "localizer", NoLocalization())
     l2_reg = get_entry(reg_config, "l2_reg", nothing)
     kwargs_ref_stats = get_ref_stats_kwargs(ref_config, reg_config)
     ref_stats = ReferenceStatistics(ref_models; kwargs_ref_stats...)
     process = ekp_old.process
-
-    ekp_kwargs = Dict(:outdir_path => outdir_path, :failure_handler => failure_handler, :localizer => localizer)
-
+    ekp_kwargs = Dict(
+        :outdir_path => outdir_path,
+        :failure_handler => failure_handler,
+        :localizer => localizer,
+        :verbose => true,
+        :scheduler => scheduler,
+    )
     if isa(process, Unscented)
         # Reconstruct UKI using regularization toward the prior
         algo = Unscented(

--- a/test/NetCDFIO/runtests.jl
+++ b/test/NetCDFIO/runtests.jl
@@ -10,6 +10,7 @@ using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.DistributionUtils
 using CalibrateEDMF.HelperFuncs
 using CalibrateEDMF.TurbulenceConvectionUtils
+using CalibrateEDMF.KalmanProcessUtils
 using CalibrateEDMF.NetCDFIO
 const CN = CalibrateEDMF.NetCDFIO
 using EnsembleKalmanProcesses
@@ -56,6 +57,7 @@ using EnsembleKalmanProcesses: DataContainer
     config["reference"] = Dict()
     priors = construct_priors(config["prior"]["constraints"]; to_file = false)
     ekp = EnsembleKalmanProcess(rand(2, 10), ref_stats.y, ref_stats.Γ, Inversion(), verbose = true)
+    ekp = modify_field(ekp, :Δt, [1.0])
     N_ens = size(get_u_final(ekp), 2)
     diags = NetCDFIO_Diags(config, data_dir, ref_stats, N_ens, priors)
     # Write fabricated loss data to ekp

--- a/test/Pipeline/config.jl
+++ b/test/Pipeline/config.jl
@@ -10,12 +10,13 @@ using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.LESUtils
 using CalibrateEDMF.TurbulenceConvectionUtils
-const src_dir = dirname(pathof(CalibrateEDMF))
 using CalibrateEDMF.HelperFuncs
 # Import EKP modules
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
 using JLD2
+cedmf = pkgdir(CalibrateEDMF)
+test_dir = joinpath(cedmf, "test", "Pipeline")
 
 namelist_args = [
     ("time_stepping", "t_max", 2.0 * 3600),
@@ -65,7 +66,7 @@ end
 
 function get_process_config()
     config = Dict()
-    config["N_iter"] = 2
+    config["N_iter"] = 5
     config["N_ens"] = 5
     config["algorithm"] = "Inversion" # "Sampler", "Unscented"
     return config
@@ -78,8 +79,7 @@ function get_reference_config(::Bomex)
     config["y_reference_type"] = SCM()
     config["Σ_reference_type"] = SCM()
     config["y_names"] = [["thetal_mean", "qt_mean"]]
-    ref_root_dir = mktempdir()
-    config["y_dir"] = [joinpath(ref_root_dir, "Output.Bomex.ref")]
+    config["y_dir"] = [joinpath(test_dir, "ref_data", "Output.Bomex.ref")]
     config["t_start"] = [0.0]
     config["t_end"] = [2.0 * 3600]
     config["namelist_args"] = [namelist_args]

--- a/test/Pipeline/runtests.jl
+++ b/test/Pipeline/runtests.jl
@@ -4,6 +4,7 @@ using Random
 using JLD2
 using CalibrateEDMF
 using CalibrateEDMF.DistributionUtils
+using CalibrateEDMF.KalmanProcessUtils
 using CalibrateEDMF.ReferenceModels
 using CalibrateEDMF.ReferenceStats
 using CalibrateEDMF.TurbulenceConvectionUtils
@@ -34,6 +35,30 @@ ref_model = ReferenceModel(
 output_root = dirname(y_dir)
 uuid = last(split(y_dir, "."))
 run_reference_SCM(ref_model; output_root = output_root, uuid = uuid, run_single_timestep = false)
+
+"""Perturbs results from single SCM simulation to emulate ensemble."""
+function generate_SCM_runs(scm_args, outdir_path, versions, priors; precondition_ek::Bool = true)
+    batch_indices = scm_args["batch_indices"]
+    model_evaluator = scm_args["model_evaluator"]
+    if precondition_ek
+        model_evaluator = precondition(model_evaluator, priors)
+    end
+    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator)
+
+    for version in versions
+        g_scm = g_scm_orig .* (1.0 + rand())
+        g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
+        jldsave(
+            scm_output_path(outdir_path, version);
+            sim_dirs,
+            g_scm,
+            g_scm_pca,
+            model_evaluator,
+            version,
+            batch_indices,
+        )
+    end
+end
 
 # Test a range of calibration initializations
 @testset "init_calibration" begin
@@ -93,7 +118,7 @@ end
     test_id = basename(temp_file)
     outdir_path =
         init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"), job_id = test_id)
-
+    priors = load(joinpath(outdir_path, "prior.jld2"))["prior"]
     # Check for output
     @test isdir(outdir_path)
     @test isfile(joinpath(outdir_path, "prior.jld2"))
@@ -108,23 +133,8 @@ end
 
     # Run one simulation and perturb results to emulate ensemble
     scm_args = load(scm_init_path(outdir_path, versions[1]))
-    batch_indices = scm_args["batch_indices"]
-    priors = load(joinpath(outdir_path, "prior.jld2"))["prior"]
-    model_evaluator = scm_args["model_evaluator"]
-    model_evaluator = precondition(model_evaluator, priors)
-    sim_dirs, g_scm_orig, g_scm_pca_orig = run_SCM(model_evaluator)
+    generate_SCM_runs(scm_args, outdir_path, versions, priors; precondition_ek = true)
     for version in versions
-        g_scm = g_scm_orig .* (1.0 + rand())
-        g_scm_pca = g_scm_pca_orig .* (1.0 + rand())
-        jldsave(
-            scm_output_path(outdir_path, version);
-            sim_dirs,
-            g_scm,
-            g_scm_pca,
-            model_evaluator,
-            version,
-            batch_indices,
-        )
         @test isfile(joinpath(outdir_path, "scm_output_$version.jld2"))
     end
 
@@ -133,12 +143,13 @@ end
     # Test ek_update output
     @test isfile(joinpath(outdir_path, "ekobj_iter_2.jld2"))
     @test isfile(joinpath(outdir_path, "versions_2.txt"))
+    ekobj_i2 = load(ekobj_path(outdir_path, 2))["ekp"]
     versions = readlines(joinpath(outdir_path, "versions_2.txt"))
     for i in 1:config["process"]["N_ens"]
         @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
 
-    restart_calibration(ekobj, priors, 2, config, outdir_path; mode = "hpc", job_id = test_id)
+    restart_calibration(ekobj_i2, priors, 2, config, outdir_path; mode = "hpc", job_id = test_id)
     @test isfile(joinpath(outdir_path, "ekobj_iter_3.jld2"))
     @test isfile(joinpath(outdir_path, "versions_3.txt"))
     versions = readlines(joinpath(outdir_path, "versions_3.txt"))
@@ -147,6 +158,105 @@ end
     end
 
     rm(outdir_path, recursive = true)
+end
+
+@testset "Pipeline with Different Learning Rate Schedulers" begin
+
+    ###  Test HPC pipeline with EKP-native learning rate schedulers
+    temp_file = tempname(pwd())
+    test_id = basename(temp_file)
+    schedulers =
+        [nothing, DefaultScheduler(0.75), DataMisfitController(on_terminate = "continue"), EKSStableScheduler()]
+
+    for scheduler in schedulers
+        config = get_config()
+        N_iter = config["process"]["N_iter"]
+        config["process"]["scheduler"] = scheduler
+        outdir_path =
+            init_calibration(config; mode = "hpc", config_path = joinpath(test_dir, "config.jl"), job_id = test_id)
+        ekobj = load(ekobj_path(outdir_path, 1))["ekp"]
+        versions = readlines(joinpath(outdir_path, "versions_1.txt"))
+
+        # check that correct learning rate scheduler is used
+        initial_obs_noise_cov = deepcopy(ekobj.obs_noise_cov)
+        if isnothing(scheduler)
+            @test ekobj.scheduler == DefaultScheduler(1.0)
+        else
+            @test ekobj.scheduler == scheduler
+        end
+        @test isempty(ekobj.Δt) # test ekp Δt isn't modified before update
+
+        priors = load(joinpath(outdir_path, "prior.jld2"))["prior"]
+
+        # Calibration process
+        @info "Running EK updates for $N_iter iterations"
+        for iteration in 1:N_iter
+            @info "   iter = $iteration"
+            # precondition for first iteration
+            precondition_ek = iteration == 1
+            versions = readlines(joinpath(outdir_path, "versions_$(iteration).txt"))
+            scm_args = load(scm_init_path(outdir_path, versions[1]))
+            # Run one simulation and perturb results to emulate ensemble
+            generate_SCM_runs(scm_args, outdir_path, versions, priors; precondition_ek = precondition_ek)
+            ekp = load(ekobj_path(outdir_path, iteration))["ekp"]
+
+            # perform update
+            ek_update(ekp, priors, iteration, config, versions, outdir_path)
+
+            if iteration < N_iter
+                ekp_next = load(ekobj_path(outdir_path, iteration + 1))["ekp"]
+            else
+                ekp_next = load(ekobj_path(outdir_path, iteration))["ekp"]
+            end
+
+            # check that scheduler is updated appropriately
+            if typeof(ekp_next.scheduler) <: DataMisfitController
+                # timestep and scheduler are updated in ek_update, so check that previous iteration is correct
+                @test ekp_next.scheduler.iteration[end] == iteration
+                @test length(ekp_next.scheduler.inv_sqrt_noise) == iteration
+            end
+            @test length(ekp_next.Δt) == iteration
+
+        end
+
+        # mimick restart with 2 additional iterations
+        config["process"]["N_iter"] = N_iter + 2
+        # load ekobj from previous iteration before restart
+        ekobj_prev = load(ekobj_path(outdir_path, N_iter))["ekp"]
+        restart_calibration(ekobj_prev, priors, N_iter, config, outdir_path; mode = "hpc", job_id = test_id)
+        ekobj_restart = load(ekobj_path(outdir_path, N_iter + 1))["ekp"]
+        # ensure scheduler is unchanged after restart
+        @test ekobj_restart.scheduler == ekobj_prev.scheduler
+
+        # make an update after restart (iteration = original N_iter + 1)
+        versions = readlines(joinpath(outdir_path, "versions_$(N_iter+1).txt"))
+        scm_args = load(scm_init_path(outdir_path, versions[1]))
+        generate_SCM_runs(scm_args, outdir_path, versions, priors; precondition_ek = false)
+        ek_update(ekobj_restart, priors, N_iter + 1, config, versions, outdir_path)
+        ekobj_final = load(ekobj_path(outdir_path, N_iter + 2))["ekp"]
+
+        if typeof(ekobj_final.scheduler) <: DataMisfitController
+            # check for expected update behavior after restart
+            @test ekobj_final.scheduler.iteration[end] == N_iter + 1
+            @test length(ekobj_final.scheduler.inv_sqrt_noise) == N_iter + 1
+        end
+        @test length(ekobj_final.Δt) == N_iter + 1
+
+        # check that timesteps are constant for default scheduler
+        if typeof(ekobj_final.scheduler) <: DefaultScheduler
+            if isnothing(scheduler)
+                @test all(ekobj_final.Δt .== 1.0)
+            else
+                @test all(ekobj_final.Δt .== 0.75)
+            end
+        end
+
+        # ensure obs_noise_cov remains unchanged
+        @test initial_obs_noise_cov == ekobj_final.obs_noise_cov
+
+        rm(outdir_path, recursive = true)
+    end
+
 end
 
 @testset "Pipeline_with_validation" begin
@@ -233,3 +343,5 @@ end
         @test isfile(joinpath(outdir_path, "scm_initializer_$(versions[i]).jld2"))
     end
 end
+
+rm(output_root, recursive = true)


### PR DESCRIPTION
## Changes

1. Adds functionality for using native learning rate schedulers from EKP.jl
2. Outputs timestep history to `Diagnostics.nc` output file.
3. Make EKP verbose
