### PR TITLE
Update climacommon to 2024_10_09

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ env:
 
 agents:
   queue: new-central
-  modules: climacommon/2024_05_27
+  modules: climacommon/2024_10_09
 
 steps:
 


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.0.